### PR TITLE
Use the correct docker server ip address for ssh

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -35,7 +35,12 @@ module Beaker
         container.start({"PublishAllPorts" => true, "Privileged" => true})
 
         # Find out where the ssh port is from the container
-        ip   = container.json["NetworkSettings"]["Ports"]["22/tcp"][0]["HostIp"]
+        if ENV['DOCKER_HOST']
+          ip = URI.parse(ENV['DOCKER_HOST']).host
+          @logger.info("Using docker server at #{ip}")
+        else
+          ip = container.json["NetworkSettings"]["Ports"]["22/tcp"][0]["HostIp"]
+        end
         port = container.json["NetworkSettings"]["Ports"]["22/tcp"][0]["HostPort"]
 
         # Update host metadata

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -36,6 +36,7 @@ module Beaker
       container.stub(:start)
       container.stub(:json).and_return({
         'NetworkSettings' => {
+          'IPAddress' => '192.0.2.1',
           'Ports' => {
             '22/tcp' => [
               {
@@ -133,11 +134,25 @@ module Beaker
         docker.provision
       end
 
-      it 'should expose port 22 to beaker' do
-        docker.provision
+      context "connecting to ssh" do
+        before { @docker_host = ENV['DOCKER_HOST'] }
+        after { ENV['DOCKER_HOST'] = @docker_host }
 
-        hosts[0]['ip'].should == '127.0.1.1'
-        hosts[0]['port'].should == 8022
+        it 'should expose port 22 to beaker' do
+          ENV['DOCKER_HOST'] = nil
+          docker.provision
+
+          hosts[0]['ip'].should == '127.0.1.1'
+          hosts[0]['port'].should == 8022
+        end
+
+        it 'should expose port 22 to beaker when using DOCKER_HOST' do
+          ENV['DOCKER_HOST'] = "tcp://192.0.2.2:2375"
+          docker.provision
+
+          hosts[0]['ip'].should == '192.0.2.2'
+          hosts[0]['port'].should == 8022
+        end
       end
 
       it 'should record the image and container for later' do


### PR DESCRIPTION
Honor DOCKER_HOST envvar, used with boot2docker
Use the IpAddress field from docker info otherwise, `[Ports][22/tcp][0][HostPort]` is the
bind address and can be 0.0.0.0

The current implementation is trying to ssh connect to 0.0.0.0 for me (using boot2docker on OS X)

My NetworkSettings from docker info

```
  "NetworkSettings": {
    "IPAddress": "172.17.0.47",
    "IPPrefixLen": 16,
    "Gateway": "172.17.42.1",
    "Bridge": "docker0",
    "PortMapping": null,
    "Ports": {
      "22/tcp": [
        {
          "HostIp": "0.0.0.0",
          "HostPort": "49155"
        }
      ]
    }
  },
```

I have tested it with https://github.com/maestrodev/puppet-maven

```
BEAKER_set=centos-65-x64-docker rspec spec/acceptance
```
