### PR TITLE
google compute engine integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The `vcloud` option requires a slightly-modified test configuration file, specif
 
 
 ## Vagrant support ##
-The option allows for testing against local Vagrant boxes.  As a prerequisite the Vagrant package (greather than 1.1) needs to installed - see <a href = "http://downloads.vagrantup.com/">downloads.vagrantup.com</a> for downloads.  
+This option allows for testing against local Vagrant boxes.  As a prerequisite the Vagrant package (greather than 1.1) needs to installed - see <a href = "http://downloads.vagrantup.com/">downloads.vagrantup.com</a> for downloads.  
 
 The vm is identified by `box` or `box_url` in the config file.  No snapshot name is required as the vm is reverted back to original state post testing using `vagrant destroy --force`.
 
@@ -303,6 +303,49 @@ VagrantFiles are created per host configuration file.  They can be found in the 
     sample.cfg
     > cd sample.cfg; ls
     VagrantFile
+    
+## Google Compute Engine Support ##
+This option provisions instances from pre-existing Google Compute Engine images.  Currently only supports debian-7 and centos-6 platforms (<a href = "https://developers.google.com/compute/docs/images#availableimages">Google Compute Engine available images</a>)
+
+Pre-requisites:
+
+  * A Google Compute Engine project 
+  * An active service account to your Google Compute Engine project (<a href = "https://developers.google.com/drive/service-accounts">Service Accounts Documentation</a>), along with the following information:
+    * The service account private key file (named xxx-privatekey.p12)
+    * The service account email address (named xxx@developer.gserviceaccount.com)
+    * The service account password
+  * A passwordless ssh keypair (<a href = "http://www.linuxproblem.org/art_9.html">SSH login without password</a>, <a href = "https://developers.google.com/compute/docs/console#sshkeys">Setting up Google Compute sshKeys metadata</a>)
+    * Name the pair `google-compute`
+    * Place the public key in your Google Compute Engine project metadata
+      * `key`: `sshKeys`
+      * `value` is the contents of your google_compute.pub with "google_compute:" prepended, eg:
+<pre>
+google_compute:ssh-rsaAAAABCCCCCCCCCCDDDDDeeeeeeeeFFFFFFFGGGGGGGGGGGGGGGGHHHHHHHHiiiiiiiiiiiJJJJJJJJKKKKKKKKKlllllllllllllllllllMNOppppppppppppppppppQRSTUV123456789101010101101010101011010101010110/ABCDEFGHIJKLMNOP+AB user@machine.local </pre>
+
+Example hosts file:
+
+    HOSTS:
+      debian-7-master:
+        roles:
+          - master
+          - agent
+          - database
+        platform: debian-7-wheezy-xxx
+        hypervisor: google
+      centos-6-agent:
+        roles:
+          - agent
+        platform: centos-6-xxx
+        hypervisor: google
+    CONFIG:
+      nfs_server: none
+      consoleport: 443
+      gce_project : google-compute-project-name
+      gce_keyfile : /path/to/*****-privatekey.p12
+      gce_password: notasecret
+      gce_email : *********@developer.gserviceaccount.com
+      
+Google Compute cloud instances and disks are deleted after test runs, but it is up to the owner of the Google Compute Engine project to ensure that any zombie instances/disks are properly removed should Beaker fail during cleanup.
 
 # Putting it all together #
 

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rbvmomi', '1.6' #HACK pinning to 1.6 to deal with QA-659
   s.add_runtime_dependency 'blimpy', '~> 0.6'
   s.add_runtime_dependency 'fission', '~> 0.4'
+  s.add_runtime_dependency 'google-api-client', '~> 0.6.4'
 
   # These are transitive dependencies that we include or pin to because...
   # Ruby 1.8 compatibility

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -1,6 +1,5 @@
 module Beaker
   class CLI
-    GEMSPEC = File.join(File.expand_path(File.dirname(__FILE__)), "../../beaker.gemspec")
     VERSION_STRING = 
 "      wWWWw
       |o o|
@@ -21,9 +20,7 @@ module Beaker
         exit
       end
       if @options[:version]
-        require 'rubygems' unless defined?(Gem)
-        spec = Gem::Specification::load(GEMSPEC)
-        @logger.notify(VERSION_STRING % spec.version)
+        @logger.notify(VERSION_STRING % @options[:v])
         exit
       end
       @logger.info(@options.dump)

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -388,10 +388,10 @@ module Beaker
         #process the version files if necessary
         hosts.each do |host|
           if host['platform'] =~ /windows/
-            host['pe_ver'] = host['pe_ver'] || 
+            host['pe_ver'] = host['pe_ver'] || options['pe_ver'] ||
               Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || options[:pe_dir], options[:pe_version_file_win])
           else
-            host['pe_ver'] = host['pe_ver'] || 
+            host['pe_ver'] = host['pe_ver'] || options['pe_ver'] ||
               Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || options[:pe_dir], options[:pe_version_file])
           end
         end

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -1,6 +1,8 @@
 module Beaker
   class Hypervisor
 
+    CHARMAP = [('a'..'z'),('0'..'9')].map{|r| r.to_a}.flatten
+
     def configure(hosts)
       @logger.debug "No post-provisioning configuration necessary for #{self.class.name} boxes"
     end
@@ -27,6 +29,8 @@ module Beaker
           end
         when /vagrant/
           Beaker::Vagrant
+        when /google/
+          Beaker::GoogleCompute
         end
       hypervisor = hyper_class.new(hosts_to_provision, options)
       hypervisor.provision
@@ -38,10 +42,34 @@ module Beaker
       nil
     end
 
+    def generate_host_name
+      CHARMAP[rand(25)] + (0...14).map{CHARMAP[rand(CHARMAP.length)]}.join
+    end
+
+    def copy_ssh_to_root host
+      #make it possible to log in as root by copying the ssh dir to root's account
+      @logger.debug "Give root a copy of current host's keys"
+      if host['platform'] =~ /windows/
+        host.exec(Command.new('sudo su -c "cp -r .ssh /home/Administrator/."'))
+      else
+        host.exec(Command.new('sudo su -c "cp -r .ssh /root/."'), {:pty => true})
+      end
+    end
+
+    def hack_etc_hosts hosts
+      etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
+      hosts.each do |host|
+        etc_hosts += "#{host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
+      end
+      hosts.each do |host|
+        set_etc_hosts(host, etc_hosts)
+      end
+    end
+
   end
 end
 
-%w( vsphere_helper vagrant fusion blimper vsphere vcloud vcloud_pooled aixer solaris).each do |lib|
+%w( vsphere_helper vagrant fusion blimper vsphere vcloud vcloud_pooled aixer solaris google_compute).each do |lib|
   begin
     require "hypervisor/#{lib}"
   rescue LoadError

--- a/lib/beaker/hypervisor/google_compute.rb
+++ b/lib/beaker/hypervisor/google_compute.rb
@@ -1,0 +1,389 @@
+require 'google/api_client'
+require 'json'
+require 'time'
+require 'ostruct'
+
+module Beaker
+  class GoogleCompute < Beaker::Hypervisor
+    SLEEPWAIT = 5
+    #number of hours before an instance is considered a zombie
+    ZOMBIE = 3
+
+    # Constants for use as request parameters.
+    AUTH_URL = 'https://www.googleapis.com/auth/compute'
+    API_VERSION = 'v1'
+    BASE_URL = "https://www.googleapis.com/compute/#{API_VERSION}/projects/"
+    CENTOS_PROJECT = 'centos-cloud'
+    DEBIAN_PROJECT = 'debian-cloud'
+    DEFAULT_ZONE_NAME = 'us-central1-a'
+    DEFAULT_MACHINE_TYPE = 'n1-highmem-2'
+    DEFAULT_DISK_SIZE = 25
+
+    def default_zone
+      BASE_URL + @options[:gce_project] + '/global/zones/' + DEFAULT_ZONE_NAME 
+    end
+
+    def default_network
+      BASE_URL + @options[:gce_project] + '/global/networks/default' 
+    end
+
+    def get_platform_project(name)
+      if name =~ /debian/
+        return DEBIAN_PROJECT
+      elsif name =~ /centos/
+        return CENTOS_PROJECT
+      else
+        raise "Unsupported platform for Google Compute Engine: #{name}"
+      end
+    end
+
+    def initialize(google_hosts, options)
+      @options = options
+      @logger = options[:logger]
+      @google_hosts = google_hosts
+      try = 1
+      attempts = @options[:timeout].to_i / SLEEPWAIT
+      start = Time.now
+
+      set_client(@options[:v])
+      set_compute_api(API_VERSION, start, attempts)
+
+      raise 'You must specify a gce_project for Google Compute Engine instances!' unless @options[:gce_project]
+      raise 'You must specify a gce_keyfile for Google Compute Engine instances!' unless @options[:gce_keyfile]
+      raise 'You must specify a gce_password for Google Compute Engine instances!' unless @options[:gce_password]
+      raise 'You must specify a gce_email for Google Compute Engine instances!' unless @options[:gce_email]
+
+      authenticate(@options[:gce_keyfile], @options[:gce_password], @options[:gce_email], start, attempts)
+    end
+
+    def set_client(version)
+      @client = Google::APIClient.new({:application_name => "Beaker", :application_version => version})
+    end
+
+    def set_compute_api version, start, attempts
+      try = (Time.now - start) / SLEEPWAIT
+      while try <= attempts
+        begin
+          @compute = @client.discovered_api('compute', version)
+          @logger.debug("Google Compute API discovered")
+          return
+        rescue => e
+          @logger.debug("Failed to discover Google Compute API")
+          if try >= attempts 
+            raise e
+          end
+        end
+        try += 1
+      end
+    end
+
+    def authenticate(keyfile, password, email, start, attempts)
+      # OAuth authentication, using the service account
+      key = Google::APIClient::PKCS12.load_key(keyfile, password)
+      service_account = Google::APIClient::JWTAsserter.new(
+          email,
+          AUTH_URL,
+          key)
+      try = (Time.now - start) / SLEEPWAIT
+      while try <= attempts
+        begin
+          @client.authorization = service_account.authorize
+          @logger.debug("Authorized to use Google Compute")
+          return
+        rescue => e
+          @logger.debug("Failed to authorize to use Google Compute")
+          if try >= attempts 
+            raise e
+          end
+        end
+        try += 1
+      end
+    end
+
+    def request_body name, image, machineType, project
+      {
+        'name' => name,
+        'image' => image,
+        'zone' => default_zone,
+        'machineType' => machineType,
+        'networkInterfaces' => [{ 'network' => default_network }]
+      }
+    end
+
+    def execute req
+      result = @client.execute(req)
+      parsed = JSON.parse(result.body)
+      if not result.success?
+        error_code = parsed["error"] ? parsed["error"]["code"] : 0
+        if error_code == 404
+          raise "Resource Not Found: #{result.body}"
+        elsif error_code == 400
+          raise "Bad Request: #{result.body}"
+        else
+          raise "Error attempting Google Compute API execute: #{result.body}"
+        end
+      end
+      parsed
+    end
+
+    def image_list_req(name)
+      platformProject = get_platform_project(name)
+      { :api_method  => @compute.images.list, 
+        :parameters  => { 'project' => platformProject } }
+    end
+
+    def disk_list_req
+      { :api_method  => @compute.disks.list, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME } }
+    end
+
+    def disk_get_req(name)
+      { :api_method  => @compute.disks.get, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'disk' => name } }
+    end
+
+    def disk_delete_req(name)
+      { :api_method  => @compute.disks.delete, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'disk' => name } }
+    end
+
+    def disk_insert_req(name, source)
+      { :api_method  => @compute.disks.insert, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'sourceImage' => source }, 
+        :body_object => { 'name' => name, 'sizeGb' => DEFAULT_DISK_SIZE } }
+    end
+
+    def instance_list_req
+      { :api_method  => @compute.instances.list, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME } }
+    end
+
+    def instance_get_req(name)
+      { :api_method  => @compute.instances.get, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'instance' => name } }
+    end
+
+    def instance_delete_req(name)
+      { :api_method  => @compute.instances.delete, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'instance' => name } }
+    end
+
+    def instance_insert_req(name, image, machineType, disk)
+      { :api_method  => @compute.instances.insert, 
+        :parameters  => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME }, 
+        :body_object => { 'name' => name, 
+                          'image' => image, 
+                          'zone' => default_zone, 
+                          'machineType' => machineType, 
+                          'disks' => [ { 'source' => disk, 
+                                         'type' => 'PERSISTENT', 'boot' => 'true'} ], 
+                                         'networkInterfaces' => [ { 'accessConfigs' => [{ 'type' => 'ONE_TO_ONE_NAT', 'name' => 'External NAT' }], 
+                                                                    'network' => default_network } ] } }
+    end
+
+    def machineType_get_req()
+      { :api_method => @compute.machine_types.get, 
+        :parameters => { 'project' => @options[:gce_project], 'zone' => DEFAULT_ZONE_NAME, 'machineType' => @options[:gce_machine_type] || DEFAULT_MACHINE_TYPE } }
+    end
+
+    def allow_root_login host
+      @logger.debug "Update /etc/ssh/sshd_config to allow root login"
+      host.exec(Command.new("sudo su -c \"sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config\""), {:pty => true})
+      #restart sshd
+      if host['platform'] =~ /debian|ubuntu/
+        host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
+      elsif host['platform'] =~ /centos|el-|redhat|fedora/
+        host.exec(Command.new("sudo su -c \"service sshd restart\""), {:pty => true})
+      else
+        raise "Attempting to update ssh on non-supported platform: #{host.name}: #{host['platform']}"
+      end
+    end
+
+    def disable_se_linux_and_firewall host
+      if host['platform'] =~ /centos/
+        @logger.debug("Disabling se_linux on #{host.name}")
+        host.exec(Command.new("sudo su -c \"setenforce 0\""), {:pty => true})
+        host.exec(Command.new("sudo su -c \"/etc/init.d/iptables stop\""), {:pty => true})
+      end
+    end
+
+    def get_latest_image(platform)
+      #break up my platform for information
+      platform_name, platform_version, platform_extra_info = platform.split('-', 3)
+      #find latest image to use
+      result = execute( image_list_req(platform_name) ) 
+      images = result["items"]
+      #reject images of the wrong version of the given platform
+      images.delete_if { |image| image['name'] !~ /^#{platform_name}-#{platform_version}/}
+      #reject deprecated images
+      images.delete_if { |image| image['deprecated']}
+      #find a match based upon platform type
+      if images.length != 1
+        raise "Unable to find a single matching image for #{host[:platform]}, found #{images}"
+      end
+      images[0]
+    end
+
+    def provision
+      try = 1
+      attempts = @options[:timeout].to_i / SLEEPWAIT
+      start = Time.now
+
+      #get machineType resource, used my all instances
+      machineType = execute( machineType_get_req )
+
+      @google_hosts.each do |host|
+        img = get_latest_image(host[:platform])
+
+        #create boot disk name
+        host['diskname'] = generate_host_name
+        #create a new boot disk for this instance
+        disk = execute( disk_insert_req( host['diskname'], img['selfLink'] ) )
+
+        status = ''
+        try = (Time.now - start) / SLEEPWAIT
+        while status !~ /READY/ and try <= attempts 
+          begin
+            disk = execute( disk_get_req( host['diskname'] ) )
+            status = disk['status']
+          rescue
+            @logger.debug("Waiting for #{host.name}: #{host['diskname']} disk creation")
+            sleep(SLEEPWAIT)
+          end
+          try += 1
+        end
+        if status == ''
+          raise "Unable to create disk #{host.name}: #{host['diskname']}"
+        end
+        @logger.debug("Created disk #{host.name}: #{host['diskname']}")
+
+        #create new host name
+        host['vmhostname'] = generate_host_name
+        #add a new instance of the image
+        instance = execute( instance_insert_req( host['vmhostname'], img['selfLink'], machineType['selfLink'], disk['selfLink'] ) )
+        status = ''
+        try = (Time.now - start) / SLEEPWAIT
+        while status !~ /RUNNING/ and try <= attempts
+          begin
+            instance = execute( instance_get_req( host['vmhostname'] ) ) 
+            status = instance['status']
+          rescue
+            @logger.debug("Waiting for #{host.name}: #{host['vmhostname']} instance creation")
+            sleep(SLEEPWAIT)
+          end
+          try += 1
+        end
+        if status == ''
+          raise "Unable to create instance #{host.name}: #{host['vmhostname']}"
+        end
+        @logger.debug("Created instance #{host.name}: #{host['vmhostname']}")
+
+        #get ip for this host
+        host['ip'] = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
+
+        #configure ssh
+        default_user = host['user']
+        host['user'] = 'google_compute'
+
+        disable_se_linux_and_firewall(host)
+        copy_ssh_to_root(host)
+        allow_root_login(host)
+        host['user'] = default_user
+
+        #shut down connection, will reconnect on next exec
+        host.close
+
+        @logger.debug("Instance ready: #{host['vmhostname']} for #{host.name}}")
+      end
+    end
+
+    def delete_instance(name, start, attempts)
+      result = execute( instance_delete_req( name ) )
+      #ensure deletion of instance
+      try = (Time.now - start) / SLEEPWAIT
+      while try <= attempts
+        begin
+          result = execute( instance_get_req( name ) ) 
+          @logger.debug("Waiting for #{name} instance deletion")
+          sleep(SLEEPWAIT)
+        rescue
+          @logger.debug("#{name} instance deleted!")
+          return
+        end
+        try += 1
+      end
+      @logger.debug("#{name} instance was not removed before timeout, may still exist")
+    end
+
+    def delete_disk(name, start, attempts)
+      result = execute( disk_delete_req( name ) )
+      #ensure deletion of disk
+      try = (Time.now - start) / SLEEPWAIT
+      while try <= attempts
+        begin
+          disk = execute( disk_get_req( name ) ) 
+          @logger.debug("Waiting for #{name} disk deletion")
+          sleep(SLEEPWAIT)
+        rescue
+          @logger.debug("#{name} disk deleted!")
+          return
+        end
+        try += 1
+      end
+      @logger.debug("#{name} disk was not removed before timeout, may still exist")
+    end
+
+    def cleanup()
+      attempts = @options[:timeout].to_i / SLEEPWAIT
+      start = Time.now
+
+      @google_hosts.each do |host|
+        delete_instance(host['vmhostname'], start, attempts)
+        @logger.debug("Deleted instance #{host['vmhostname']} for #{host.name}")
+        delete_disk(host['diskname'], start, attempts)
+        @logger.debug("Deleted disk #{host['diskname']} for #{host.name}")
+      end
+
+    end
+
+    def kill_zombies(max_age = ZOMBIE)
+      now = start = Time.now
+      attempts = @options[:timeout].to_i / SLEEPWAIT
+
+      #get rid of old instances 
+      result = execute( instance_list_req() ) 
+      instances = result["items"]
+      if instances
+        instances.each do |instance|
+          created = Time.parse(instance['creationTimestamp'])
+          alive = (now - created ) /60 /60
+          if alive >= max_age
+            #kill it with fire!
+            @logger.debug("Deleting zombie instance #{instance['name']}")
+            delete_instance( instance['name'], start, attempts )
+          end
+        end
+      else 
+        @logger.debug("No zombie instances found")
+      end
+      #get rid of old disks
+      result = execute( disk_list_req() ) 
+      disks = result["items"]
+      if disks
+        disks.each do |disk|
+          created = Time.parse(disk['creationTimestamp'])
+          alive = (now - created ) /60 /60
+          if alive >= max_age
+            #kill it with fire!
+            @logger.debug("Deleting zombie disk #{disk['name']}")
+            delete_disk( disk['name'], start, attempts )
+          end
+        end
+      else
+        @logger.debug("No zombie disks found")
+      end
+
+    end
+
+  end
+end

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -42,26 +42,6 @@ module Beaker
       end
     end
 
-    def hack_etc_hosts hosts
-      etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
-      hosts.each do |host|
-        etc_hosts += "#{host['ip'].to_s}\t#{host.name}\n"
-      end
-      hosts.each do |host|
-        set_etc_hosts(host, etc_hosts)
-      end
-    end
-
-    def copy_ssh_to_root host
-      #make is possible to log in as root by copying the ssh dir to root's account
-      @logger.debug "Give root a copy of vagrant's keys"
-      if host['platform'] =~ /windows/
-        host.exec(Command.new('sudo su -c "cp -r .ssh /home/Administrator/."'))
-      else
-        host.exec(Command.new('sudo su -c "cp -r .ssh /root/."'))
-      end
-    end
-
     def set_ssh_config host, user
         f = Tempfile.new("#{host.name}")
         ssh_config = Dir.chdir(@vagrant_path) do

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -2,7 +2,6 @@ require 'yaml' unless defined?(YAML)
 
 module Beaker 
   class Vcloud < Beaker::Hypervisor
-    CHARMAP = [('a'..'z'),('0'..'9')].map{|r| r.to_a}.flatten
 
     def initialize(vcloud_hosts, options)
       @options = options
@@ -50,10 +49,6 @@ module Beaker
           raise "vSphere registration failed after #{@options[:timeout].to_i} seconds"
         end
       end
-    end
-
-    def generate_host_name
-      CHARMAP[rand(25)] + (0...14).map{CHARMAP[rand(CHARMAP.length)]}.join
     end
 
     def create_clone_spec host

--- a/lib/beaker/hypervisor/vcloud_pooled.rb
+++ b/lib/beaker/hypervisor/vcloud_pooled.rb
@@ -4,7 +4,6 @@ require 'net/http'
 
 module Beaker 
   class VcloudPooled < Beaker::Hypervisor
-    CHARMAP = [('a'..'z'),('0'..'9')].map{|r| r.to_a}.flatten
     SSH_EXCEPTIONS = [
       SocketError,
       Timeout::Error,

--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -8,7 +8,7 @@ end
 
 module Beaker
   class NetworkManager
-    HYPERVISOR_TYPES = ['solaris', 'blimpy', 'vsphere', 'fusion', 'aix', 'vcloud', 'vagrant']
+    HYPERVISOR_TYPES = ['solaris', 'blimpy', 'vsphere', 'fusion', 'aix', 'vcloud', 'vagrant', 'google']
 
     def provision? options, host 
       #provision this box

--- a/lib/beaker/options/hosts_file_parser.rb
+++ b/lib/beaker/options/hosts_file_parser.rb
@@ -25,6 +25,7 @@ module Beaker
         end
 
         # Make sure the roles array is present for all hosts
+        host_options['HOSTS'] ||= {}
         host_options['HOSTS'].each_key do |host|
           host_options['HOSTS'][host]['roles'] ||= []
         end

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -5,6 +5,9 @@ module Beaker
     #An Object that parses, merges and normalizes all supported Beaker options and arguments
     class Parser
       GITREPO      = 'git://github.com/puppetlabs'
+      #location of the gemspec for Beaker
+      GEMSPEC = File.join(File.expand_path(File.dirname(__FILE__)), "../../../beaker.gemspec")
+
       #These options can have the form of arg1,arg2 or [arg] or just arg, 
       #should default to []
       LONG_OPTS    = [:helper, :load_path, :tests, :pre_suite, :post_suite, :install, :modules]
@@ -35,6 +38,13 @@ module Beaker
       # @return [String] The usage String
       def usage
        @command_line_parser.usage
+      end
+
+      # Returns the current Beaker version number contained in the beaker.gemspec file.
+      # @return [String] The version number
+      def get_version
+        gemspec = File.read(GEMSPEC)
+        /version\s+=\s+('|")([\d\.]*)('|")/.match(gemspec)[2]
       end
 
       # Normalizes argument into an Array.  Argument can either be converted into an array of a single value,
@@ -152,6 +162,9 @@ module Beaker
         # merge command line and file options with defaults
         #   overwrite defaults with command line and file options 
         @options = @options.merge(cmd_line_and_file_options)
+
+        #set the version
+        @options[:v] = get_version
 
         if not @options[:help] and not @options[:version]
           #read the hosts file that contains the node configuration and hypervisor info
@@ -273,7 +286,7 @@ module Beaker
             parser_error "Only agent nodes may have the role 'frictionless', fix #{@options[:hosts_file]}"
           end
         end
-        if master > 1 or master < 1
+        if master > 1 
           parser_error "One and only one host/node may have the role 'master', fix #{@options[:hosts_file]}"
         end
 

--- a/lib/beaker/utils/setup_helper.rb
+++ b/lib/beaker/utils/setup_helper.rb
@@ -14,9 +14,17 @@ module Beaker
 
       def add_master_entry
         @logger.notify "Add Master entry to /etc/hosts"
+        if hosts_with_role(@hosts, :master) == []
+          @logger.debug "No master to configure"
+          return
+        end
         master = only_host_with_role(@hosts, :master)
         if master["hypervisor"] and master["hypervisor"] =~ /vagrant/
           @logger.debug "Don't update master entry on vagrant masters"
+          return
+        end
+        if master["hypervisor"] and master["hypervisor"] =~ /google/
+          @logger.debug "Don't update master entry on google masters"
           return
         end
         @logger.debug "Get ip address of Master #{master}"

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -154,7 +154,7 @@ module Beaker
       it "can correctly combine arguments from different sources" do
         FakeFS.deactivate!
         args = ["-h", hosts_path, "--log-level", "debug", "--type", "git", "--install", "PUPPET/1.0,HIERA/hello"]
-        expect(parser.parse_args(args)).to be === {:log_level=>"debug", :hosts_file=>hosts_path, :options_file=>nil, :type=>"git", :provision=>true, :preserve_hosts=>false, :root_keys=>false, :quiet=>false, :xml=>false, :color=>true, :dry_run=>false, :timeout=>300, :fail_mode=>nil, :timesync=>false, :repo_proxy=>false, :add_el_extras=>false, :consoleport=>443, :pe_dir=>"/opt/enterprise/dists", :pe_version_file=>"LATEST", :pe_version_file_win=>"LATEST-win", :dot_fog=>"#{home}/.fog", :help=>false, :ec2_yaml=>"config/image_templates/ec2.yaml", :ssh=>{:config=>false, :paranoid=>false, :timeout=>300, :auth_methods=>["publickey"], :port=>22, :forward_agent=>true, :keys=>["#{home}/.ssh/id_rsa"], :user_known_hosts_file=>"#{home}/.ssh/known_hosts"}, :install=>["git://github.com/puppetlabs/puppet.git#1.0", "git://github.com/puppetlabs/hiera.git#hello"], :HOSTS=>{:"pe-ubuntu-lucid"=>{:roles=>["agent", "dashboard", "database", "master"], :vmname=>"pe-ubuntu-lucid", :platform=>"ubuntu-10.04-i386", :snapshot=>"clean-w-keys", :hypervisor=>"fusion"}, :"pe-centos6"=>{:roles=>["agent"], :vmname=>"pe-centos6", :platform=>"el-6-i386", :hypervisor=>"fusion", :snapshot=>"clean-w-keys"}}, :nfs_server=>"none", :helper=>[], :load_path=>[], :tests=>[], :pre_suite=>[], :post_suite=>[], :modules=>[]}
+        expect(parser.parse_args(args)).to be === {:log_level=>"debug", :hosts_file=>hosts_path, :options_file=>nil, :type=>"git", :provision=>true, :preserve_hosts=>false, :root_keys=>false, :quiet=>false, :xml=>false, :color=>true, :dry_run=>false, :timeout=>300, :fail_mode=>nil, :timesync=>false, :repo_proxy=>false, :add_el_extras=>false, :consoleport=>443, :pe_dir=>"/opt/enterprise/dists", :pe_version_file=>"LATEST", :pe_version_file_win=>"LATEST-win", :dot_fog=>"#{home}/.fog", :help=>false, :ec2_yaml=>"config/image_templates/ec2.yaml", :ssh=>{:config=>false, :paranoid=>false, :timeout=>300, :auth_methods=>["publickey"], :port=>22, :forward_agent=>true, :keys=>["#{home}/.ssh/id_rsa"], :user_known_hosts_file=>"#{home}/.ssh/known_hosts"}, :install=>["git://github.com/puppetlabs/puppet.git#1.0", "git://github.com/puppetlabs/hiera.git#hello"], :v=>parser.get_version, :HOSTS=>{:"pe-ubuntu-lucid"=>{:roles=>["agent", "dashboard", "database", "master"], :vmname=>"pe-ubuntu-lucid", :platform=>"ubuntu-10.04-i386", :snapshot=>"clean-w-keys", :hypervisor=>"fusion"}, :"pe-centos6"=>{:roles=>["agent"], :vmname=>"pe-centos6", :platform=>"el-6-i386", :hypervisor=>"fusion", :snapshot=>"clean-w-keys"}}, :nfs_server=>"none", :helper=>[], :load_path=>[], :tests=>[], :pre_suite=>[], :post_suite=>[], :modules=>[]}
       end
 
       it "ensures that file-mode is one of fast/stop" do
@@ -169,7 +169,7 @@ module Beaker
         expect{parser.parse_args(args)}.to raise_error(ArgumentError)
       end
 
-      describe "normalize_args" do
+      describe "normalize_args", :use_fakefs => true do
         let(:hosts) do
           {
             'HOSTS' => {
@@ -181,6 +181,14 @@ module Beaker
               },
             }
           }
+        end
+        let(:gemspec) { "version = '0.0.0'" }
+
+        before :each do
+          File.open('tmp.gemspec', 'w') do |f|
+            f.puts(gemspec)
+          end
+          stub_const("Beaker::Options::Parser::GEMSPEC", 'tmp.gemspec') 
         end
 
         def fake_hosts_file_for_platform(hosts, platform)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -53,7 +53,11 @@ module HostHelpers
                                                :pooling_api => 'http://vcloud.delivery.puppetlabs.net/',
                                                :datastore => 'instance0',
                                                :folder => 'Delivery/Quality Assurance/Staging/Dynamic',
-                                               :resourcepool => 'delivery/Quality Assurance/Staging/Dynamic' } )
+                                               :resourcepool => 'delivery/Quality Assurance/Staging/Dynamic',
+                                               :gce_project => 'beaker-compute',
+                                               :gce_keyfile => '/path/to/keyfile.p12',
+                                               :gce_password => 'notasecret',
+                                               :gce_email => '12345678910@developer.gserviceaccount.com' } )
   end
 
   def generate_result (name, opts )


### PR DESCRIPTION
Initial google compute engine integration.
- includes
  - ability to provision google compute instances from google compute images
  - since this uses google compute pre-built images only supports debian + centos
  - fixes to existing spec tests
  - update to README to cover new hypervisor
- missing new spec tests to cover new google hypervisor
- if we start to create our own google compute images some of the set up steps will need to be updated (right now images are pulled from the centos-cloud and debian-cloud projects)
