### PR TITLE
Beaker uses netmask from config for vagrant boxes if present

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -29,7 +29,7 @@ module Beaker
         v_file << "    v.vm.box = '#{host['box']}'\n"
         v_file << "    v.vm.box_url = '#{host['box_url']}'\n" unless host['box_url'].nil?
         v_file << "    v.vm.base_mac = '#{randmac}'\n"
-        v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"255.255.0.0\"\n"
+        v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\"\n"
         v_file << "  end\n"
         @logger.debug "created Vagrantfile for VagrantHost #{host.name}"
       end


### PR DESCRIPTION
The hardcoded netmask in beaker prevents vagrant guest boxen from being able to connect to the host, which means that one can't just run git daemon on the host in order to let the guests check out local changes for testing.

This commit allows the netmask to be configured in beaker's config file, and falls back to the old hardcoded value if that is not present.
