### PR TITLE
(QE-501) beaker raises warning about missing gem (unf)

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'inifile'
   #unf is an 'optional' fog dependency, but it warns when it is missing
   #  see https://github.com/fog/fog/pull/2320/commits
-  s.add_runtime_dependency 'unf'
+  #  uncomment to remove unf warning
+  #s.add_runtime_dependency 'unf'
 end


### PR DESCRIPTION
- adding missing gem broke platform testing
- commenting out offending line in beaker.gemspec, it can easily be
  flipped back on if desired
