### PR TITLE
Support hash of boxes for multiple Vagrant providers

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -26,8 +26,17 @@ module Beaker
         host['ip'] ||= randip #use the existing ip, otherwise default to a random ip
         v_file << "  c.vm.define '#{host.name}' do |v|\n"
         v_file << "    v.vm.hostname = '#{host.name}'\n"
-        v_file << "    v.vm.box = '#{host['box']}'\n"
+        v_file << "    v.vm.box = '#{host['box']}'\n" unless host['box'].nil?
         v_file << "    v.vm.box_url = '#{host['box_url']}'\n" unless host['box_url'].nil?
+        if host['boxes']
+          host['boxes'].keys.sort.each do |provider|
+            popts = host['boxes'][provider]
+            v_file << %Q{    v.vm.provider :#{provider} do |p, override|\n}
+            v_file << %Q{      override.vm.box = '#{popts['box']}'\n}
+            v_file << %Q{      override.vm.box_url = '#{popts['box_url']}'\n} unless popts['box_url'].nil?
+            v_file << %Q{    end\n}
+          end
+        end
         v_file << "    v.vm.base_mac = '#{randmac}'\n"
         v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\"\n"
         if /windows/i.match(host['platform'])

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -28,6 +28,20 @@ module Beaker
       expect( File.read( File.expand_path( File.join( path, "Vagrantfile") ) ) ).to be === "Vagrant.configure(\"2\") do |c|\n  c.vm.define 'vm1' do |v|\n    v.vm.hostname = 'vm1'\n    v.vm.box = 'vm1_of_my_box'\n    v.vm.box_url = 'http://address.for.my.box.vm1'\n    v.vm.base_mac = '0123456789'\n    v.vm.network :private_network, ip: \"ip.address.for.vm1\", :netmask => \"255.255.0.0\"\n  end\n  c.vm.define 'vm2' do |v|\n    v.vm.hostname = 'vm2'\n    v.vm.box = 'vm2_of_my_box'\n    v.vm.box_url = 'http://address.for.my.box.vm2'\n    v.vm.base_mac = '0123456789'\n    v.vm.network :private_network, ip: \"ip.address.for.vm2\", :netmask => \"255.255.0.0\"\n  end\n  c.vm.define 'vm3' do |v|\n    v.vm.hostname = 'vm3'\n    v.vm.box = 'vm3_of_my_box'\n    v.vm.box_url = 'http://address.for.my.box.vm3'\n    v.vm.base_mac = '0123456789'\n    v.vm.network :private_network, ip: \"ip.address.for.vm3\", :netmask => \"255.255.0.0\"\n  end\n  c.vm.provider :virtualbox do |vb|\n    vb.customize [\"modifyvm\", :id, \"--memory\", \"1024\"]\n  end\nend\n"
     end
 
+    it "can make a Vagranfile with per-provider boxes" do
+      FakeFS.activate!
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      vagrant.stub( :randmac ).and_return( "0123456789" )
+
+      host = @hosts.first
+      host['boxes'] = {'virtualbox' => {'box' => 'vboxbox', 'box_url' => 'http://example.com/vboxbox'},
+                       'libvirt'    => {'box' => 'libvirtbox', 'box_url' => 'http://example.com/libvirtbox'}}
+      host['box'] = host['box_url'] = nil
+      vagrant.make_vfile([@hosts.first])
+
+      expect( File.read( File.expand_path( File.join( path, "Vagrantfile") ) ) ).to be === "Vagrant.configure(\"2\") do |c|\n  c.vm.define 'vm1' do |v|\n    v.vm.hostname = 'vm1'\n    v.vm.provider :libvirt do |p, override|\n      override.vm.box = 'libvirtbox'\n      override.vm.box_url = 'http://example.com/libvirtbox'\n    end\n    v.vm.provider :virtualbox do |p, override|\n      override.vm.box = 'vboxbox'\n      override.vm.box_url = 'http://example.com/vboxbox'\n    end\n    v.vm.base_mac = '0123456789'\n    v.vm.network :private_network, ip: \"ip.address.for.vm1\", :netmask => \"255.255.0.0\"\n  end\n  c.vm.provider :virtualbox do |vb|\n    vb.customize [\"modifyvm\", :id, \"--memory\", \"1024\"]\n  end\nend\n"
+    end
+
     it "generates a valid windows config" do
       FakeFS.activate!
       path = vagrant.instance_variable_get( :@vagrant_path )


### PR DESCRIPTION
This enables the box to be varied to support different Vagrant backends, so
users have more flexibility about the hypervisor they use.

Host files can now take the following form, with a hash of boxes instead of
the single box/box_url keys:

<pre>
  centos-65-x64:
    roles:
      - master
    platform: el-6-x86_64
    boxes:
      virtualbox:
        box: centos-65-x64-virtualbox-nocm
        box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
      libvirt:
        box: fm-centos64
        box_url: http://m0dlx.com/files/foreman/boxes/centos64.box
    hypervisor : vagrant
</pre>


Users should export VAGRANT_DEFAULT_PROVIDER to change the provider.

---

Generates a Vagrantfile of the form:

<pre>
Vagrant.configure("2") do |c|
  c.vm.define 'centos-65-x64' do |v|
    v.vm.hostname = 'centos-65-x64'
    v.vm.provider :libvirt do |p, override|
      override.vm.box = 'fm-centos64'
      override.vm.box_url = 'http://m0dlx.com/files/foreman/boxes/centos64.box'
    end
    v.vm.provider :virtualbox do |p, override|
      override.vm.box = 'centos-65-x64-virtualbox-nocm'
      override.vm.box_url = 'http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box'
    end
    v.vm.base_mac = '080027BEB781'
    v.vm.network :private_network, ip: "10.255.86.225", :netmask => "255.255.0.0"
  end
  c.vm.provider :virtualbox do |vb|
    vb.customize ["modifyvm", :id, "--memory", "1024"]
  end
end
</pre>
