### PR TITLE
pre-release of 1.0.1 beaker

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -6,7 +6,7 @@ less_than_one_nine = ruby_conf['MAJOR'].to_i == 1 && ruby_conf['MINOR'].to_i < 9
 
 Gem::Specification.new do |s|
   s.name        = "beaker"
-  s.version     = '1.0.0'
+  s.version     = '1.0.1.pre'
   s.authors     = ["Puppetlabs"]
   s.email       = ["delivery@puppetlabs.com"]
   s.homepage    = "https://github.com/puppetlabs/beaker"


### PR DESCRIPTION
Turns out, you just add a .pre (or .beta or any .string) to create a pre release gem.
