### PR TITLE
Removing unnecessary `razor` wrapper function

### DIFF
--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -32,18 +32,6 @@ module Beaker
         Command.new('hiera', args, options )
       end
 
-      # This is hairy and because of legacy code it will take a bit more
-      # work to disentangle all of the things that are being passed into
-      # this catchall param.
-      #
-      # @api dsl
-      def razor(*args)
-        options = args.last.is_a?(Hash) ? args.pop : {}
-        options['ENV'] ||= {}
-        options['ENV'] = options['ENV'].merge( Command::DEFAULT_GIT_ENV )
-        Command.new('razor', args, options )
-      end
-
       # @param [String] command_string A string of to be interpolated
       #                                within the context of a host in
       #                                question

--- a/spec/beaker/dsl/wrappers_spec.rb
+++ b/spec/beaker/dsl/wrappers_spec.rb
@@ -23,14 +23,6 @@ describe ClassMixedWithDSLWrappers do
     end
   end
 
-  describe '#razor' do
-    it 'should split out the options and pass "razor" as first arg to Command' do
-      Beaker::Command.should_receive( :new ).
-        with('razor', [ '-p' ], opts)
-      subject.razor( '-p' )
-    end
-  end
-
   describe '#puppet' do
     it 'should split out the options and pass "puppet <blank>" to Command' do
       merged_opts = {}


### PR DESCRIPTION
The `razor` function was unnecessarily defined in the
wrapper, which was overriding a helper definition.
