### PR TITLE
(QA-705) Create manifest files to apply

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -669,7 +669,7 @@ module Beaker
       #                      validation, etc.
       #
       def apply_manifest_on(host, manifest, opts = {}, &block)
-        on_options = {:stdin => manifest + "\n"}
+        on_options = {}
         on_options[:acceptable_exit_codes] = Array(opts.delete(:acceptable_exit_codes))
         args = ["--verbose"]
         args << "--parseonly" if opts[:parseonly]
@@ -714,6 +714,9 @@ module Beaker
           args << { :environment => opts[:environment]}
         end
 
+        file_path = "/tmp/apply_manifest.#{rand(1000000000).to_s}.pp"
+        create_remote_file(host, file_path, manifest + "\n")
+        args << file_path
         on host, puppet( 'apply', *args), on_options, &block
       end
 

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -298,26 +298,26 @@ describe ClassMixedWithDSLHelpers do
 
   describe '#apply_manifest_on' do
     it 'calls puppet' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose').
+        with( 'apply', '--verbose', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).
         with( 'my_host', 'puppet_command',
-              :acceptable_exit_codes => [0],
-              :stdin => "class { \"boo\": }\n" )
+              :acceptable_exit_codes => [0] )
 
       subject.apply_manifest_on( 'my_host', 'class { "boo": }')
     end
     it 'adds acceptable exit codes with :catch_failures' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).
         with( 'my_host', 'puppet_command',
-              :acceptable_exit_codes => [0,2],
-              :stdin => "class { \"boo\": }\n" )
+              :acceptable_exit_codes => [0,2] )
 
       subject.apply_manifest_on( 'my_host',
                                 'class { "boo": }',
@@ -325,14 +325,14 @@ describe ClassMixedWithDSLHelpers do
                                 :catch_failures => true )
     end
     it 'allows acceptable exit codes through :catch_failures' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).
         with( 'my_host', 'puppet_command',
-              :acceptable_exit_codes => [4,0,2],
-              :stdin => "class { \"boo\": }\n" )
+              :acceptable_exit_codes => [4,0,2] )
 
       subject.apply_manifest_on( 'my_host',
                                 'class { "boo": }',
@@ -341,15 +341,15 @@ describe ClassMixedWithDSLHelpers do
                                 :catch_failures => true )
     end
     it 'enforces a 0 exit code through :catch_changes' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).with(
         'my_host',
         'puppet_command',
-        :acceptable_exit_codes => [0],
-        :stdin                 => "class { \"boo\": }\n"
+        :acceptable_exit_codes => [0]
       )
 
       subject.apply_manifest_on(
@@ -360,15 +360,15 @@ describe ClassMixedWithDSLHelpers do
       )
     end
     it 'enforces exit codes through :expect_failures' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).with(
         'my_host',
         'puppet_command',
-        :acceptable_exit_codes => [1,4,6],
-        :stdin                 => "class { \"boo\": }\n"
+        :acceptable_exit_codes => [1,4,6]
       )
 
       subject.apply_manifest_on(
@@ -390,15 +390,15 @@ describe ClassMixedWithDSLHelpers do
       }.to raise_error ArgumentError, /catch_failures.+expect_failures/
     end
     it 'enforces added exit codes through :expect_failures' do
+      subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).
-        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes' ).
+        with( 'apply', '--verbose', '--trace', '--detailed-exitcodes', /apply_manifest.\d+.pp/ ).
         and_return( 'puppet_command' )
 
       subject.should_receive( :on ).with(
         'my_host',
         'puppet_command',
-        :acceptable_exit_codes => [1,2,3,4,5,6],
-        :stdin                 => "class { \"boo\": }\n"
+        :acceptable_exit_codes => [1,2,3,4,5,6]
       )
 
       subject.apply_manifest_on(


### PR DESCRIPTION
When applying puppet manifests with `puppet apply` beaker will generate
the manifest code and send it to `stdin`. This is troublesome for
debugging as the actual code is never shown and hard to replicate.

This commit causes the manifest code to be stored in a `.pp` file in
`/tmp` and apply that file so that it may be viewed and reused when
debugging. This is similar to how rspec-system does it.
