### PR TITLE
[QE-498] Use saner timeout in host::port_open?

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -63,13 +63,13 @@ module Beaker
     end
 
     def port_open? port
-      Timeout.timeout 1 do
-        begin
+      begin
+        Timeout.timeout 10 do
           TCPSocket.new(reachable_name, port).close
           return true
-        rescue Errno::ECONNREFUSED
-          return false
         end
+      rescue Errno::ECONNREFUSED, Timeout::Error
+        return false
       end
     end
 


### PR DESCRIPTION
previously, host::port_open? had two issues with its timeout:

1) the timeout of 1s was just too slow for crappy networks. With my
laptop on the office wifi, I am able to consistently exceed this
timeout when starting a TCP handshake with a server in our vmware
cluster.

2) When the timeout failed, it would blow up the entire process, even
if there were additional retries further up the stack.

This commit fixes both of these issues by catching the Timeout::Error
when it occurs, and also by increasing the timeout for the TCP
handshake.
