### PR TITLE
fix for not using --keyfile specified in an options file

### DIFF
--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -80,7 +80,7 @@ module Beaker
           opts.on '--keyfile /PATH/TO/SSH/KEY',
                   'Specify alternate SSH key',
                   '(default: ~/.ssh/id_rsa)' do |key|
-            @cmd_options[:ssh] = {:keys => [key]}
+            @cmd_options[:keyfile] = key
           end
 
           opts.on '--timeout TIMEOUT',

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -181,6 +181,7 @@ module Beaker
       #Validate all merged options values for correctness
       #
       #Currently checks:
+      #  - if a keyfile is provided then use it
       #  - paths provided to --test, --pre-suite, --post-suite provided lists of .rb files for testing
       #  - --type is one of 'pe' or 'git'
       #  - --fail-mode is one of 'fast', 'stop' or nil
@@ -192,6 +193,11 @@ module Beaker
       #
       #@raise [ArgumentError] Raise if argument/options values are invalid
       def normalize_args
+
+        #use the keyfile if present
+        if @options.has_key?(:keyfile)
+          @options[:ssh][:keys] = [@options[:keyfile]]
+        end
 
         #split out arguments - these arguments can have the form of arg1,arg2 or [arg] or just arg
         #will end up being normalized into an array

--- a/spec/beaker/options/command_line_parser_spec.rb
+++ b/spec/beaker/options/command_line_parser_spec.rb
@@ -13,7 +13,7 @@ module Beaker
       end
 
       it "supports all our command line options" do
-        expect(parser.parse!(full_opts)).to be === {:hosts_file=>"anotherfile.cfg", :options_file=>"opts_file", :type=>"pe", :helper=>"path_to_helper", :load_path=>"load_path", :tests=>"test1.rb,test2.rb,test3.rb", :pre_suite=>"pre_suite.rb", :post_suite=>"post_suite.rb", :provision=>false, :preserve_hosts=>true, :root_keys=>true, :ssh=>{:keys=>["../.ssh/id_rsa"]}, :install=>"gitrepopath", :modules=>"module", :quiet=>true, :xml=>false, :dry_run=>true, :timesync=>false, :repo_proxy=>true, :add_el_extras=>true, :fail_mode=>"fast", :color=>false}
+        expect(parser.parse!(full_opts)).to be === {:hosts_file=>"anotherfile.cfg", :options_file=>"opts_file", :type=>"pe", :helper=>"path_to_helper", :load_path=>"load_path", :tests=>"test1.rb,test2.rb,test3.rb", :pre_suite=>"pre_suite.rb", :post_suite=>"post_suite.rb", :provision=>false, :preserve_hosts=>true, :root_keys=>true, :keyfile=>"../.ssh/id_rsa", :install=>"gitrepopath", :modules=>"module", :quiet=>true, :xml=>false, :dry_run=>true, :timesync=>false, :repo_proxy=>true, :add_el_extras=>true, :fail_mode=>"fast", :color=>false}
       end
 
       it "can produce a usage description" do


### PR DESCRIPTION
Had some leftover magic in command_line_parser that needed to be moved to general parsing so that it is also used for options file parsing.
