### PR TITLE
Relax regex for windows group names

### DIFF
--- a/lib/beaker/host/windows/group.rb
+++ b/lib/beaker/host/windows/group.rb
@@ -5,7 +5,7 @@ module Windows::Group
     execute('cmd /c echo "" | wmic group where localaccount="true" get name /format:value') do |result|
       groups = []
       result.stdout.each_line do |line|
-        groups << (line.match(/^Name=([\w ]+)/) or next)[1]
+        groups << (line.match(/^Name=(.+)$/) or next)[1]
       end
 
       yield result if block_given?

--- a/spec/beaker/host/windows/group_spec.rb
+++ b/spec/beaker/host/windows/group_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+module Beaker
+  describe Windows::Group do
+    class WindowsGroupTest
+      include Windows::Group
+    end
+
+    let(:instance) { WindowsGroupTest.new }
+    let(:result) { mock(:result, :stdout => group_list_output) }
+    let(:group_list_output) do <<-EOS
+
+
+Name=Foo
+
+
+Name=Bar6
+
+
+      EOS
+    end
+
+    def add_group(group_name)
+      group_list_output << <<-EOS
+Name=#{group_name}
+
+
+      EOS
+    end
+
+    before(:each) do
+      instance.should_receive(:execute).with(/wmic group where/).and_yield(result)
+    end
+
+    it "gets a group_list" do
+      expect(instance.group_list).to eql(["Foo", "Bar6"])
+    end
+
+    it "gets groups with spaces" do
+      add_group("With Spaces")
+      expect(instance.group_list).to eql(["Foo", "Bar6", "With Spaces"])
+    end
+
+
+    it "gets groups with dashes" do
+      add_group("With-Dashes")
+      expect(instance.group_list).to eql(["Foo", "Bar6", "With-Dashes"])
+    end
+
+    it "gets groups with underscores" do
+      add_group("With_Underscores")
+      expect(instance.group_list).to eql(["Foo", "Bar6", "With_Underscores"])
+    end
+  end
+end


### PR DESCRIPTION
Windows::Group.group_list was only recording group names matching
/[\w ]/, but windows groups have a much larger set of valid characters
(http://technet.microsoft.com/en-us/library/bb726984.aspx).  This was
causing a failure on a Windows 2012 template which had a group with a
'-' in it.

Instead of trying to specify what is valid, accept whatever the wmic
group indicates is a group, since it should know.
