### PR TITLE
(QA-805) Add timestamp to on(host) calls

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -158,7 +158,7 @@ module Beaker
       if options[:silent]
         output_callback = nil
       else
-        @logger.debug "\n#{log_prefix} $ #{cmdline}"
+        @logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{cmdline}"
         output_callback = logger.method(:host_output)
       end
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -115,7 +115,7 @@ module Beaker
       it 'logs the amount of time spent executing the command' do
         result.exit_code = 0
 
-        expect(host.logger).to receive(:debug).with(/host executed in \d\.\d{2} seconds/)
+        expect(host.logger).to receive(:debug).with(/executed in \d\.\d{2} seconds/)
 
         host.exec(command,{})
       end


### PR DESCRIPTION
Previously there was no timestamp, which makes it hard to correlate
beaker commands with logs on the SUT.

```
lw5bhs6m2zu4ysb (centos5-64-1) 14:21:44$  which curl
/usr/bin/curl

lw5bhs6m2zu4ysb (centos5-64-1) executed in 5.99 seconds
```
