### PR TITLE
Quote ruby interpolated data in bash commands

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -475,10 +475,10 @@ module Beaker
       def restore_puppet_conf_from_backup( host, backup_file )
         puppetpath = host['puppetpath']
 
-        host.exec( Command.new( "if [ -f #{backup_file} ]; then " +
-                                    "cat #{backup_file} > " +
-                                    "#{puppetpath}/puppet.conf; " +
-                                    "rm -f #{backup_file}; " +
+        host.exec( Command.new( "if [ -f '#{backup_file}' ]; then " +
+                                    "cat '#{backup_file}' > " +
+                                    "'#{puppetpath}/puppet.conf'; " +
+                                    "rm -f '#{backup_file}'; " +
                                 "fi" ) )
       end
 

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -642,7 +642,7 @@ describe ClassMixedWithDSLHelpers do
 
         it 'restores puppet.conf' do
           subject.with_puppet_running_on(host, {})
-          expect(host).to execute_commands_matching(/cat #{backup_location} > #{original_location}/).once
+          expect(host).to execute_commands_matching(/cat '#{backup_location}' > '#{original_location}'/).once
         end
       end
 


### PR DESCRIPTION
Bash conditionals demonstrate strange behaviors when not given an arg.
Given the following:

```
if [ -f  ]; then
  echo "how did I get here?"
fi
#=> how did I get here?
```

Wrapping ruby interpolated variables in quotes act as expected:

```
if [ -f '' ]; then echo
  "how did I get here?"
else
  echo "the empty string is not a file"
fi
#=> the empty string is not a file
```

The moral of the story is that bash exists to make everybody sad.
