### PR TITLE
(QENG-775) Do not use puppet to stop puppet on older PE on SLES

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -423,40 +423,6 @@ module Beaker
         on install_hosts, puppet_agent('-t'), :acceptable_exit_codes => [0,2]
       end
 
-      #Is PE version a less than PE version b
-      #@param [String] a A PE version of the from '\d.\d.\d.*'
-      #@param [String] b A PE version of the form '\d.\d.\d.*'
-      #@return [Boolean] true if a is less than b, otherwise return false
-      #
-      #@note 3.0.0-160-gac44cfb is greater than 3.0.0, and 2.8.2
-      # @!visibility private
-      def version_is_less a, b
-        a_nums = a.split('-')[0].split('.')
-        b_nums = b.split('-')[0].split('.')
-        (0...a_nums.length).each do |i|
-          if i < b_nums.length
-            if a_nums[i] < b_nums[i]
-              return true
-            elsif a_nums[i] > b_nums[i]
-              return false
-            end
-          else
-            return false
-          end
-        end
-        #checks all dots, they are equal so examine the rest
-        a_rest = a.split('-', 2)[1]
-        b_rest = b.split('-', 2)[1]
-        if a_rest and b_rest and a_rest < b_rest
-          return false
-        elsif a_rest and not b_rest
-          return false
-        elsif not a_rest and b_rest
-          return true
-        end
-        return false
-      end
-
       #Sort array of hosts so that it has the correct order for PE installation based upon each host's role
       # @example
       #  h = sorted_hosts

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -557,6 +557,33 @@ describe ClassMixedWithDSLHelpers do
     end
   end
 
+  describe 'version_is_less' do
+
+    it 'reports 3.0.0-160-gac44cfb is not less than 3.0.0' do
+      expect( subject.version_is_less( '3.0.0-160-gac44cfb', '3.0.0' ) ).to be === false
+    end
+
+    it 'reports 3.0.0-160-gac44cfb is not less than 2.8.2' do
+      expect( subject.version_is_less( '3.0.0-160-gac44cfb', '2.8.2' ) ).to be === false
+    end
+
+    it 'reports 3.0.0 is less than 3.0.0-160-gac44cfb' do
+      expect( subject.version_is_less( '3.0.0', '3.0.0-160-gac44cfb' ) ).to be === true
+    end
+
+    it 'reports 2.8.2 is less than 3.0.0-160-gac44cfb' do
+      expect( subject.version_is_less( '2.8.2', '3.0.0-160-gac44cfb' ) ).to be === true
+    end
+
+    it 'reports 2.8 is less than 3.0.0-160-gac44cfb' do
+      expect( subject.version_is_less( '2.8', '3.0.0-160-gac44cfb' ) ).to be === true
+    end
+
+    it 'reports 2.8 is less than 2.9' do
+      expect( subject.version_is_less( '2.8', '2.9' ) ).to be === true
+    end
+  end
+
   describe "#stop_agent_on" do
     let( :result_fail ) { Beaker::Result.new( [], "" ) }
     let( :result_pass ) { Beaker::Result.new( [], "" ) }

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -101,33 +101,6 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
-  describe 'version_is_less' do
-
-    it 'reports 3.0.0-160-gac44cfb is not less than 3.0.0' do
-      expect( subject.version_is_less( '3.0.0-160-gac44cfb', '3.0.0' ) ).to be === false
-    end
-
-    it 'reports 3.0.0-160-gac44cfb is not less than 2.8.2' do
-      expect( subject.version_is_less( '3.0.0-160-gac44cfb', '2.8.2' ) ).to be === false
-    end
-
-    it 'reports 3.0.0 is less than 3.0.0-160-gac44cfb' do
-      expect( subject.version_is_less( '3.0.0', '3.0.0-160-gac44cfb' ) ).to be === true
-    end
-
-    it 'reports 2.8.2 is less than 3.0.0-160-gac44cfb' do
-      expect( subject.version_is_less( '2.8.2', '3.0.0-160-gac44cfb' ) ).to be === true
-    end
-
-    it 'reports 2.8 is less than 3.0.0-160-gac44cfb' do
-      expect( subject.version_is_less( '2.8', '3.0.0-160-gac44cfb' ) ).to be === true
-    end
-
-    it 'reports 2.8 is less than 2.9' do
-      expect( subject.version_is_less( '2.8', '2.9' ) ).to be === true
-    end
-  end
-
   describe 'installer_cmd' do
 
     it 'generates a windows PE install command for a windows host' do
@@ -243,18 +216,20 @@ describe ClassMixedWithDSLInstallUtils do
 
       subject.should_not_receive(:scp_to)
       subject.should_not_receive(:on)
+      subject.stub(:version_is_less).with('3.2.0', '3.2.0').and_return(false)
       subject.fetch_puppet( [unixhost], {} )
     end
   end
 
   describe 'do_install' do
-    it 'can preform a simple installation' do
+    it 'can perform a simple installation' do
       subject.stub( :on ).and_return( Beaker::Result.new( {}, '' ) )
       subject.stub( :fetch_puppet ).and_return( true )
       subject.stub( :create_remote_file ).and_return( true )
       subject.stub( :sign_certificate_for ).and_return( true )
       subject.stub( :stop_agent_on ).and_return( true )
       subject.stub( :sleep_until_puppetdb_started ).and_return( true )
+      subject.stub( :version_is_less ).with('3.0', '3.0').and_return( false )
       subject.stub( :wait_for_host_in_dashboard ).and_return( true )
       subject.stub( :puppet_agent ).and_return do |arg|
         "puppet agent #{arg}"
@@ -402,6 +377,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       subject.stub( :hosts ).and_return( the_hosts )
       subject.stub( :options ).and_return( {} )
+      subject.stub( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       subject.should_receive( :do_install ).with( the_hosts, { :type => :upgrade } )
@@ -417,6 +393,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       subject.stub( :hosts ).and_return( the_hosts )
       subject.stub( :options ).and_return( {} )
+      subject.stub( :version_is_less ).with('3.1', '3.0').and_return( false )
       version = version_win = '3.1'
       path = "/path/to/upgradepkg"
       subject.should_receive( :do_install ).with( the_hosts, { :type => :upgrade } )
@@ -432,6 +409,7 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       subject.stub( :hosts ).and_return( the_hosts )
       subject.stub( :options ).and_return( {} )
+      subject.stub( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
       subject.should_receive( :do_install ).with( the_hosts, { :type => :upgrade } )


### PR DESCRIPTION
A bug in the init script on older versions of SLES causes the init
script to kill our `puppet resource` invocation as well as the daemon
agent.
