### PR TITLE
(QE-71) print full stack traces when in --debug mode

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -119,7 +119,7 @@ module Beaker
     # to a human-readable string (which some IDEs/editors
     # will recognize as links to the line numbers in the trace)
     def pretty_backtrace backtrace = caller(1)
-      trace = purge_harness_files_from( Array( backtrace ) )
+      trace = is_debug? ? backtrace : purge_harness_files_from( Array( backtrace ) ) 
       expand_symlinks( trace ).join "\n"
     end
 


### PR DESCRIPTION
This is a reversal of the original purpose of the bug, which was to
remove harness related parts of stack traces to make them more readable
- unfortunately it made them less readable and also made it more
  difficult to differentiate between harness and test code bugs
