### PR TITLE
(MAINT) travis failing on ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 before_install:
-  - gem update --system 2.2.1
+  - gem install bundler -v 1.5.3
+  - gem update --system 2.2.2
   - gem --version
+install:
+  - bundle _1.5.3_ install
 language: ruby
-script: "bundle exec rake travis"
+script: "bundle _1.5.3_ exec rake travis"
 notifications:
   email: false
 rvm:

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
 
   # Documentation dependencies
-  s.add_development_dependency 'redcarpet', '1.17.2'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
   s.add_development_dependency 'thin'


### PR DESCRIPTION
- pin to bundler 1.5.3 (which used to be used by travis, but was updated
  overnight)
- remove unnecessary redcarpet gem dependency 
