### PR TITLE
Correctly determine win arch for installing packages.

### DIFF
--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -9,13 +9,15 @@ module Windows::Pkg
   def install_package(name, cmdline_args = '')
     cygwin = ""
     rootdir = ""
-    result = execute("echo '' | wmic os get osarchitecture | grep 32", :acceptable_exit_codes => (0...127))
-    if result.exit_code == 0 #32 bit version
-      rootdir = "c:\\\\cygwin"
-      cygwin = "setup-x86.exe"
-    else  #64 bit version
-      rootdir = "c:\\\\cygwin64"
-      cygwin = "setup-x86_64.exe"
+    execute("echo '' | wmic os get osarchitecture | grep 32", 
+            :acceptable_exit_codes => (0...127)) do |result|
+      if result.exit_code == 0 #32 bit version
+        rootdir = "c:\\\\cygwin"
+        cygwin = "setup-x86.exe"
+      else  #64 bit version
+        rootdir = "c:\\\\cygwin64"
+        cygwin = "setup-x86_64.exe"
+      end
     end
     if not check_for_package(cygwin)
       execute("curl --retry 5 http://cygwin.com/#{cygwin} -o /cygdrive/c/Windows/System32/#{cygwin}")


### PR DESCRIPTION
My previous implementation had a bug in that it expected execute to
return a result object.  Instead, execute exposes the result object to a
passed block.  So now we check the result within a block and set rootdir
and cygwin executable there.

This fix is needed to get beaker working with the newer vcloud templates (only win2008 tested so far)
