### PR TITLE
Rename `fact` to `fact_on` for uniformity

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -842,9 +842,15 @@ module Beaker
       #
       # @returns String The value of the fact 'name' on the provided host
       # @raise  [FailTest] Raises an exception if call to facter fails
-      def fact host, name, opts= {}
+      def fact_on(host, name, opts = {})
         result = on host, facter(name, opts)
-        result.stdout.chomp
+        result.stdout.chomp if result.stdout
+      end
+
+      # Get a facter fact from the default host
+      # @see #fact_on
+      def fact(name, opts = {})
+        fact_on(default, name, opts)
       end
 
     end

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -662,4 +662,23 @@ describe ClassMixedWithDSLHelpers do
 
     end
   end
+
+  describe '#fact_on' do
+    it 'retreives a fact on host(s)' do
+      subject.should_receive(:facter).with('osfamily',{}).once
+      subject.should_receive(:on).and_return(result)
+
+      subject.fact_on('host','osfamily')
+    end
+  end
+
+  describe '#fact' do
+    it 'delegates to #fact_on with the default host' do
+      subject.stub(:hosts).and_return(hosts)
+      subject.should_receive(:fact_on).with(master,"osfamily",{}).once
+
+      subject.fact('osfamily')
+    end
+  end
+
 end


### PR DESCRIPTION
The DSL method `fact` was recently added, but most dsl methods take the form of `<method>_on` for multi-node functions and `<method>` for running on a default node. This makes `fact_on()` run on designated nodes, and `fact()` run on the default node.
