### PR TITLE
(QENG-672) Ensure beaker checks pe_dir from host as well as pe_ver

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -191,9 +191,9 @@ module Beaker
       #                  (Otherwise uses individual Windows hosts pe_ver)
       # @api private
       def fetch_puppet_on_windows(host, opts)
-        path = opts[:pe_dir] || host['pe_dir']
+        path = host['pe_dir'] || opts[:pe_dir]
         local = File.directory?(path)
-        version = opts[:pe_ver_win] || host['pe_ver']
+        version = host['pe_ver'] || opts[:pe_ver_win]
         filename = "puppet-enterprise-#{version}"
         extension = ".msi"
         if local
@@ -219,7 +219,7 @@ module Beaker
       #                  (Otherwise uses individual hosts pe_ver)
       # @api private
       def fetch_puppet_on_unix(host, opts)
-        path = opts[:pe_dir] || host['pe_dir']
+        path = host['pe_dir'] || opts[:pe_dir]
         local = File.directory?(path)
         filename = "#{host['dist']}"
         if local


### PR DESCRIPTION
The previous code for QENG-672 only fixed the version lookup, not the
source path lookup.
