### PR TITLE
Allow single exit codes

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -161,7 +161,7 @@ module Beaker
           # No, TestCase has the knowledge about whether its failed, checking acceptable
           # exit codes at the host level and then raising...
           # is it necessary to break execution??
-          unless result.exit_code_in?(options[:acceptable_exit_codes] || [0])
+          unless result.exit_code_in?(Array(options[:acceptable_exit_codes] || 0))
             limit = 10
             raise "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{limit} lines of output were:\n#{result.formatted_output(limit)}"
           end


### PR DESCRIPTION
When using `:allowed_exit_codes` it is cumbersome to always have an
array of specified values. This change allows `:allowed_exit_codes => 1`
to be used.
