### PR TITLE
[fixes QE-504] allow Beaker gem to be installed on 1.8

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -1,8 +1,4 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require 'rbconfig'
-ruby_conf = defined?(RbConfig) ? RbConfig::CONFIG : Config::CONFIG
-less_than_one_nine = ruby_conf['MAJOR'].to_i == 1 && ruby_conf['MINOR'].to_i < 9
 
 Gem::Specification.new do |s|
   s.name        = "beaker"
@@ -23,25 +19,28 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'fakefs', '0.4'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'simplecov' unless less_than_one_nine
+  s.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown' unless less_than_one_nine
+  s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'net-ssh'
-  s.add_runtime_dependency 'net-scp'
-  s.add_runtime_dependency 'rbvmomi'
-  s.add_runtime_dependency 'blimpy'
+  s.add_runtime_dependency 'json', '~> 1.8'
+  s.add_runtime_dependency 'net-ssh', '~> 2.6'
+  s.add_runtime_dependency 'net-scp', '~> 1.1'
+  s.add_runtime_dependency 'inifile', '~> 2.0'
+
+  # Optional provisioner specific support
+  s.add_runtime_dependency 'rbvmomi', '~> 1.6'
+  s.add_runtime_dependency 'blimpy', '~> 0.6'
+  s.add_runtime_dependency 'fission', '~> 0.4'
+
+  # These are transitive dependencies that we include or pin to because...
+  # Ruby 1.8 compatibility
   s.add_runtime_dependency 'nokogiri', '1.5.10'
-  s.add_runtime_dependency 'mime-types', '1.25' if RUBY_VERSION < "1.9"
-  s.add_runtime_dependency 'fission' if RUBY_PLATFORM =~ /darwin/i
-  s.add_runtime_dependency 'inifile'
-  #unf is an 'optional' fog dependency, but it warns when it is missing
-  #  see https://github.com/fog/fog/pull/2320/commits
-  #  uncomment to remove unf warning
-  #s.add_runtime_dependency 'unf'
+  s.add_runtime_dependency 'mime-types', '~> 1.25' # 2.0 won't install on 1.8
+  # So fog doesn't always complain of unmet AWS dependencies
+  s.add_runtime_dependency 'unf', '~> 0.1'
 end


### PR DESCRIPTION
This locks down explicit runtime and select transitive dependencies to ensure they work on 1.8/1.9

Note this shouldn't be merged until after QE-517 is fixed.
