### PR TITLE
GH-320 - Disable vbguest plugin

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -42,7 +42,7 @@ module Beaker
           v_file << "    end\n"
         end
 
-        if ENV['BEAKER_VB_GUEST_PLUGIN_DISABLE']
+        if @options[:vbguest_plugin] == 'disable'
           v_file << "    v.vbguest.auto_update = false\n"
         end
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -26,6 +26,7 @@ module Beaker
         :release_apt_repo_url => ['BEAKER_RELEASE_APT_REPO', 'RELEASE_APT_REPO'],
         :release_yum_repo_url => ['BEAKER_RELEASE_YUM_REPO', 'RELEASE_YUM_REPO'],
         :dev_builds_url       => ['BEAKER_DEV_BUILDS_URL', 'DEV_BUILDS_URL'],
+        :vbguest_plugin       => ['BEAKER_VB_GUEST_PLUGIN', 'BEAKER_vb_guest_plugin'],
         :q_puppet_enterpriseconsole_auth_user_email => 'q_puppet_enterpriseconsole_auth_user_email',
         :q_puppet_enterpriseconsole_auth_password   => 'q_puppet_enterpriseconsole_auth_password',
         :q_puppet_enterpriseconsole_smtp_host       => 'q_puppet_enterpriseconsole_smtp_host',

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -70,7 +70,7 @@ module Beaker
       path = vagrant.instance_variable_get( :@vagrant_path )
       vagrant.stub( :randmac ).and_return( "0123456789" )
 
-      stub_const('ENV', {'VB_GUEST_PLUGIN_DISABLE' => 'true'})
+      stub_const('ENV', {'BEAKER_VB_GUEST_PLUGIN' => 'disable'})
 
       vagrant.make_vfile( @hosts )
 


### PR DESCRIPTION
I've found when running a large suite of Beaker vagrant tests it would take a really long time even for really simple tests. This was because the https://github.com/dotless-de/vagrant-vbguest plugin is on by default, and my Virtualbox is using a different version than the nodes referenced most of the time, so it has to install the GuestAdditions everytime.

Whilst useful, there should be an option to turn this off.

This could possibly be spun out to include other common vagrant plugins (vagrant-cachier maybe?)
