### PR TITLE
Add pe_ver ENV variable so we can control it outside the config files.

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -8,7 +8,7 @@ module Beaker
       # 
       # Currently supports:
       #
-      #   consoleport, IS_PE, pe_dist_dir, pe_version_file, pe_version_file_win
+      #   consoleport, IS_PE, pe_dist_dir, pe_version_file, pe_version_file_win, pe_ver
       #
       # @return [OptionsHash] The supported environment variables in an OptionsHash,
       #                       empty or nil environment variables are removed from the OptionsHash
@@ -20,6 +20,7 @@ module Beaker
           :pe_dir => ENV['pe_dist_dir'],
           :pe_version_file => ENV['pe_version_file'],
           :pe_version_file_win => ENV['pe_version_file'],
+          :pe_ver => ENV['pe_ver']
         }.delete_if {|key, value| value.nil? or value.empty? })
       end
 


### PR DESCRIPTION
This can be handy when you want to test against different PE versions in jenkins for example.
