### PR TITLE
Add default 'puppetservice' name for Unix hosts.

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -472,8 +472,8 @@ module Beaker
           backup_file = backup_the_file(host, host['puppetpath'], testdir, 'puppet.conf')
           lay_down_new_puppet_conf host, conf_opts, testdir
 
-          if host.is_pe?
-            bounce_service( host, 'pe-httpd' )
+          if host.is_pe? || host['puppetservice']
+            bounce_service( host, host['puppetservice'] )
           else
             puppet_master_started = start_puppet_from_source_on!( host, cmdline_args )
           end
@@ -488,8 +488,8 @@ module Beaker
           begin
             restore_puppet_conf_from_backup( host, backup_file )
 
-            if host.is_pe?
-              bounce_service( host, 'pe-httpd' )
+            if host.is_pe? || host['puppetservice']
+              bounce_service( host, host['puppetservice'] )
             else
               if puppet_master_started
                 stop_puppet_from_source_on( host )

--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -22,6 +22,7 @@ module Unix
       h.merge({
         'user'          => 'root',
         'group'         => 'pe-puppet',
+        'puppetservice' => 'pe-httpd',
         'puppetpath'    => '/etc/puppetlabs/puppet',
         'puppetbin'     => '/opt/puppet/bin/puppet',
         'puppetbindir'  => '/opt/puppet/bin',
@@ -39,6 +40,7 @@ module Unix
       h.merge({
         'user'              => 'root',
         'group'             => 'puppet',
+        'puppetservice'     => '',
         'puppetpath'        => '/etc/puppet',
         'puppetvardir'      => '/var/lib/puppet',
         'puppetbin'         => '/usr/bin/puppet',


### PR DESCRIPTION
Instead of hard-coding 'pe-httpd' and then only "bounce_service"ing if the
Beaker type is 'pe', add fall-through case if 'puppetservice' key is
defined/nonempty on the host.

Signed-off-by: Wayne wayne@puppetlabs.com
