### PR TITLE
(QENG-600) Install lsb-release package if needed

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -450,7 +450,7 @@ module Beaker
             on host, 'yum install -y puppet'
           elsif host['platform'] =~ /(ubuntu|debian)/
             if ! host.check_for_package 'lsb-release'
-              on host, 'apt-get install -y lsb-release'
+              host.install_package('lsb-release')
             end
             if ! host.check_for_package 'curl'
               on host, 'apt-get install -y curl'


### PR DESCRIPTION
For Debian and Ubuntu systems, check if lsb-release package is
installed. Install if needed. This package is needed to correctly
determine the release packages of puppet to install on the SUT.
This package is not present on a minimal Debian 7 installation.
