### PR TITLE
(MAINT) add redcarpet gem for travis errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ task :yard do
 end
 
 task :travis do
-  Rake::Task['yard'].invoke
+  Rake::Task['yard'].invoke unless RUBY_VERSION < '1.9'
   Rake::Task['spec'].invoke
 end
 

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
 
   # Documentation dependencies
+  s.add_development_dependency 'redcarpet', '1.17.2'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
   s.add_development_dependency 'thin'


### PR DESCRIPTION
```
- add redcarpet gem (pinned to 1.17.2) required by
  yard

- do not run yard on ruby 1.8 because of this:

  [error]: Missing 'redcarpet' gem for Markdown formatting. Install it
  with `gem install redcarpet`
```
