### PR TITLE
(QE-428) bundle install fails on Ruby 1.8.7 because of new mime-types 2.0 dependency requiring 1.9.2

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rbvmomi'
   s.add_runtime_dependency 'blimpy'
   s.add_runtime_dependency 'nokogiri', '1.5.10'
+  s.add_runtime_dependency 'mime-types', '1.25' if RUBY_VERSION < "1.9"
   s.add_runtime_dependency 'fission' if RUBY_PLATFORM =~ /darwin/i
   s.add_runtime_dependency 'inifile'
 end


### PR DESCRIPTION
- add entry to gemspec to use mime-types 1.25 with ruby 1.8.7
