### PR TITLE
(QENG-409) Beaker does not write out JUnit XML when...

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -131,13 +131,13 @@ module Beaker
               @test_status = :pending
             rescue SkipTest
               @test_status = :skip
-            rescue StandardError, ScriptError => e
+            rescue StandardError, ScriptError, SignalException => e
               log_and_fail_test(e)
             ensure
               @teardown_procs.each do |teardown|
                 begin
                   teardown.call
-                rescue StandardError => e
+                rescue StandardError, SignalException => e
                   log_and_fail_test(e)
                 end
               end

--- a/spec/beaker/test_case_spec.rb
+++ b/spec/beaker/test_case_spec.rb
@@ -1,6 +1,90 @@
 require 'spec_helper'
 
 module Beaker
-  describe TestCase do
+  describe TestCase, :use_fakefs => true do
+    let(:logger) {  double('logger').as_null_object }
+    let(:path) { @path || '/tmp/nope' }
+    let(:testcase) { TestCase.new({}, logger, {}, path) }
+
+    context 'run_test' do
+      it 'defaults to test_status :pass on success' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write ""
+        end
+        @path = path
+        testcase.should_not_receive( :log_and_fail_test )
+        testcase.run_test
+        status = testcase.instance_variable_get(:@test_status)
+        expect(status).to be === :pass
+      end
+
+      it 'updates test_status to :skip on SkipTest' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise SkipTest"
+        end
+        @path = path
+        testcase.should_not_receive( :log_and_fail_test )
+        testcase.run_test
+        status = testcase.instance_variable_get(:@test_status)
+        expect(status).to be === :skip
+      end
+
+      it 'updates test_status to :pending on PendingTest' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise PendingTest"
+        end
+        @path = path
+        testcase.should_not_receive( :log_and_fail_test )
+        testcase.run_test
+        status = testcase.instance_variable_get(:@test_status)
+        expect(status).to be === :pending
+      end
+
+      it 'updates test_status to :fail on FailTest' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise FailTest"
+        end
+        @path = path
+        testcase.should_not_receive( :log_and_fail_test )
+        testcase.run_test
+        status = testcase.instance_variable_get(:@test_status)
+        expect(status).to be === :fail
+      end
+
+      it 'correctly handles RuntimeError' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise RuntimeError"
+        end
+        @path = path
+        testcase.should_receive( :log_and_fail_test ).once.with(kind_of(RuntimeError))
+        testcase.run_test
+      end
+
+      it 'correctly handles ScriptError' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise ScriptError"
+        end
+        @path = path
+        testcase.should_receive( :log_and_fail_test ).once.with(kind_of(ScriptError))
+        testcase.run_test
+      end
+
+      it 'correctly handles Timeout::Error' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise Timeout::Error"
+        end
+        @path = path
+        testcase.should_receive( :log_and_fail_test ).once.with(kind_of(Timeout::Error))
+        testcase.run_test
+      end
+    end
+
   end
 end


### PR DESCRIPTION
...certain internal exceptions occur
- on ruby 1.8 Timeouts are raised as Interrupt (parented by SignalException)
  instead of out of RuntimeError (which is parented by StandardError) and are
  thus not being caught appropraitely.
- added spec test coverage for correct error reporting
