### PR TITLE
Fix for "uninitialized constant MiniTest" error

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -22,6 +22,8 @@ elsif defined?(Test::Unit::Runner)
   # For test/unit bundled in Ruby >= 1.9.3
   Test::Unit::Runner.module_eval("@@stop_auto_run = true")
 end
+# Fix for "uninitialized constant MiniTest (NameError) error"
+require "minitest/autorun"
 
 module Beaker
   # This class represents a single test case. A test case is necessarily


### PR DESCRIPTION
This fixed `/Library/Ruby/Gems/2.0.0/gems/beaker-1.12.0/lib/beaker/test_case.rb:47:in``<class:TestCase>': uninitialized constant MiniTest (NameError)` error which I was getting on **Mac OS X 10.9.3**, with system **Ruby 2.0.0p451**, **minitest 5.3.4**.

I haven't tested it with any other ruby/minitest combination.
