### PR TITLE
(QE-602) Beaker Throws Fatal Error when Displaying Current Version

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -1,8 +1,10 @@
 # -*- encoding: utf-8 -*-
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require 'beaker/version'
 
 Gem::Specification.new do |s|
   s.name        = "beaker"
-  s.version     = '1.3.1'
+  s.version     = Beaker::Version::STRING
   s.authors     = ["Puppetlabs"]
   s.email       = ["delivery@puppetlabs.com"]
   s.homepage    = "https://github.com/puppetlabs/beaker"

--- a/lib/beaker.rb
+++ b/lib/beaker.rb
@@ -1,7 +1,7 @@
 require 'rubygems' unless defined?(Gem)
 module Beaker
 
-  %w( utils test_suite result command options network_manager cli ).each do |lib|
+  %w( version utils test_suite result command options network_manager cli ).each do |lib|
     begin
       require "beaker/#{lib}"
     rescue LoadError

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -21,9 +21,7 @@ module Beaker
         exit
       end
       if @options[:version]
-        require 'rubygems' unless defined?(Gem)
-        spec = Gem::Specification::load(GEMSPEC)
-        @logger.notify(VERSION_STRING % spec.version)
+        @logger.notify(VERSION_STRING % Beaker::Version::STRING)
         exit
       end
       @logger.info(@options.dump)

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,0 +1,5 @@
+module Beaker
+  module Version
+    STRING = '1.3.1'
+  end
+end


### PR DESCRIPTION
- just don't do a gemspec load when looking for the version number, thus
  it doesn't end up calling git-ls, thus no fatal errors
