### PR TITLE
Rubygems broke spec for rvm 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# Rubygems broke build for rvm 1.8.7
+# Temporary workound until https://github.com/rubygems/rubygems/pull/763 is merged
+before_install:
+  - gem update --system 2.1.11
+  - gem --version
 language: ruby
 script: "bundle exec rspec"
 notifications:


### PR DESCRIPTION
- Temporary workound until https://github.com/rubygems/rubygems/pull/763 is merged
