### PR TITLE
Handle missing puppet.conf

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -12,6 +12,8 @@ end
 module Beaker
   class Host
 
+    class CommandFailure < StandardError; end
+
     # This class providers array syntax for using puppet --configprint on a host
     class PuppetConfigReader
       def initialize(host, command)
@@ -163,7 +165,7 @@ module Beaker
           # is it necessary to break execution??
           unless result.exit_code_in?(Array(options[:acceptable_exit_codes] || 0))
             limit = 10
-            raise "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{limit} lines of output were:\n#{result.formatted_output(limit)}"
+            raise CommandFailure, "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{limit} lines of output were:\n#{result.formatted_output(limit)}"
           end
         end
         # Danger, so we have to return this result?

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -14,7 +14,7 @@ module Unix::File
   end
 
   def file_exist?(path)
-    result = exec("test -e #{path}", :acceptable_exit_codes => [0, 1])
+    result = exec(Beaker::Command.new("test -e #{path}"), :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end
 end

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -545,6 +545,7 @@ describe ClassMixedWithDSLHelpers do
     def stub_host_and_subject_to_allow_the_default_testdir_argument_to_be_created
       subject.instance_variable_set(:@path, test_case_path)
       host.stub(:tmpdir).and_return(tmpdir_path)
+      host.stub(:file_exist?).and_return(true)
     end
 
     before do
@@ -643,6 +644,12 @@ describe ClassMixedWithDSLHelpers do
         it 'restores puppet.conf' do
           subject.with_puppet_running_on(host, {})
           expect(host).to execute_commands_matching(/cat '#{backup_location}' > '#{original_location}'/).once
+        end
+
+        it "doesn't restore a non-existent file" do
+          subject.stub(:backup_the_file)
+          subject.with_puppet_running_on(host, {})
+          expect(host).to execute_commands_matching(/rm -f '#{original_location}'/)
         end
       end
 


### PR DESCRIPTION
When `#with_puppet_running_on` is executed, it attempts to back up
puppet.conf and replace it for the duration for the test. The old
behavior of the code would always try to back up the file regardless of
the existence of the file, and would fail when the copy failed. This
commit ensures that the puppet.conf file is only backed up when present,
and the temporary puppet.conf is returned to the original state
when the method returns.

This supersedes GH-60.
