### PR TITLE
unpin rbvmomi from 1.6.0

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'inifile', '~> 2.0'
 
   # Optional provisioner specific support
-  s.add_runtime_dependency 'rbvmomi', '1.6' #HACK pinning to 1.6 to deal with QA-659
+  s.add_runtime_dependency 'rbvmomi', '1.8.1'
   s.add_runtime_dependency 'blimpy', '~> 0.6'
   s.add_runtime_dependency 'fission', '~> 0.4'
 


### PR DESCRIPTION
- rbvmomi issue fixed for ruby 1.8.7, should be good to go now (was in 1.8.0, fixed in 1.8.1)
