### PR TITLE
Add 'preserve' failure mode

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -83,6 +83,7 @@ module Beaker
 
     def execute!
 
+      skip_cleanup = ["stop", "preserve"].include? @options[:fail_mode]
       begin
         trap(:INT) do
           @logger.warn "Interrupt received; exiting..."
@@ -103,7 +104,7 @@ module Beaker
         rescue => e
           #post acceptance on failure
           #if we error then run the post suite as long as we aren't in fail-stop mode
-          run_suite(:post_suite) unless @options[:fail_mode] == "stop"
+          run_suite(:post_suite) unless skip_cleanup
           raise e
         else
           #post acceptance on success
@@ -114,7 +115,7 @@ module Beaker
         #cleanup on error
         #only do cleanup if we aren't in fail-stop mode
         @logger.notify "Cleanup: cleaning up after failed run"
-        if @options[:fail_mode] != "stop"
+        unless skip_cleanup
           if @network_manager
             @network_manager.cleanup
           end

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -146,7 +146,8 @@ module Beaker
                   'How should the harness react to errors/failures',
                   'Possible values:',
                   'fast (skip all subsequent tests, cleanup, exit)',
-                  'stop (skip all subsequent tests, do no cleanup, exit immediately)'  do |mode|
+                  'stop (skip all subsequent tests, do no cleanup, exit immediately)',
+                  'preserve (finish all subsequent tests, but do no cleanup)'  do |mode|
             @cmd_options[:fail_mode] = mode
           end
 

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -239,7 +239,7 @@ module Beaker
         end
 
         #check for valid fail mode
-        if not ["fast", "stop", nil].include?(@options[:fail_mode])
+        if not ["fast", "stop", "preserve", nil].include?(@options[:fail_mode])
           parser_error "--fail-mode must be one of fast, stop" 
         end
 

--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -57,10 +57,10 @@ module Beaker
           @logger.debug msg
         when :fail
           @logger.error msg
-          break if fail_mode #all failure modes cause us to kick out early on failure
+          break if ["fast", "stop"].include? fail_mode
         when :error
           @logger.warn msg
-          break if fail_mode #all failure modes cause use to kick out early on error
+          break if ["fast", "stop"].include? fail_mode
         end
       end
 


### PR DESCRIPTION
Previously, the only way to skip the host cleanup was to use the
'stop' fail mode. Unfortunately, this also caused all subsequent tests
to be ignored.

This adds a new failure mode which will finish all subsequent tests,
but leave the hosts behind for investigation of failures.
