### PR TITLE
Fix catch_failures option

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -651,7 +651,6 @@ module Beaker
       #
       def apply_manifest_on(host, manifest, opts = {}, &block)
         on_options = {:stdin => manifest + "\n"}
-        on_options[:acceptable_exit_codes] = opts.delete(:acceptable_exit_codes)
         args = ["--verbose"]
         args << "--parseonly" if opts[:parseonly]
         args << "--trace" if opts[:trace]
@@ -664,7 +663,9 @@ module Beaker
           # '4' means there were failures during the transaction, and an exit
           # code of '6' means there were both changes and failures."
           # We're after failures specifically so catch exit codes 4 and 6 only.
-          on_options[:acceptable_exit_codes] |= [0, 2]
+          on_options[:acceptable_exit_codes] = Array(opts.delete(:acceptable_exit_codes)) | [0, 2]
+        else
+          on_options[:acceptable_exit_codes] = Array(opts.delete(:acceptable_exit_codes)) | 0
         end
 
         # Not really thrilled with this implementation, might want to improve it

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -297,6 +297,22 @@ describe ClassMixedWithDSLHelpers do
   end
 
   describe '#apply_manifest_on' do
+
+    it 'adds acceptable exit codes with :catch_failures' do
+      subject.should_receive( :puppet ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        and_return( 'puppet_command' )
+
+      subject.should_receive( :on ).
+        with( 'my_host', 'puppet_command',
+              :acceptable_exit_codes => [0,2],
+              :stdin => "class { \"boo\": }\n" )
+
+      subject.apply_manifest_on( 'my_host',
+                                'class { "boo": }',
+                                :trace => true,
+                                :catch_failures => true )
+    end
     it 'allows acceptable exit codes through :catch_failures' do
       subject.should_receive( :puppet ).
         with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).


### PR DESCRIPTION
If `:catch_failures => true` is supplied and no extra `:acceptable_exit_codes` are supplied, a bug hindered the `#apply_manifest_on` method from performing correctly.
