### PR TITLE
Avoid IPs ending in .0, .1, or .255

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -11,7 +11,7 @@ module Beaker
     end
 
     def rand_chunk
-      (1 + rand(253)).to_s #don't want a 0 or a 255
+      (2 + rand(252)).to_s #don't want a 0, 1, or a 255
     end
     
     def randip


### PR DESCRIPTION
Vagrant 1.2.5 and later do not allow IPs ending in `.1`, in addition to
the usual limitations of `.0` or `.255`.
