### PR TITLE
(QA-753) Make sure to still support saving MSIs locally

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -223,13 +223,17 @@ module Beaker
             end
             gunzip = ""
             untar = ""
+            save_locally = ""
             if extension =~ /gz/
               gunzip = "| gunzip"
             end
             if extension =~ /tar/
               untar = "| tar -xvf -"
             end
-            on host, "cd #{host['working_dir']}; curl #{path}/#{filename}#{extension} #{gunzip} #{untar}"
+            if extension =~ /msi/
+              save_locally = "-O"
+            end
+            on host, "cd #{host['working_dir']}; curl #{save_locally} #{path}/#{filename}#{extension} #{gunzip} #{untar}"
           end
         end
       end

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -166,7 +166,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar'
-      subject.should_receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl #{ path }/#{ filename }#{ extension }  | tar -xvf -" ).once
+      subject.should_receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl  #{ path }/#{ filename }#{ extension }  | tar -xvf -" ).once
       subject.fetch_puppet( [unixhost], {} )
     end
 
@@ -179,7 +179,7 @@ describe ClassMixedWithDSLInstallUtils do
       path = unixhost['pe_dir']
       filename = "#{ unixhost['dist'] }"
       extension = '.tar.gz'
-      subject.should_receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl #{ path }/#{ filename }#{ extension } | gunzip | tar -xvf -" ).once
+      subject.should_receive( :on ).with( unixhost, "cd #{ unixhost['working_dir'] }; curl  #{ path }/#{ filename }#{ extension } | gunzip | tar -xvf -" ).once
       subject.fetch_puppet( [unixhost], {} )
     end
      


### PR DESCRIPTION
The initial commit for QA-753 didn't account for the MSI case, which
still requires saving the .msi file locally. This adds a save_locally
option to the cURL command line, based on whether we're fetch an msi.
