### PR TITLE
Fix regexp for finding ip address for Fedora

### DIFF
--- a/lib/beaker/shared/host_handler.rb
+++ b/lib/beaker/shared/host_handler.rb
@@ -22,7 +22,7 @@ module Beaker
       end
 
       def get_ip(host)
-        host.exec(Command.new("ip a|awk '/g/{print$2}' | cut -d/ -f1 | head -1")).stdout.chomp
+        host.exec(Command.new("ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1")).stdout.chomp
       end
 
       def set_etc_hosts(host, etc_hosts)

--- a/lib/beaker/utils/setup_helper.rb
+++ b/lib/beaker/utils/setup_helper.rb
@@ -23,7 +23,7 @@ module Beaker
         if master['platform'].include? 'solaris'
           stdout = master.exec(Command.new("ifconfig -a inet| awk '/broadcast/ {print $2}' | cut -d/ -f1 | head -1")).stdout
         else
-          stdout = master.exec(Command.new("ip a|awk '/g/{print$2}' | cut -d/ -f1 | head -1")).stdout
+          stdout = master.exec(Command.new("ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1")).stdout
         end
         ip=stdout.chomp
 

--- a/spec/beaker/shared/host_handler_spec.rb
+++ b/spec/beaker/shared/host_handler_spec.rb
@@ -36,7 +36,7 @@ module Beaker
         it "can exec the get_ip command" do
           host = make_host('name', { :stdout => "192.168.2.130\n" } )
 
-          Command.should_receive( :new ).with( "ip a|awk '/g/{print$2}' | cut -d/ -f1 | head -1" ).once
+          Command.should_receive( :new ).with( "ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1" ).once
 
           expect( host_handler.get_ip( host ) ).to be === "192.168.2.130"
 

--- a/spec/beaker/utils/setup_helper_spec.rb
+++ b/spec/beaker/utils/setup_helper_spec.rb
@@ -20,7 +20,7 @@ module Beaker
           path = Beaker::Utils::SetupHelper::ETC_HOSTS_PATH
           master = setup_helper.only_host_with_role(hosts, :master)
 
-          Command.should_receive( :new ).with( "ip a|awk '/g/{print$2}' | cut -d/ -f1 | head -1" ).once
+          Command.should_receive( :new ).with( "ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1" ).once
           Command.should_receive( :new ).with( "cp %s %s.old" % [path, path] ).once
           Command.should_receive( :new ).with( "cp %s %s.new" % [path, path] ).once
           Command.should_receive( :new ).with( "grep -v '#{ip} #{master}' %s > %s.new" % [path, path] ).once


### PR DESCRIPTION
The previous command for finding the IP address of a host:

```
ip a | awk '/g/{print$2}'
```

Picks up all kinds of stray entries, on Amazon Linux for example:

```
# ip a | awk '/g/{print$2}'
109.74.196.121/24
2a01:7e00::f03c:91ff:fe96:e1e4/64
gre0:
0.0.0.0
gretap0:
ip6gre0:
```

On a Fedora 20 box hosted in EC2:

```
# ip a|awk '/g/{print$2}'
lo:
eth0:
10.232.140.48/26
```

This is because its just looking for the letter 'g' which is not accurate
enough. Some interface lines have the word 'group' for example.

Changing this to the actual word 'global' seems to solve it:

```
# ip a | awk '/global/{print$2}'
109.74.196.121/24
```

This has been tested to work on:
- Debian 6/7
- Fedora 18, 20
- Amazon Linux
- Redhat 5/6

So I believe the behaviour should still be consistent after this change.

Signed-off-by: Ken Barber ken@bob.sh
