### PR TITLE
(maint) Use explicit path to rake when running PE console rake tasks

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -244,8 +244,8 @@ module Beaker
       def deploy_frictionless_to_master(host)
         klass = host['platform'].gsub(/-/, '_').gsub(/\./,'')
         klass = "pe_repo::platform::#{klass}"
-        on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec rake nodeclass:add[#{klass},skip]"
-        on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec rake node:addclass[#{master},#{klass}]"
+        on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec /opt/puppet/bin/rake nodeclass:add[#{klass},skip]"
+        on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec /opt/puppet/bin/rake node:addclass[#{master},#{klass}]"
         on master, "puppet agent -t", :acceptable_exit_codes => [0,2]
       end
 


### PR DESCRIPTION
Bundler and/or rake gets confused when we aren't explicit.
