### PR TITLE
(QA-659) Pin beaker to rbvmomi 1.6.0

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'inifile', '~> 2.0'
 
   # Optional provisioner specific support
-  s.add_runtime_dependency 'rbvmomi', '~> 1.6'
+  s.add_runtime_dependency 'rbvmomi', '1.6' #HACK pinning to 1.6 to deal with QA-659
   s.add_runtime_dependency 'blimpy', '~> 0.6'
   s.add_runtime_dependency 'fission', '~> 0.4'
 


### PR DESCRIPTION
- pin to rbvmomi 1.6.0 until we can figure out what's broken with
  latest rbvmomi
