### PR TITLE
move VagrantFiles into .vagrant_files directory of working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ The vm is identified by `box` or `box_url` in the config file.  No snapshot name
       nfs_server: none
       consoleport: 443
 
+VagrantFiles are created per host configuration file.  They can be found in the `.vagrant/beaker_vagrant_files` directory of the current working directory in a subdirectory named after the host configuration file.
+
+    > beaker --hosts sample.cfg
+    > cd .vagrant/beaker_vagrant_files; ls
+    sample.cfg
+    > cd sample.cfg; ls
+    VagrantFile
+
 # Putting it all together #
 
 ## Running FOSS tests ##

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -88,7 +88,7 @@ module Beaker
       @logger = options[:logger]
       @temp_files = []
       @vagrant_hosts = vagrant_hosts
-      @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', 'vagrant_files', File.basename(options[:hosts_file])))
+      @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', '.vagrant', 'beaker_vagrant_files', File.basename(options[:hosts_file])))
       FileUtils.mkdir_p(@vagrant_path)
       @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
 

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -8,6 +8,16 @@ module Beaker
       @hosts = make_hosts()
     end
 
+    it "stores the vagrant file in $WORKINGDIR/.vagrant/beaker_vagrant_files/sample.cfg" do
+      FakeFS.activate!
+      vagrant.stub( :randmac ).and_return( "0123456789" )
+      path = vagrant.instance_variable_get( :@vagrant_path )
+
+      expect( path ).to be === File.join(Dir.pwd, '.vagrant', 'beaker_vagrant_files', 'sample.cfg')
+
+    end
+
+
     it "can make a Vagranfile for a set of hosts" do
       FakeFS.activate!
       path = vagrant.instance_variable_get( :@vagrant_path )


### PR DESCRIPTION
Request from module testing team to stop vagrant files from being incorporated into `puppet module build` generated packages.
