### PR TITLE
(QENG-841) don't run beaker package configuration on osx hosts

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -91,7 +91,7 @@ module Beaker
               host.install_package pkg
             end
           end
-        when host['platform'] !~ /aix|solaris|windows|sles-/
+        when host['platform'] !~ /aix|solaris|windows|sles-|osx-/
           UNIX_PACKAGES.each do |pkg|
             if not host.check_for_package pkg
               host.install_package pkg


### PR DESCRIPTION
- beaker doesn't know how to do package installation on osx, so don't
  try to
