### PR TITLE
Add option to enable and set package manager proxy url

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -89,6 +89,9 @@ module Beaker
       if @options[:add_master_entry]
         add_master_entry(@hosts, @options)
       end
+      if @options[:package_proxy]
+        package_proxy(@hosts, @options)
+      end
     end
 
     #Default validation steps to be run for a given hypervisor
@@ -98,7 +101,7 @@ module Beaker
       end
     end
 
-    #Generate a random straing composted of letter and numbers
+    #Generate a random string composted of letter and numbers
     def generate_host_name
       CHARMAP[rand(25)] + (0...14).map{CHARMAP[rand(CHARMAP.length)]}.join
     end

--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -77,6 +77,16 @@ module Beaker
       end
     end
 
+    # configure proxy on all provioned machines
+    #@raise [Exception] Raise an exception if virtual machines fail to be configured
+    def package_proxy
+      if @hypervisors
+        @hypervisors.each_key do |type|
+          @hypervisors[type].package_proxy
+        end
+      end
+    end
+
     #Shut down network connections and revert all provisioned virtual machines
     def cleanup
       #shut down connections

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -198,6 +198,9 @@ module Beaker
             @cmd_options[:log_level] =  bool ? 'debug' : 'info'
           end
 
+          opts.on '--package-proxy URL', 'Set proxy url for package managers (yum and apt)' do |value|
+            @cmd_options[:package_proxy] = value
+          end
         end
 
       end

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -42,7 +42,8 @@ module Beaker
                                       ENV['q_verify_packages'] || 'y',
                                     :q_puppetdb_password =>
                                       ENV['q_puppetdb_password'] || '~!@#$%^*-/ aZ',
-                                  }
+                                  },
+          :package_proxy        => ENV['BEAKER_PACKAGE_PROXY']
         }.delete_if {|key, value| value.nil? or value.empty? })
       end
 
@@ -73,6 +74,7 @@ module Beaker
           :fail_mode           => 'slow',
           :timesync            => false,
           :repo_proxy          => false,
+          :package_proxy       => false,
           :add_el_extras       => false,
           :add_master_entry    => false,
           :consoleport         => 443,

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -418,4 +418,30 @@ describe Beaker do
 
   end
 
+  context "package_proxy" do
+
+    subject { dummy_class.new }
+    proxyurl = "http://192.168.2.100:3128"
+
+    it "can set proxy config on a debian/ubuntu host" do
+      host = make_host('name', { :platform => 'ubuntu' } )
+
+      Beaker::Command.should_receive( :new ).with( "echo 'Acquire::http::Proxy \"#{proxyurl}/\";' >> /etc/apt/apt.conf.d/10proxy" ).once
+      host.should_receive( :exec ).once
+
+      subject.package_proxy(host, options.merge( {'package_proxy' => proxyurl}) )
+    end
+
+    it "can set proxy config on a redhat/centos host" do
+      host = make_host('name', { :platform => 'centos' } )
+
+      Beaker::Command.should_receive( :new ).with( "echo 'proxy=#{proxyurl}/' >> /etc/yum.conf" ).once
+      host.should_receive( :exec ).once
+
+      subject.package_proxy(host, options.merge( {'package_proxy' => proxyurl}) )
+
+    end
+
+  end
+
 end

--- a/spec/beaker/options/command_line_parser_spec.rb
+++ b/spec/beaker/options/command_line_parser_spec.rb
@@ -6,14 +6,14 @@ module Beaker
 
       let(:parser) {Beaker::Options::CommandLineParser.new}
       let(:test_opts) {["-h", "vcloud.cfg", "--debug", "--tests", "test.rb", "--help"]}
-      let(:full_opts) {["--hosts", "host.cfg", "--options", "opts_file", "--type", "pe", "--helper", "path_to_helper", "--load-path", "load_path", "--tests", "test1.rb,test2.rb,test3.rb", "--pre-suite", "pre_suite.rb", "--post-suite", "post_suite.rb", "--no-provision", "--preserve-hosts", "always", "--root-keys", "--keyfile", "../.ssh/id_rsa", "--install", "gitrepopath", "-m", "module", "-q", "--no-xml", "--dry-run", "--no-ntp", "--repo-proxy", "--add-el-extras", "--config", "anotherfile.cfg", "--fail-mode", "fast", "--no-color", "--version", "--log-level", "info"]}
+      let(:full_opts) {["--hosts", "host.cfg", "--options", "opts_file", "--type", "pe", "--helper", "path_to_helper", "--load-path", "load_path", "--tests", "test1.rb,test2.rb,test3.rb", "--pre-suite", "pre_suite.rb", "--post-suite", "post_suite.rb", "--no-provision", "--preserve-hosts", "always", "--root-keys", "--keyfile", "../.ssh/id_rsa", "--install", "gitrepopath", "-m", "module", "-q", "--no-xml", "--dry-run", "--no-ntp", "--repo-proxy", "--add-el-extras", "--config", "anotherfile.cfg", "--fail-mode", "fast", "--no-color", "--version", "--log-level", "info", "--package-proxy", "http://192.168.100.1:3128"]}
 
       it "can correctly read command line input" do
         expect(parser.parse(test_opts)).to be === {:hosts_file=>"vcloud.cfg", :log_level=>"debug", :tests=>"test.rb", :help=>true}
       end
 
       it "supports all our command line options" do
-        expect(parser.parse(full_opts)).to be === {:hosts_file=>"anotherfile.cfg", :options_file=>"opts_file", :type=>"pe", :helper=>"path_to_helper", :load_path=>"load_path", :tests=>"test1.rb,test2.rb,test3.rb", :pre_suite=>"pre_suite.rb", :post_suite=>"post_suite.rb", :provision=>false, :preserve_hosts=>"always", :root_keys=>true, :keyfile=>"../.ssh/id_rsa", :install=>"gitrepopath", :modules=>"module", :quiet=>true, :xml=>false, :dry_run=>true, :timesync=>false, :repo_proxy=>true, :add_el_extras=>true, :fail_mode=>"fast", :color=>false, :version=>true, :log_level=>"info"}
+        expect(parser.parse(full_opts)).to be === {:hosts_file=>"anotherfile.cfg", :options_file=>"opts_file", :type=>"pe", :helper=>"path_to_helper", :load_path=>"load_path", :tests=>"test1.rb,test2.rb,test3.rb", :pre_suite=>"pre_suite.rb", :post_suite=>"post_suite.rb", :provision=>false, :preserve_hosts=>"always", :root_keys=>true, :keyfile=>"../.ssh/id_rsa", :install=>"gitrepopath", :modules=>"module", :quiet=>true, :xml=>false, :dry_run=>true, :timesync=>false, :repo_proxy=>true, :add_el_extras=>true, :fail_mode=>"fast", :color=>false, :version=>true, :log_level=>"info", :package_proxy => "http://192.168.100.1:3128"}
       end
 
       it "can produce a usage description" do


### PR DESCRIPTION
With this feature you can set the proxy url for the package manager.
Currently supports Yum and Apt package managers.
