### PR TITLE
(maint) Wrap windows PE installation in `cmd /C`

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -144,7 +144,7 @@ module Beaker
         version = options[:pe_ver] || host['pe_ver']
         if host['platform'] =~ /windows/
           version = options[:pe_ver_win] || host['pe_ver']
-          "cd #{host['working_dir']} && cmd /C 'msiexec.exe /qn /i puppet-enterprise-#{version}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'"
+          "cd #{host['working_dir']} && cmd /C 'start /w msiexec.exe /qn /i puppet-enterprise-#{version}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'"
         # Frictionless install didn't exist pre-3.2.0, so in that case we fall
         # through and do a regular install.
         elsif host['roles'].include? 'frictionless' and ! version_is_less(version, '3.2.0')

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -127,7 +127,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'generates a windows PE install command for a windows host' do
       subject.stub( :hosts ).and_return( [ hosts[1], hosts[0], hosts[2], winhost ] )
-      expect( subject.installer_cmd( winhost, {} ) ).to be === "cd /tmp && cmd /C 'msiexec.exe /qn /i puppet-enterprise-3.0.msi PUPPET_MASTER_SERVER=vm1 PUPPET_AGENT_CERTNAME=winhost'"
+      expect( subject.installer_cmd( winhost, {} ) ).to be === "cd /tmp && cmd /C 'start /w msiexec.exe /qn /i puppet-enterprise-3.0.msi PUPPET_MASTER_SERVER=vm1 PUPPET_AGENT_CERTNAME=winhost'"
     end
 
     it 'generates a unix PE install command for a unix host' do


### PR DESCRIPTION
When cygwin converts the posix-style commandline that bash provides to
a windows-style one for calling msiexec, it adds quotes around some
arguments. These quotes cause msiexec to fail. By wrapping the msiexec
invocation in `cmd /C`, we use the windows command interpreter to
handle the command line instead of bash/cygwin. This avoids the
translation issues introduced by cygwin.
