### PR TITLE
(MAINT) aws-sdk 1.43 breaks beaker specs

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'blimpy', '~> 0.6'
   s.add_runtime_dependency 'fission', '~> 0.4'
   s.add_runtime_dependency 'google-api-client', '~> 0.7.1'
-  s.add_runtime_dependency 'aws-sdk', '~> 1.38'
+  s.add_runtime_dependency 'aws-sdk', '1.42.0'
   s.add_runtime_dependency 'docker-api' unless RUBY_VERSION < '1.9'
 
   # These are transitive dependencies that we include or pin to because...


### PR DESCRIPTION
- pin to aws-sdk 1.42.0
