### PR TITLE
(maint) Remove unneeded options for 'apt-get update'

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -454,7 +454,7 @@ module Beaker
             end
             on host, 'curl -O http://apt.puppetlabs.com/puppetlabs-release-$(lsb_release -c -s).deb'
             on host, 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb'
-            on host, 'apt-get -y -f -m update'
+            on host, 'apt-get update'
             on host, 'apt-get install -y puppet'
           else
             raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -199,7 +199,7 @@ module Beaker
         host.map { |h| apt_get_update(h) }
       else
         if host[:platform] =~ /(ubuntu)|(debian)/ 
-          host.exec(Command.new("apt-get -y -f -m update"))
+          host.exec(Command.new("apt-get update"))
         end
       end
     end

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -299,7 +299,7 @@ describe ClassMixedWithDSLInstallUtils do
       it 'installs' do
         expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-\$\(lsb_release -c -s\)\.deb/)
         expect(subject).to receive(:on).with(hosts[0], 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb')
-        expect(subject).to receive(:on).with(hosts[0], 'apt-get -y -f -m update')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get update')
         expect(subject).to receive(:on).with(hosts[0], 'apt-get install -y puppet')
         subject.install_puppet
       end
@@ -309,7 +309,7 @@ describe ClassMixedWithDSLInstallUtils do
       it 'installs' do
         expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-\$\(lsb_release -c -s\)\.deb/)
         expect(subject).to receive(:on).with(hosts[0], 'dpkg -i puppetlabs-release-$(lsb_release -c -s).deb')
-        expect(subject).to receive(:on).with(hosts[0], 'apt-get -y -f -m update')
+        expect(subject).to receive(:on).with(hosts[0], 'apt-get update')
         expect(subject).to receive(:on).with(hosts[0], 'apt-get install -y puppet')
         subject.install_puppet
       end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -111,7 +111,7 @@ describe Beaker do
     it "can perform apt-get on ubuntu hosts" do
       host = make_host( 'testhost', { :platform => 'ubuntu' } )
 
-      Beaker::Command.should_receive( :new ).with("apt-get -y -f -m update").once
+      Beaker::Command.should_receive( :new ).with("apt-get update").once
 
       subject.apt_get_update( host )
 
@@ -120,7 +120,7 @@ describe Beaker do
     it "can perform apt-get on debian hosts" do
       host = make_host( 'testhost', { :platform => 'debian' } )
 
-      Beaker::Command.should_receive( :new ).with("apt-get -y -f -m update").once
+      Beaker::Command.should_receive( :new ).with("apt-get update").once
 
       subject.apt_get_update( host )
 


### PR DESCRIPTION
Previously apt-get update was invoked with the -y -f -m
options. None of these options actually make sense for _update_
(though -y makes total sense for _install_). Starting with
trusty's apt-get, apt-get actually rejects (at least) -f for
apt-get install.

So this patch simply removes those unneeded options.
