### PR TITLE
Avoid using 192.168.0.0/16

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -15,7 +15,7 @@ module Beaker
     end
     
     def randip
-      "192.168.#{rand_chunk}.#{rand_chunk}"
+      "10.255.#{rand_chunk}.#{rand_chunk}"
     end
 
     def make_vfile hosts


### PR DESCRIPTION
When using 192.168.0.0/16 address space on a 192.168.x.0/24 NAT'd
network (such as most home routers) VirtualBox will complain that the
virtual private network overlaps with an existing network and refuses to
start the VMs. 10.255.0.0/16 is a less-likely to conflict range, though
not perfect.
