### PR TITLE
(QA-747) Log the amount of time each command takes to execute

### DIFF
--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -112,6 +112,14 @@ module Beaker
       it 'receives a result object from the connection#execute'
       it "returns the result object"
 
+      it 'logs the amount of time spent executing the command' do
+        result.exit_code = 0
+
+        expect(host.logger).to receive(:debug).with(/host executed in \d\.\d{2} seconds/)
+
+        host.exec(command,{})
+      end
+
       context "controls the result objects logging" do
         it "and passes a test if the exit_code doesn't match the default :acceptable_exit_codes of 0" do
           result.exit_code = 0


### PR DESCRIPTION
Previously, there was no way to tell how long each beaker command took
to execute on a remote VM. I would like to know this information to
track down a timing issue in acceptance testing on Windows.

This commit modifies the host object to log timing information when
beaker is run in debug mode. It uses the same logging prefix as is used
when displaying the executed command, e.g.

```
a4e5hyo2m0ooom1 (master) $  cp /etc/puppet/puppet.conf ...
a4e5hyo2m0ooom1 (master) executed in 0.01 seconds
```
