### PR TITLE
(maint) Re-Allow an array of hosts in apply_manifest_on

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -674,6 +674,13 @@ module Beaker
       #                      validation, etc.
       #
       def apply_manifest_on(host, manifest, opts = {}, &block)
+        if host.is_a?(Array)
+          host.each do |h|
+            apply_manifest_on(h, manifest, opts, &block)
+          end
+          return
+        end
+
         on_options = {}
         on_options[:acceptable_exit_codes] = Array(opts.delete(:acceptable_exit_codes))
         args = ["--verbose"]

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -309,6 +309,24 @@ describe ClassMixedWithDSLHelpers do
 
       subject.apply_manifest_on( agent, 'class { "boo": }')
     end
+
+    it 'accepts an array of hosts' do
+      the_hosts = [master, agent]
+
+      subject.should_receive( :create_remote_file ).twice.and_return( true )
+      the_hosts.each do |host|
+        subject.should_receive( :puppet ).
+          with( 'apply', '--verbose', host.to_s ).
+          and_return( 'puppet_command' )
+
+        subject.should_receive( :on ).
+          with( host, 'puppet_command',
+                :acceptable_exit_codes => [0] ).ordered
+      end
+
+      subject.apply_manifest_on( the_hosts, 'include foobar')
+    end
+
     it 'adds acceptable exit codes with :catch_failures' do
       subject.should_receive( :create_remote_file ).and_return( true )
       subject.should_receive( :puppet ).


### PR DESCRIPTION
Before it was refactored, apply_manifest_on allowed an array of
hosts. The Puppet acceptance tests rely on this behavior, so we need
to re-introduce it.
