### PR TITLE
(QA-841) Windows complains about colons in dir names

### DIFF
--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -247,7 +247,7 @@ module Beaker
     end
 
     def log_path(name)
-      @@log_dir ||= File.join("log", @start_time.strftime("%F_%T"))
+      @@log_dir ||= File.join("log", @start_time.strftime("%F_%H_%M_%S"))
       unless File.directory?(@@log_dir) then
         FileUtils.mkdir_p(@@log_dir)
 


### PR DESCRIPTION
Creating a directory with colons (':') in the name will fail on Windows
and prevent beaker from executing tests. This change moves from calling
%T to using %H_%M_%S for time-based directory names.
