### PR TITLE
(QE-204) allow for use of local vagrant file when using --no-provision

### DIFF
--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -87,7 +87,7 @@ module Beaker
       before :each do
         vagrant.should_receive( :make_vfile ).with( @hosts ).once
 
-        vagrant.should_receive( :vagrant_cmd ).with( "halt" ).once
+        vagrant.should_receive( :vagrant_cmd ).with( "destroy --force" ).once
         vagrant.should_receive( :vagrant_cmd ).with( "up" ).once
         @hosts.each do |host|
           host_prev_name = host['user']


### PR DESCRIPTION
- use already set up vagrant boxes when running with --no-provision

Workflow:
1. initial setup of vagrant machines
   bundle exec beaker --config vagrant.cfg --preserve-hosts
2. use those same hosts on the next run
   bundle exec beaker --config vagrant.cfg --preserve-hosts --no-provision
