### PR TITLE
adding modulepath to apply_manifest_on

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -699,6 +699,11 @@ module Beaker
       #                         from Puppet verion 3.2
       #                         By default it will use the 'current' parser.
       #
+      # @option opts [String]   :modulepath The search path for modules, as
+      #                         a list of directories separated by the system
+      #                         path separator character. (The POSIX path separator
+      #                         is ‘:’, and the Windows path separator is ‘;’.) 
+      #
       # @param [Block] block This method will yield to a block of code passed
       #                      by the caller; this can be used for additional
       #                      validation, etc.


### PR DESCRIPTION
When running as an agent aka master-less (tested using windows) you need to be able to specify the module path because there isn't one otherwise. 

The creation of said directory should occur as part of the puppet_module_install command from beaker-rspec.
