### PR TITLE
Allow 2 as exit code when non-agent cert submit

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -715,7 +715,7 @@ module Beaker
        def sign_certificate(host)
          if [master, dashboard, database].include? host
 
-           on host, puppet( 'agent -t' ), :acceptable_exit_codes => [0,1]
+           on host, puppet( 'agent -t' ), :acceptable_exit_codes => [0,1,2]
            on master, puppet( "cert --allow-dns-alt-names sign #{host}" ), :acceptable_exit_codes => [0,24]
 
          else


### PR DESCRIPTION
We have nodes with more-than-just-an-agent ensure they've
checked in prior to signing certs (in case they do not follow default
naming schemes). Unfortunately in some cases the agent will also change
the system, returning 2. This is valid behavior.
