### PR TITLE
Install the puppetmaster packages as well.

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -420,11 +420,11 @@ module Beaker
           if host['platform'] =~ /el-(5|6)/
             relver = $1
             on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-#{relver}.noarch.rpm"
-            on host, 'yum install -y puppet'
+            on host, 'yum install -y puppet puppet-server'
           elsif host['platform'] =~ /fedora-(\d+)/
             relver = $1
             on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-fedora-#{relver}.noarch.rpm"
-            on host, 'yum install -y puppet'
+            on host, 'yum install -y puppet-server'
           elsif host['platform'] =~ /(ubuntu|debian)/
             if ! host.check_for_package 'curl'
               on host, 'apt-get install -y curl'
@@ -432,7 +432,7 @@ module Beaker
             on host, 'curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -c -s).deb'
             on host, 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb'
             on host, 'apt-get -y -f -m update'
-            on host, 'apt-get install -y puppet'
+            on host, 'apt-get install -y puppet puppetmaster'
           else
             raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"
           end


### PR DESCRIPTION
This was done primarily to make testing Puppetdb easier, but I figure it
should be harmless to do, it can be useful to have the master available
for generating certs and so forth.
