### PR TITLE
Add hostname to dns exception

### DIFF
--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -120,7 +120,7 @@ module Beaker
 
             retry
           else
-            raise "DNS resolution failed after #{@options[:timeout].to_i} seconds"
+            raise "DNS resolution of #{h['vmhostname']} failed after #{@options[:timeout].to_i} seconds"
           end
         end
       end


### PR DESCRIPTION
Without this patch the exception message on dns failures looks like:

DNS resolution failed after 300 seconds (RuntimeError)

This patch adds the hostname, possibly helpful for troubleshooting infrastructure failures.
