### PR TITLE
adding support for windows to install_puppet

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -475,7 +475,13 @@ module Beaker
             on host, "msiexec /qn /i puppet-#{relver}.msi"
 
             #Because the msi installer doesn't add Puppet to the environment path
-            on host, %q{ echo 'export PATH=$PATH:"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin"' > /etc/bash.bashrc }
+            if fact_on(host, 'architecture').eql?('x86_64')
+              install_dir = '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin'
+            else
+              install_dir = '/cygdrive/c/Program Files/Puppet Labs/Puppet/bin'
+            end
+            on host, %Q{ echo 'export PATH=$PATH:"#{install_dir}"' > /etc/bash.bashrc }
+            
           else
             raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"
           end


### PR DESCRIPTION
I have added support for windows so that it is possible to test using the msi installation. 

I added the opts hash argument in order to get this functionality to work but it could (and should) be also be used to allow centos/debian hosts to install specific versions of puppet.
