### PR TITLE
(MODULES-1168) Fixes use of Beaker logger in retry_command.

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -967,9 +967,9 @@ module Beaker
       def retry_command(desc, host, command, desired_exit_codes = 0,
                         max_retries = 60, retry_interval = 1, verbose = false)
         log_prefix = host.log_prefix
-        @logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{command}"
-        @logger.debug "  Trying command #{max_retries} times."
-        @logger.debug ".", add_newline=false
+        logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{command}"
+        logger.debug "  Trying command #{max_retries} times."
+        logger.debug ".", add_newline=false
         desired_exit_codes = [desired_exit_codes].flatten
         result = on host, command, {:acceptable_exit_codes => (0...127), :silent => !verbose}
         num_retries = 0
@@ -977,13 +977,13 @@ module Beaker
           sleep retry_interval
           result = on host, command, {:acceptable_exit_codes => (0...127), :silent => !verbose}
           num_retries += 1
-          @logger.debug ".", add_newline=false
+          logger.debug ".", add_newline=false
           if (num_retries > max_retries)
-            @logger.debug "  Command \`#{command}\` failed."
+            logger.debug "  Command \`#{command}\` failed."
             fail("Command \`#{command}\` failed.")
           end
         end
-        @logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{command} ostensibly successful."
+        logger.debug "\n#{log_prefix} #{Time.new.strftime('%H:%M:%S')}$ #{command} ostensibly successful."
       end
 
       #Is semver-ish version a less than semver-ish version b


### PR DESCRIPTION
Looks like the Beaker DSL always assumes a method, `logger`, that returns a
Logger object--assuming that the namespace loading the DSL modules has a logger
object available as `@logger` breaks beaker-rspec.

Signed-off-by: Wayne wayne@puppetlabs.com
