### PR TITLE
(MAINT) Add PE 3.4 installer answers module.

### DIFF
--- a/lib/beaker/answers.rb
+++ b/lib/beaker/answers.rb
@@ -1,4 +1,4 @@
-[ 'version32', 'version30', 'version28', 'version20' ].each do |lib|
+[ 'version34', 'version32', 'version30', 'version28', 'version20' ].each do |lib|
   require "beaker/answers/#{lib}"
 end
 
@@ -21,6 +21,8 @@ module Beaker
     def self.answers(version, hosts, master_certname, options)
 
       case version
+      when /\A3\.4/
+        Version34.answers(hosts, master_certname, options)
       when /\A3\.[2-3]/
         Version32.answers(hosts, master_certname, options)
       when /\A3\.1/

--- a/lib/beaker/answers/version34.rb
+++ b/lib/beaker/answers/version34.rb
@@ -1,0 +1,12 @@
+require 'beaker/answers/version32'
+
+module Beaker
+  module Answers
+    module Version34
+      def self.answers(hosts, master_certname, options)
+        the_answers = Version32.answers(hosts, master_certname, options)
+        return the_answers
+      end
+    end
+  end
+end

--- a/spec/beaker/answers_spec.rb
+++ b/spec/beaker/answers_spec.rb
@@ -9,6 +9,12 @@ module Beaker
                           basic_hosts }
     let( :master_certname ) { 'master_certname' }
 
+    it 'generates 3.4 answers for 3.4 hosts' do
+      @ver = '3.4'
+      Beaker::Answers::Version34.should_receive( :answers ).with( hosts, master_certname, {}).once
+      subject.answers( @ver, hosts, master_certname, {} )
+    end
+
     it 'generates 3.2 answers for 3.3 hosts' do
       @ver = '3.3'
       Beaker::Answers::Version32.should_receive( :answers ).with( hosts, master_certname, {}).once
@@ -52,6 +58,23 @@ module Beaker
   end
 
   module Answers
+    describe Version34 do
+      let( :options )     { Beaker::Options::Presets.env_vars }
+      let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+      let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                      basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                      basic_hosts[2]['roles'] = ['database', 'agent']
+                      basic_hosts }
+      let( :master_certname ) { 'master_certname' }
+      it 'should add answers to the host objects' do
+        @ver = '3.4'
+        answers = subject.answers( hosts, master_certname, options )
+        hosts.each do |host|
+          expect( host[:answers] ).to be === answers[host.name]
+        end
+      end
+    end
+
     describe Version32 do
       let( :options )     { Beaker::Options::Presets.env_vars }
       let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }


### PR DESCRIPTION
Basically followed the patter established by version30 -> version32 and PE installer seems to work without a hitch. I expect this will change as the PE 3.4 installer evolves to include questions about JVM Puppet.
