### PR TITLE
(maint) Dump master puppet log if failed to start puppet.

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -449,7 +449,11 @@ module Beaker
             if host.is_pe?
               bounce_service( host, 'pe-httpd' )
             else
-              stop_puppet_from_source_on( host ) if puppet_master_started
+              if puppet_master_started
+                stop_puppet_from_source_on( host )
+              else
+                dump_puppet_log(host)
+              end
             end
 
           rescue Exception => teardown_exception
@@ -498,7 +502,6 @@ module Beaker
 
         logger.debug 'Waiting for the puppet master to start'
         unless port_open_within?( host, 8140, 10 )
-          dump_puppet_log(host)
           raise Beaker::DSL::FailTest, 'Puppet master did not start in a timely fashion'
         end
         logger.debug 'The puppet master has started'
@@ -515,9 +518,6 @@ module Beaker
             sleep 1
           end
         end
-      rescue RuntimeError => e
-        dump_puppet_log host
-        raise e
       end
 
       # @!visibility private

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -535,6 +535,13 @@ describe ClassMixedWithDSLHelpers do
       expect { subject.with_puppet_running_on(host, '--foo --bar') }.to raise_error(ArgumentError, /conf_opts must be a Hash. You provided a String: '--foo --bar'/)
     end
 
+    it 'raises the early_exception if backup_the_file fails' do
+      subject.should_receive(:backup_the_file).and_raise(RuntimeError.new('puppet conf backup failed'))
+      expect {
+        subject.with_puppet_running_on(host, {})
+      }.to raise_error(RuntimeError, /puppet conf backup failed/)
+    end
+
     describe "with valid arguments" do
       before do
         Tempfile.should_receive(:open).with('beaker')


### PR DESCRIPTION
Centralize logging after puppet master fails to start.

Before this change, you might miss getting master log output depending on where the failure occurred.
