### PR TITLE
Auto format correction for spacing and alignment of => and = operands

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -88,10 +88,10 @@ module Beaker
           # Also, let additional checking be performed by the caller.
           if block_given?
             case block.arity
-              #block with arity of 0, just hand back yourself
+            #block with arity of 0, just hand back yourself
             when 0
               yield self
-              #block with arity of 1 or greater, hand back the result object
+            #block with arity of 1 or greater, hand back the result object
             else
               yield @result
             end


### PR DESCRIPTION
Maintenance no other chances.  Consistency across case when alignments and aligning assignment operands.
