### PR TITLE
(QENG-608) Check_for_package method should not use which command

### DIFF
--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -1,8 +1,13 @@
 module Windows::Pkg
   include Beaker::CommandFactory
 
-  def check_for_package(name)
+  def check_for_command(name)
     result = exec(Beaker::Command.new("which #{name}"), :acceptable_exit_codes => (0...127))
+    result.exit_code == 0
+  end
+
+  def check_for_package(name)
+    result = exec(Beaker::Command.new("cygcheck #{name}"), :acceptable_exit_codes => (0...127))
     result.exit_code == 0
   end
 
@@ -20,7 +25,7 @@ module Windows::Pkg
       cygwin = "setup-x86.exe"
     end
 
-    if not check_for_package(cygwin)
+    if not check_for_command(cygwin)
       execute("curl --retry 5 http://cygwin.com/#{cygwin} -o /cygdrive/c/Windows/System32/#{cygwin}")
     end
     execute("#{cygwin} -q -n -N -d -R #{cmdline_args} #{rootdir} -s http://cygwin.osuosl.org -P #{name}")

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+module Beaker
+  describe Unix::Pkg do
+    class UnixPkgTest
+      include Unix::Pkg
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { UnixPkgTest.new(opts, logger) }
+
+    context "check_for_package" do
+
+      it "runs the correctly on sles" do
+        @opts = {'platform' => 'sles-is-me'}
+        pkg = 'sles_package'
+        Beaker::Command.should_receive(:new).with("zypper se -i --match-exact #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+ 
+      it "runs the correctly on fedora" do
+        @opts = {'platform' => 'fedora-is-me'}
+        pkg = 'fedora_package'
+        Beaker::Command.should_receive(:new).with("rpm -q #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on centos" do
+        @opts = {'platform' => 'centos-is-me'}
+        pkg = 'centos_package'
+        Beaker::Command.should_receive(:new).with("rpm -q #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on el-" do
+        @opts = {'platform' => 'el-is-me'}
+        pkg = 'el_package'
+        Beaker::Command.should_receive(:new).with("rpm -q #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on debian" do
+        @opts = {'platform' => 'debian-is-me'}
+        pkg = 'debian_package'
+        Beaker::Command.should_receive(:new).with("dpkg -s #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on ubuntu" do
+        @opts = {'platform' => 'ubuntu-is-me'}
+        pkg = 'ubuntu_package'
+        Beaker::Command.should_receive(:new).with("dpkg -s #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on solaris-11" do
+        @opts = {'platform' => 'solaris-11-is-me'}
+        pkg = 'solaris-11_package'
+        Beaker::Command.should_receive(:new).with("pkg info #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "runs the correctly on solaris-10" do
+        @opts = {'platform' => 'solaris-10-is-me'}
+        pkg = 'solaris-10_package'
+        Beaker::Command.should_receive(:new).with("pkginfo #{pkg}").and_return('')
+        instance.should_receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.check_for_package(pkg) ).to be === true
+      end
+
+      it "returns false for el-4" do
+        @opts = {'platform' => 'el-4-is-me'}
+        pkg = 'el-4_package'
+        expect( instance.check_for_package(pkg) ).to be === false
+      end
+
+      it "raises on unknown platform" do
+        @opts = {'platform' => 'nope-is-me'}
+        pkg = 'nope_package'
+        expect{ instance.check_for_package(pkg) }.to raise_error
+
+      end
+       
+     end
+ 
+   end
+ end
+ 

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -6,7 +6,7 @@ describe Beaker do
   let( :apt_cfg )        { Beaker::HostPrebuiltSteps::APT_CFG }
   let( :ips_pkg_repo )   { Beaker::HostPrebuiltSteps::IPS_PKG_REPO }
   let( :sync_cmd )       { Beaker::HostPrebuiltSteps::ROOT_KEYS_SYNC_CMD }
-  let( :pkgs )           { Beaker::HostPrebuiltSteps::PACKAGES }
+  let( :windows_pkgs )   { Beaker::HostPrebuiltSteps::WINDOWS_PACKAGES }
   let( :unix_only_pkgs ) { Beaker::HostPrebuiltSteps::UNIX_PACKAGES }
   let( :sles_only_pkgs ) { Beaker::HostPrebuiltSteps::SLES_PACKAGES }
   let( :platform )       { @platform || 'unix' }
@@ -310,10 +310,6 @@ describe Beaker do
     it "can validate unix hosts" do
 
       hosts.each do |host|
-        pkgs.each do |pkg|
-          host.should_receive( :check_for_package ).with( pkg ).once.and_return( false )
-          host.should_receive( :install_package ).with( pkg ).once
-        end
         unix_only_pkgs.each do |pkg|
           host.should_receive( :check_for_package ).with( pkg ).once.and_return( false )
           host.should_receive( :install_package ).with( pkg ).once
@@ -329,13 +325,9 @@ describe Beaker do
       @platform = 'windows'
 
       hosts.each do |host|
-        pkgs.each do |pkg|
+        windows_pkgs.each do |pkg|
           host.should_receive( :check_for_package ).with( pkg ).once.and_return( false )
           host.should_receive( :install_package ).with( pkg ).once
-        end
-        unix_only_pkgs.each do |pkg|
-          host.should_receive( :check_for_package).with( pkg ).never
-          host.should_receive( :install_package ).with( pkg ).never
         end
       end
 
@@ -347,14 +339,6 @@ describe Beaker do
       @platform = 'sles-13.1-x64'
 
       hosts.each do |host|
-        pkgs.each do |pkg|
-          host.should_receive( :check_for_package ).with( pkg ).once.and_return( false )
-          host.should_receive( :install_package ).with( pkg ).once
-        end
-        unix_only_pkgs.each do |pkg|
-          host.should_receive( :check_for_package).with( pkg ).never
-          host.should_receive( :install_package ).with( pkg ).never
-        end
         sles_only_pkgs.each do |pkg|
           host.should_receive( :check_for_package).with( pkg ).once.and_return( false )
           host.should_receive( :install_package ).with( pkg ).once


### PR DESCRIPTION
- properly differentiate between packages and commands
- check_for_package updated to check for the given package name using
  the correct package manager per OS
- added check_for_command, which uses 'which' to determine if a command
  is currently available
