### PR TITLE
Add future parser as option when applying a manifest

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -690,6 +690,11 @@ module Beaker
       #                         if `puppet --apply` indicates there were no
       #                         failure during its execution.
       #
+      # @option opts [Boolean]  :future_parser (false) This option enables
+      #                         the future parser option that is available 
+      #                         from Puppet verion 3.2
+      #                         By default it will use the 'current' parser.
+      #
       # @param [Block] block This method will yield to a block of code passed
       #                      by the caller; this can be used for additional
       #                      validation, etc.

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -447,6 +447,26 @@ describe ClassMixedWithDSLHelpers do
         :expect_failures       => true
       )
     end
+
+    it 'can set the --parser future flag' do
+      subject.should_receive( :create_remote_file ).and_return( true )
+      subject.should_receive( :puppet ).
+        with( 'apply', '--verbose', '--parser future', '--detailed-exitcodes', 'agent' ).
+        and_return( 'puppet_command' )
+      subject.should_receive( :on ).with(
+        agent,
+        'puppet_command',
+        :acceptable_exit_codes => [1,2,3,4,5,6]
+      )
+
+      subject.apply_manifest_on(
+        agent,
+        'class { "boo": }',
+        :acceptable_exit_codes => (1..5),
+        :future_parser         => true,
+        :expect_failures       => true
+      )
+    end
   end
 
   describe "#apply_manifest" do


### PR DESCRIPTION
This option can enable the use of the future parser when applying a manifest.
I'm not 100% sure though what it will do on older puppet versions that don't support that option.
