### PR TITLE
Destroy vagrant hosts only if Vagrantfile exists

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -98,7 +98,7 @@ module Beaker
       if @options[:provision]
         #setting up new vagrant hosts
         #make sure that any old boxes are dead dead dead
-        vagrant_cmd("destroy --force")
+        vagrant_cmd("destroy --force") if File.file?(@vagrant_file)
 
         make_vfile @vagrant_hosts
 

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -89,9 +89,7 @@ module Beaker
     describe "provisioning and cleanup" do
 
       before :each do
-        vagrant.should_receive( :make_vfile ).with( @hosts ).once
-
-        vagrant.should_receive( :vagrant_cmd ).with( "destroy --force" ).once
+        FakeFS.activate!
         vagrant.should_receive( :vagrant_cmd ).with( "up" ).once
         @hosts.each do |host|
           host_prev_name = host['user']
@@ -103,6 +101,14 @@ module Beaker
       end
 
       it "can provision a set of hosts" do
+        vagrant.should_receive( :make_vfile ).with( @hosts ).once
+        vagrant.should_receive( :vagrant_cmd ).with( "destroy --force" ).never
+        vagrant.provision
+      end
+
+      it "destroys an existing set of hosts before provisioning" do
+        vagrant.make_vfile(@hosts)
+        vagrant.should_receive(:vagrant_cmd).with("destroy --force").once
         vagrant.provision
       end
 


### PR DESCRIPTION
The new `vagrant destroy --force` run during the vagrant hypervisors `provision` method added in #48 seems to fail if no `Vagrantfile` has ever been created for a nodeset. This fixes that.
