### PR TITLE
(MAINT) add redcarpet gem for travis errors

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
+  s.add_development_dependency 'redcarpet', '2.3.0'
   s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
   s.add_development_dependency 'thin'
 


### PR DESCRIPTION
- add redcarpet gem (pinned to 2.3.0 to support ruby 1.8.7) required by
  yard, current generating this error:
  
  [error]: Missing 'redcarpet' gem for Markdown formatting. Install it
  with `gem install redcarpet`
