### PR TITLE
unpin rubygems for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-# Rubygems broke build for rvm 1.8.7
-# Temporary workound until https://github.com/rubygems/rubygems/pull/763 is merged
 before_install:
-  - gem update --system 2.1.11
+  - gem update --system 2.2.1
   - gem --version
 language: ruby
 script: "bundle exec rspec"


### PR DESCRIPTION
- issue with 1.8.7 bustage fixed in rubygems 2.2.1
  http://blog.rubygems.org/2014/01/06/2.2.1-released.html
