### PR TITLE
(QENG-760) support for additional disk for vagrant

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -30,11 +30,24 @@ module Beaker
         v_file << "    v.vm.box_url = '#{host['box_url']}'\n" unless host['box_url'].nil?
         v_file << "    v.vm.base_mac = '#{randmac}'\n"
         v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\"\n"
+
+        if host['disk_path']
+          v_file << "    v.vm.provider :virtualbox do |vb|\n"
+          v_file << "      vb.name = '#{host.name}'\n"
+          unless File.exist?(host['disk_path'])
+            host['disk_path'] = File.join(host['disk_path'], "#{host.name}.vmdk")
+            v_file << "      vb.customize ['createhd', '--filename', '#{host['disk_path']}', '--size', #{host['disk_size'] ||= 5 * 1024}, '--format', 'vmdk']\n"
+          end
+          v_file << "      vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium','#{host['disk_path']}']\n"
+          v_file << "    end\n"
+        end
+
         if /windows/i.match(host['platform'])
           v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"
           v_file << "    v.vm.guest = :windows"
         end
+
         v_file << "  end\n"
         @logger.debug "created Vagrantfile for VagrantHost #{host.name}"
       end


### PR DESCRIPTION
- if a given vagrant box has a disk_path then either create a new vmdk
  disk or use the provided disk
- defaults to 50 x 1024 bytes if the disk needs to created
