### PR TITLE
Add option to preserve the built docker image

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -24,15 +24,10 @@ module Beaker
 
         @logger.debug("Creating image")
         image = ::Docker::Image.build(dockerfile_for(host), { :rm => true })
-        @logger.debug("Tagging image #{image.id} as #{host.name}")
-        image.tag({
-          :repo => host.name,
-          :force => true,
-        })
 
-        @logger.debug("Creating container from image")
+        @logger.debug("Creating container from image #{image.id}")
         container = ::Docker::Container.create({
-          'Image' => host.name,
+          'Image' => image.id,
           'Hostname' => host.name,
         })
 
@@ -75,7 +70,8 @@ module Beaker
           end
         end
 
-        if image = host['docker_image']
+        # Do not remove the image if docker_reserve_image is set to true, otherwise remove it
+        if image = (host['docker_preserve_image'] ? nil : host['docker_image'])
           @logger.debug("delete image #{image.id}")
           begin
             image.delete

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -116,21 +116,10 @@ module Beaker
         docker.provision
       end
 
-      it 'should tag the Image with the host.name' do
-        hosts.each do |host|
-          image.should_receive(:tag).with({
-            :repo => host.name,
-            :force => true,
-          })
-        end
-
-        docker.provision
-      end
-
-      it 'should create a container based on the Image (identified by host.name)' do
+      it 'should create a container based on the Image (identified by image.id)' do
         hosts.each do |host|
           ::Docker::Container.should_receive(:create).with({
-            'Image' => host.name,
+            'Image' => image.id,
             'Hostname' => host.name,
           })
         end
@@ -180,6 +169,23 @@ module Beaker
         image.should_receive(:delete)
         docker.cleanup
       end
+
+      it 'should not delete the image if docker_preserve_image is set to true' do
+        hosts.each do |host|
+          host['docker_preserve_image']=true
+        end
+        image.should_not_receive(:delete)
+        docker.cleanup
+      end
+
+      it 'should delete the image if docker_preserve_image is set to false' do
+        hosts.each do |host|
+          host['docker_preserve_image']=false
+        end
+        image.should_receive(:delete)
+        docker.cleanup
+      end
+
     end
 
     describe '#dockerfile_for' do


### PR DESCRIPTION
With the nodeset config option 'docker_preserve_image' we can disable the image deletion.
This is useful when running in CI environments and multiple containers are built using the same dockerfile content and re-used allot of times.

Improved Pr of #241
