### PR TITLE
(QA-777) Allow beaker to deploy a split PE on version 3.2

### DIFF
--- a/lib/beaker/answers/version32.rb
+++ b/lib/beaker/answers/version32.rb
@@ -13,6 +13,14 @@ module Beaker
           the_answers[dashboard.name][:q_puppetmaster_certname] = master_certname
         end
 
+        if options[:type] == :upgrade && dashboard != database
+          # In a split configuration, there is no way for the upgrader
+          # to know how much disk space is available for the database
+          # migration. We tell it to continue on, because we're
+          # awesome.
+          the_answers[dashboard.name][:q_upgrade_with_unknown_disk_space] = 'y'
+        end
+
         return the_answers
       end
     end


### PR DESCRIPTION
3.2 includes a large database schema change. Part of the schema
migration is to validate availability of free space. On split
configurations, the dashboard upgrader will ask the user to make sure
there is sufficient space on the database node. We need to answer
"yes" to this from Beaker.
