### PR TITLE
QE-364 Clean up line endings

### DIFF
--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -27,7 +27,7 @@ module Beaker
     end
 
     def normalize_line_endings string
-      return string.gsub(/\r\n?/, "\n")
+      return string.gsub(/\r\n?/, "\n").chomp
     end
 
     def convert string

--- a/spec/beaker/result_spec.rb
+++ b/spec/beaker/result_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Beaker::Result do
+  subject do
+    Beaker::Result.new('host','ls')
+  end
+
+  describe '#formatted_output'
+  describe '#convert'
+
+  describe "return output values" do
+    it 'have no final line ending' do
+      subject.stdout = "RedHat\n"
+      subject.stderr = "Some error!\n"
+      subject.finalize!
+
+      expect(subject.stdout).to eq("RedHat")
+      expect(subject.stderr).to eq("Some error!")
+    end
+    it 'maintain intermediate line endings' do
+      subject.stdout = "operatingsystem => CentOS\nosfamily => RedHat\n"
+      subject.stderr = "Danger!\nDanger Will Robinson!\n"
+      subject.finalize!
+
+      expect(subject.stdout).to eq("operatingsystem => CentOS\nosfamily => RedHat")
+      expect(subject.stderr).to eq("Danger!\nDanger Will Robinson!")
+    end
+    it 'convert \r and CRLF to newline' do
+      subject.stdout = "operatingsystem => CentOS\r\nosfamily => RedHat\n"
+      subject.stderr = "Danger!\rDanger Will Robinson!\n"
+      subject.finalize!
+
+      expect(subject.stdout).to eq("operatingsystem => CentOS\nosfamily => RedHat")
+      expect(subject.stderr).to eq("Danger!\nDanger Will Robinson!")
+    end
+  end
+end


### PR DESCRIPTION
When using `Beaker::Command` helpers such as `facter()` or even `on()`
the resulting output is often a single line and of interest for its
value. The newline returned at the end of the line is not relevant to
interests and ends up getting `.chomp` called on it in almost every
case.

This change chomps the final newline off of stdout and stderr output so
that tests can be more simply written without having to `.chomp`
