### PR TITLE
(QENG-743) Beaker options hash 'merge' should not modify the...

### DIFF
--- a/lib/beaker/options/options_hash.rb
+++ b/lib/beaker/options/options_hash.rb
@@ -109,7 +109,7 @@ module Beaker
         base
       end
 
-      # Recursively merge self with an OptionsHash or Hash
+      # Create new OptionsHash from recursively merged self with an OptionsHash or Hash
       #
       # @param [OptionsHash, Hash] hash The hash to merge from
       #
@@ -124,6 +124,26 @@ module Beaker
       #
       # @return [OptionsHash] The combined hash
       def merge hash
+        #make a deep copy into an empty hash object
+        merged_hash = rmerge(OptionsHash.new, self)
+        rmerge(merged_hash, hash)
+      end
+
+      # Recursively merge self with an OptionsHash or Hash
+      #
+      # @param [OptionsHash, Hash] hash The hash to merge from
+      #
+      # @example
+      #   base = { :key => { :subkey1 => 'subval', :subkey2 => 'subval' } }
+      #   hash = { :key => { :subkey1 => 'newval'} }
+      #
+      #   base.merge!(hash)
+      #   #=> {:key =>
+      #         {:subkey1 => 'newval',
+      #          :subkey2 => 'subval' }
+      #
+      # @return [OptionsHash] The combined hash
+      def merge! hash
         rmerge(self, hash)
       end
 

--- a/spec/beaker/options/options_hash_spec.rb
+++ b/spec/beaker/options/options_hash_spec.rb
@@ -36,8 +36,13 @@ module Beaker
       end
 
       it "when merged with a hash that contains a hash, the sub-hash becomes an OptionsHash" do
+        newhash = options.merge({'key' => {'subkey' => 'subvalue'}})
+        expect(newhash[:key].is_a?(OptionsHash)) === true and expect(newhash[:key][:subkey]) === 'subvalue'
+      end
+
+      it "does not alter the original hash when doing a merge" do
         options.merge({'key' => {'subkey' => 'subvalue'}})
-        expect(options[:key].is_a?(OptionsHash)) === true and expect(options[:key][:subkey]) === 'subvalue'
+        expect(options[:key]).to be === nil
       end
 
       context 'pretty prints itself' do


### PR DESCRIPTION
...global settings
- merge was behaving like merge!
- merging two OptionsHash objects should result in a new OptionsHash
  and not affect the original hashes at all.
