### PR TITLE
(QE-150) update harness to use correct 32/64 bit version of cygwin setup.exe

### DIFF
--- a/lib/puppet_acceptance/host/windows/pkg.rb
+++ b/lib/puppet_acceptance/host/windows/pkg.rb
@@ -7,10 +7,20 @@ module Windows::Pkg
   end
 
   def install_package name
-    if not check_for_package('setup.exe')
-      execute("curl --retry 5 http://cygwin.com/setup-x86.exe -o /cygdrive/c/Windows/System32/setup.exe")
+    cygwin = ""
+    rootdir = ""
+    result = exec(PuppetAcceptance::Command.new("wmic os get osarchitecture | grep 32"), :acceptable_exit_codes => (0...127))
+    if result.exit_code == 0 #32 bit version
+      rootdir = "c:\\\\cygwin"
+      cygwin = "setup-x86.exe"
+    else  #64 bit version
+      rootdir = "c:\\\\cygwin64"
+      cygwin = "setup-x86_64.exe"
     end
-    execute("setup.exe -q -n -N -d -R c:\\\\cygwin -s http://cygwin.osuosl.org -P #{name}") 
+    if not check_for_package(cygwin)
+      execute("curl --retry 5 http://cygwin.com/#{cygwin} -o /cygdrive/c/Windows/System32/#{cygwin}")
+    end
+    execute("#{cygwin} -q -n -N -d -R #{rootdir} -s http://cygwin.osuosl.org -P #{name}") 
   end
 
 end


### PR DESCRIPTION
Can't be landed till https://jira.puppetlabs.com/browse/QE-145 is fixed.
This patch depends on the windows static vms being updated
