### PR TITLE
(maint) create host.hostname procedure

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Testing dependencies
+  s.add_development_dependency 'minitest', '~> 4.0'
   s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'fakefs', '0.4'
   s.add_development_dependency 'rake', '~> 10.1.0'

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -92,8 +92,9 @@ module Beaker
       end
     end
 
+    # Return the preferred method to reach the host, will use IP is available and then default to {#hostname}.
     def reachable_name
-      self['ip'] || self['vmhostname'] || name
+      self['ip'] || hostname
     end
 
     # Returning our PuppetConfigReader here allows users of the Host
@@ -116,11 +117,19 @@ module Beaker
       @defaults.has_key?(k)
     end
 
+    # The {#hostname} of this host.
     def to_str
-      @defaults['vmhostname'] || @name
+      hostname
     end
 
+    # The {#hostname} of this host.
     def to_s
+      hostname
+    end
+
+    # Return the public name of the particular host, which may be different then the name of the host provided in
+    # the configuration file as some provisioners create random, unique hostnames.
+    def hostname
       @defaults['vmhostname'] || @name
     end
 


### PR DESCRIPTION
- convenience method for accessing the hostname of the given host
