### PR TITLE
(maint) Don't munge the user's opts hash in `on`

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -70,7 +70,10 @@ module Beaker
       # @raise  [FailTest] Raises an exception if *command* obviously fails.
       def on(host, command, opts = {}, &block)
         unless command.is_a? Command
-          cmd_opts = opts[:environment] ? { 'ENV' => opts.delete(:environment) } : Hash.new
+          cmd_opts = {}
+          if opts[:environment]
+            cmd_opts['ENV'] = opts[:environment]
+          end
           command = Command.new(command.to_s, [], cmd_opts)
         end
         if host.is_a? String or host.is_a? Symbol


### PR DESCRIPTION
Previously, if the user specified `:environment` in the opts to `on`
(or to a higher-level method that passes on opts to `on`), `on` would
delete that key when it was called. This not only makes it impossible
to call `on` sanely in a loop, but is generally a pretty shitty thing
to do to our users' data.

This changes the code to not modify the hash.
