### PR TITLE
Add HTTPS support to the link_exists? method

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -160,9 +160,12 @@ module Beaker
       # @api private
       def link_exists?(link)
         require "net/http"
+        require "net/https"
         require "open-uri"
         url = URI.parse(link)
-        Net::HTTP.start(url.host, url.port) do |http|
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = (url.scheme == 'https')
+        http.start do |http|
           return http.head(url.request_uri).code == "200"
         end
       end


### PR DESCRIPTION
Beaker bombed out when trying to install PE from a tarball over HTTPS.  It appeared the only reason it was failing was the link_exists? method wasn't supporting HTTPS.  This PR adds HTTPS to link_exists? in Beaker::DSL::InstallUtils.
