### PR TITLE
(QENG-486) add easy access to ip address per beaker host

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -149,6 +149,16 @@ module Beaker
       end
     end
 
+    #Determine the ip address of this host
+    def get_ip
+      @logger.warn("Uh oh, this should be handled by sub-classes but hasn't been")
+    end
+
+    #Return the ip address of this host
+    def ip
+      self[:ip] ||= get_ip
+    end
+
     def connection
       @connection ||= SshConnection.connect( reachable_name,
                                              self['user'],

--- a/lib/beaker/host/aix/exec.rb
+++ b/lib/beaker/host/aix/exec.rb
@@ -1,0 +1,7 @@
+module Aix::Exec
+  include Beaker::CommandFactory
+
+  def get_ip
+    execute("ifconfig -a inet| awk '/broadcast/ {print $2}' | cut -d/ -f1 | head -1").strip
+  end
+end

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -12,4 +12,12 @@ module Unix::Exec
   def path
     '/bin:/usr/bin'
   end
+
+  def get_ip
+    if self['platform'].include? 'solaris'
+      execute("ifconfig -a inet| awk '/broadcast/ {print $2}' | cut -d/ -f1 | head -1").strip
+    else
+      execute("ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1").strip
+    end
+  end
 end

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -15,4 +15,15 @@ module Windows::Exec
   def path
     'c:/windows/system32;c:/windows'
   end
+
+  def get_ip
+    ip = execute("ipconfig | grep -i 'IP Address' | cut -d: -f2 | head -1").strip
+    if ip == ''
+      ip = execute("ipconfig | grep -i 'IPv4 Address' | cut -d: -f2 | head -1").strip
+    end
+    if ip == ''
+      ip = execute("ipconfig | grep -i 'IPv6 Address' | cut -d: -f2 | head -1").strip
+    end
+    ip
+  end
 end

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -302,8 +302,9 @@ module Beaker
 
     #Determine the ip address of the provided host 
     # @param [Host] host the host to act upon
+    # @deprecated use {Host#get_ip}
     def get_ip(host)
-      host.exec(Command.new("ip a|awk '/global/{print$2}' | cut -d/ -f1 | head -1")).stdout.chomp
+      host.get_ip
     end
 
     #Append the provided string to the /etc/hosts file of the provided host


### PR DESCRIPTION
- either use the already determined ip address or figure it out through
  ifconfig/ipconfig
