### PR TITLE
Use `bundle` with dashboard rake tests

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -253,7 +253,7 @@ module Beaker
         else
           task = 'defaultgroup:ensure_default_group'
         end
-        on dashboard, "/opt/puppet/bin/rake -sf /opt/puppet/share/puppet-dashboard/Rakefile #{task} RAILS_ENV=production"
+        on dashboard, "BUNDLE_GEMFILE=/opt/puppet/share/puppet-dashboard/Gemfile /opt/puppet/bin/bundle/exec /opt/puppet/bin/rake -sf /opt/puppet/share/puppet-dashboard/Rakefile #{task} RAILS_ENV=production"
 
         # Now that all hosts are in the dashbaord, run puppet one more
         # time to configure mcollective


### PR DESCRIPTION
Currently the dashboard rake tests call /opt/puppet/bin/rake directly, without
using bundler. This will fail, because dashboard needs all the gems loaded by
bundler before it will give us any rake goodness. This commit updates the call
to use bundler.

Signed-off-by: Moses Mendoza moses@puppetlabs.com
