### PR TITLE
Revert "Merge pull request #17 from anodelman/beaker-rspec"

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -20,7 +20,6 @@ module Beaker
           :pe_dir => ENV['pe_dist_dir'],
           :pe_version_file => ENV['pe_version_file'],
           :pe_version_file_win => ENV['pe_version_file'],
-          :hosts_file => ENV['hosts_file'] || ENV['config_file'],
         }.delete_if {|key, value| value.nil? or value.empty? })
       end
 


### PR DESCRIPTION
This reverts commit 90c2642b4ad2323cb6c9fe642d7befdf5af7168a, reversing
changes made to 18cef9f78a3d3be4963bbde32cb394c70a83641f.

This change was ineffective and did not actually allow for the use of
the host-file env var.
