### PR TITLE
(QA-720) Provide way to install from public repos

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -383,6 +383,41 @@ module Beaker
         special_nodes + real_agents
       end
 
+      #Install POSS based upon host configuration and options
+      # @example
+      #  install_puppet
+      #
+      # @note This will attempt to add a repository for apt.puppetlabs.com on
+      #       Debian or Ubuntu machines, or yum.puppetlabs.com on EL or Fedora
+      #       machines, then install the package 'puppet'
+      #
+      # @api dsl
+      # @return nil
+      def install_puppet
+        hosts.each do |host|
+          if host['platform'] =~ /el-(5|6)/
+            relver = $1
+            on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-#{relver}.noarch.rpm"
+            on host, 'yum install -y puppet'
+          elsif host['platform'] =~ /fedora-(\d+)/
+            relver = $1
+            on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-#{relver}.noarch.rpm"
+            on host, 'yum install -y puppet'
+          elsif host['platform'] =~ /(ubuntu|debian)/
+            if ! host.check_for_package 'curl'
+              on host, 'apt-get install -y curl'
+            end
+            on host, 'curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -c -s).deb'
+            on host, 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb'
+            on host, 'apt-get -y -f -m update'
+            on host, 'apt-get install -y puppet'
+          else
+            raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"
+          end
+        end
+        nil
+      end
+
       #Install PE based upon host configuration and options
       # @example 
       #  install_pe

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -28,7 +28,7 @@ module Beaker
           end
 
           opts.on '--type TYPE',
-                  'one of git or pe', 
+                  'one of git, foss, or pe',
                   'used to determine underlying path structure of puppet install',
                   '(default pe)' do |type|
             @cmd_options[:type] = type

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -234,8 +234,8 @@ module Beaker
         end 
  
         #check for valid type
-        if @options[:type] !~ /(pe)|(git)/
-          parser_error "--type must be one of pe or git, not '#{@options[:type]}'"
+        if @options[:type] !~ /(pe)|(git)|(foss)/
+          parser_error "--type must be one of pe, git, or foss, not '#{@options[:type]}'"
         end
 
         #check for valid fail mode

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -257,6 +257,68 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  describe '#install_puppet' do
+    let(:hosts) do
+      make_hosts({:platform => platform })
+    end
+
+    before do
+      subject.stub(:hosts).and_return(hosts)
+      subject.stub(:on).and_return(Beaker::Result.new({},''))
+    end
+    context 'on el-6' do
+      let(:platform) { "el-6-i386" }
+      it 'installs' do
+        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-el-6\.noarch\.rpm/)
+        expect(subject).to receive(:on).with(hosts[0], 'yum install -y puppet')
+        subject.install_puppet
+      end
+    end
+    context 'on el-5' do
+      let(:platform) { "el-5-i386" }
+      it 'installs' do
+        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-el-5\.noarch\.rpm/)
+        expect(subject).to receive(:on).with(hosts[0], 'yum install -y puppet')
+        subject.install_puppet
+      end
+    end
+    context 'on fedora' do
+      let(:platform) { "fedora-18-x86_84" }
+      it 'installs' do
+        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-fedora-18\.noarch\.rpm/)
+        expect(subject).to receive(:on).with(hosts[0], 'yum install -y puppet')
+        subject.install_puppet
+      end
+    end
+    context 'on debian' do
+      let(:platform) { "debian-7-amd64" }
+      it 'installs' do
+        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-\$\(lsb_release -c -s\)\.deb/)
+        expect(subject).to receive(:on).with(hosts[0], 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get -y -f -m update')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get install -y puppet')
+        subject.install_puppet
+      end
+    end
+    context 'on ubuntu' do
+      let(:platform) { "ubuntu-12.04-amd64" }
+      it 'installs' do
+        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-\$\(lsb_release -c -s\)\.deb/)
+        expect(subject).to receive(:on).with(hosts[0], 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get -y -f -m update')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get install -y puppet')
+        subject.install_puppet
+      end
+    end
+    context 'on solaris' do
+      let(:platform) { 'solaris-11-x86_64' }
+      it 'raises an error' do
+        expect(subject).to_not receive(:on)
+        expect { subject.install_puppet }.to raise_error(/unsupported platform/)
+      end
+    end
+  end
+
   describe 'install_pe' do
 
     it 'calls do_install with sorted hosts' do


### PR DESCRIPTION
This commit adds an `install_puppet` DSL method that may be used to
simply add the public Puppet Labs repositories and install puppet.
