### PR TITLE
fixing ssh_to_root when run on windows

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -331,7 +331,8 @@ module Beaker
       else
         logger.debug "Give root a copy of current user's keys, on #{host.name}"
         if host['platform'] =~ /windows/
-          host.exec(Command.new('sudo su -c "cp -r .ssh /home/Administrator/."'))
+          host.exec(Command.new('cp -r .ssh /cygdrive/c/Users/Administrator/.'))
+          host.exec(Command.new('chown -R Administrator /cygdrive/c/Users/Administrator/.ssh'))
         else
           host.exec(Command.new('sudo su -c "cp -r .ssh /root/."'), {:pty => true})
         end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -91,7 +91,8 @@ module Beaker
         host = @hosts[0]
         host[:platform] = 'windows'
 
-        Command.should_receive( :new ).with("sudo su -c \"cp -r .ssh /home/Administrator/.\"").once
+        Command.should_receive( :new ).with("cp -r .ssh /cygdrive/c/Users/Administrator/.").once
+        Command.should_receive( :new ).with("chown -R Administrator /cygdrive/c/Users/Administrator/.ssh").once
 
         vagrant.copy_ssh_to_root( host, options )
 


### PR DESCRIPTION
Fixing this method because you cannot sudo from within cygwin. In addition the /home/Administrator directory is not a directory that exists on windows.
