### PR TITLE
(QA-806) have a means to dump env without running beaker test

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -15,16 +15,23 @@ module Beaker
       @options = @options_parser.parse_args
       @logger = Beaker::Logger.new(@options)
       @options[:logger] = @logger
+      @execute = true
 
       if @options[:help]
         @logger.notify(@options_parser.usage)
-        exit
+        @execute = false
+        return
       end
       if @options[:version]
         @logger.notify(VERSION_STRING % Beaker::Version::STRING)
-        exit
+        @execute = false
+        return
       end
       @logger.info(@options.dump)
+      if @options[:parse_only]
+        @execute = false
+        return
+      end
 
       #add additional paths to the LOAD_PATH
       if not @options[:load_path].empty?
@@ -81,6 +88,9 @@ module Beaker
 
     def execute!
 
+      if !@execute
+        return
+      end
       begin
         trap(:INT) do
           @logger.warn "Interrupt received; exiting..."

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -135,11 +135,6 @@ module Beaker
             @cmd_options[:log_level] = val
           end
 
-          opts.on '--[no-]debug',
-                  'DEPRECATED, use --log-level' do |bool|
-            @cmd_options[:log_level] =  bool ? 'debug' : 'info'
-          end
-
           opts.on  '-d', '--[no-]dry-run',
                    'Report what would happen on targets',
                    '(default: false)' do |bool|
@@ -179,14 +174,24 @@ module Beaker
             @cmd_options[:version] = true
           end
 
-          opts.on '-c', '--config FILE',
-                  'DEPRECATED use --hosts' do |file|
-            @cmd_options[:hosts_file] = file
+          opts.on('--parse-only', 'Display beaker parsed options and exit' ) do 
+            @cmd_options[:parse_only] = true
           end
 
           opts.on('--help', 'Display this screen' ) do 
             @cmd_options[:help] = true
           end
+
+          opts.on '-c', '--config FILE',
+                  'DEPRECATED, use --hosts' do |file|
+            @cmd_options[:hosts_file] = file
+          end
+
+          opts.on '--[no-]debug',
+                  'DEPRECATED, use --log-level' do |bool|
+            @cmd_options[:log_level] =  bool ? 'debug' : 'info'
+          end
+
         end
 
       end


### PR DESCRIPTION
- add --parse-only option to dump options and exit, useful for testing
