### PR TITLE
(maint) Add new patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ coverage
 .bundle
 .vendor
 _vendor
-!tmp/README
-tmp/*
+tmp/
 doc
+# JetBrains IDEA
+*.iml
+.idea/
+# rbenv file
+.ruby-version
+# Vagrant folder
+.vagrant/
+.vagrant_files/


### PR DESCRIPTION
Added new patterns to gitignore for IDEA, rbenv, and vagrant files and
folders. The tmp directory patterns were reduced from two to one.
