### PR TITLE
allow for setting the hosts file from an ENV var

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -20,6 +20,7 @@ module Beaker
           :pe_dir => ENV['pe_dist_dir'],
           :pe_version_file => ENV['pe_version_file'],
           :pe_version_file_win => ENV['pe_version_file'],
+          :hosts_file => ENV['hosts_file'] || ENV['config_file'],
         }.delete_if {|key, value| value.nil? or value.empty? })
       end
 


### PR DESCRIPTION
- set the --hosts file ENV (using hosts_file or config_file)

QE-222 (Beaker-rspec default host cfg file location should be tweakable )
