### PR TITLE
add safe_popen3 to Beaker::Hypervisor::Vagrant

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -65,7 +65,7 @@ module Beaker
     def set_ssh_config host, user
         f = Tempfile.new("#{host.name}")
         ssh_config = Dir.chdir(@vagrant_path) do
-          stdin, stdout, stderr, wait_thr = Open3.popen3('vagrant', 'ssh-config', host.name)
+          stdin, stdout, stderr, wait_thr = safe_popen3('vagrant', 'ssh-config', host.name)
           if not wait_thr.value.success?
             raise "Failed to 'vagrant ssh-config' for #{host.name}"
           end
@@ -156,7 +156,7 @@ module Beaker
     def vagrant_cmd(args)
       Dir.chdir(@vagrant_path) do
         exit_status = 1
-        Open3.popen3("vagrant #{args}") {|stdin, stdout, stderr, wait_thr|
+        safe_popen3("vagrant #{args}") {|stdin, stdout, stderr, wait_thr|
           while line = stdout.gets
             @logger.debug(line)
           end
@@ -168,6 +168,16 @@ module Beaker
         if exit_status != 0
           raise "Failed to execute vagrant_cmd ( #{args} )"
         end
+      end
+    end
+
+    private
+
+    def safe_popen3(*args, &block)
+      if defined?(Bundler)
+        Bundler.with_clean_env { Open3.popen3(*args, &block) }
+      else
+        Open3.popen3(*args, &block)
       end
     end
 


### PR DESCRIPTION
When running beaker under bundler the environment setup leaks out into sub
shells.  This is specifically a problem for Vagrant on Gentoo which is not a
vendored install. The safe_popen3 method is a wrapper around Open3.popen3 that
detects if beaker is running and cleans up the environment as necessary.
