### PR TITLE
[maint] Do not modify the options hash in apply_manifest_on

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -681,7 +681,8 @@ module Beaker
         end
 
         on_options = {}
-        on_options[:acceptable_exit_codes] = Array(opts.delete(:acceptable_exit_codes))
+        on_options[:acceptable_exit_codes] = Array(opts[:acceptable_exit_codes])
+
         args = ["--verbose"]
         args << "--parseonly" if opts[:parseonly]
         args << "--trace" if opts[:trace]

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -321,10 +321,10 @@ describe ClassMixedWithDSLHelpers do
 
         subject.should_receive( :on ).
           with( host, 'puppet_command',
-                :acceptable_exit_codes => [0] ).ordered
+                :acceptable_exit_codes => [0, 1] ).ordered
       end
 
-      result = subject.apply_manifest_on( the_hosts, 'include foobar')
+      result = subject.apply_manifest_on( the_hosts, 'include foobar', :acceptable_exit_codes => [0,1] )
       result.should(be_an(Array))
     end
 


### PR DESCRIPTION
1) This is just poor behavior
2) When an array of hosts is passed, apply_manifest_on is run more
than once. In this situation, the first one modifies the options hash
and ruins it for all its friends
