### PR TITLE
(QENG-597) 'master' DSL helper can return a non-master node...

### DIFF
--- a/lib/beaker/dsl/roles.rb
+++ b/lib/beaker/dsl/roles.rb
@@ -42,11 +42,7 @@ module Beaker
       #     on, master, 'cat /etc/puppet/puppet.conf'
       #
       def master
-        begin
-          find_only_one :master
-        rescue DSL::Outcomes::FailTest => e
-          default
-        end
+        find_only_one :master
       end
 
       # The host for which ['roles'] include 'database'
@@ -89,15 +85,7 @@ module Beaker
       #     on, default, "curl https://#{database}/nodes/#{agent}"
       #
       def default
-        if hosts.length == 1
-          return hosts[0]
-        elsif any_hosts_as? :default
-          return find_only_one :default
-        elsif any_hosts_as? :master
-          return find_only_one :master
-        else
-          raise DSL::Outcomes::FailTest, "no default host specified"
-        end
+        find_only_one :default
       end
 
       # Determine if there is a host or hosts with the given role defined

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -16,7 +16,7 @@ describe ClassMixedWithDSLHelpers do
   let( :host ) { double.as_null_object }
   let( :result ) { Beaker::Result.new( host, command ) }
 
-  let( :master ) { make_host( 'master',   :roles => %w( master agent )    ) }
+  let( :master ) { make_host( 'master',   :roles => %w( master agent default)    ) }
   let( :agent )  { make_host( 'agent',    :roles => %w( agent )           ) }
   let( :custom ) { make_host( 'custom',   :roles => %w( custom agent )    ) }
   let( :dash )   { make_host( 'console',  :roles => %w( dashboard agent ) ) }

--- a/spec/beaker/dsl/roles_spec.rb
+++ b/spec/beaker/dsl/roles_spec.rb
@@ -39,18 +39,8 @@ describe ClassMixedWithDSLRoles do
     end
     it 'raises an error if there is more than one master' do
       @hosts = [ master, monolith ]
-      subject.should_receive( :hosts ).exactly( 5 ).times.and_return( hosts )
+      subject.should_receive( :hosts ).exactly( 1 ).times.and_return( hosts )
       expect { subject.master }.to raise_error Beaker::DSL::FailTest
-    end
-    it 'and raises an error if there is no master and no default' do
-      @hosts = [ agent1, agent2, custom ]
-      subject.should_receive( :hosts ).exactly( 4 ).times.and_return( hosts )
-      expect { subject.master }.to raise_error Beaker::DSL::FailTest
-    end
-    it 'returns the default when there is no master' do
-      @hosts = [ agent1 ]
-      subject.should_receive( :hosts ).exactly( 3 ).times.and_return( hosts )
-      expect( subject.master ).to be == agent1 
     end
   end
   describe '#dashboard' do
@@ -90,23 +80,18 @@ describe ClassMixedWithDSLRoles do
   describe '#default' do
     it 'returns the default host when one is specified' do
       @hosts = [ db, agent1, agent2, default, master]
-      subject.should_receive( :hosts ).exactly( 3 ).times.and_return( hosts )
+      subject.should_receive( :hosts ).exactly( 1  ).times.and_return( hosts )
       expect( subject.default ).to be == default
     end
-    it 'returns the master if no default host is set' do
-      @hosts = [ db, agent1, agent2, master]
-      subject.should_receive( :hosts ).exactly( 4 ).times.and_return( hosts )
-      expect( subject.default ).to be == master
+    it 'raises an error if there is more than one default' do
+      @hosts = [ db, monolith, default, default ]
+      subject.should_receive( :hosts ).and_return( hosts )
+      expect { subject.database }.to raise_error Beaker::DSL::FailTest
     end
-    it 'returns the only host when only a single host is defined' do
-      @hosts = [ agent1 ]
-      subject.should_receive( :hosts ).exactly( 2 ).times.and_return( hosts )
-      expect( subject.default ).to be == agent1
-    end
-    it 'raises an error when there is no default (no default, no master, no single host)'  do
-      @hosts = [ agent1, agent2 ]
-      subject.should_receive( :hosts ).exactly( 3 ).times.and_return( hosts )
-      expect{ subject.default }.to raise_error Beaker::DSL::FailTest
+    it 'and raises an error if there is no default' do
+      @hosts = [ agent1, agent2, custom ]
+      subject.should_receive( :hosts ).and_return( hosts )
+      expect { subject.database }.to raise_error Beaker::DSL::FailTest
     end
   end
 end


### PR DESCRIPTION
...when actual master is confined away
- change around the logic so that the default node is defined at options
  parsing, not during test runtime
- determine the default node by it either being
  1.  the node with the role defined  as 'default'
  2.  the master node
  3.  the only node
     Then add the role 'default' to that node, if necessary
- differentiate between master and default, no longer allow the default
  to be used as a master if the master is undefined (keep roles clear,
  the master should only be the node defined as master)
