### PR TITLE
Fix broken debian installs of FOSS puppet

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -545,8 +545,12 @@ module Beaker
           on host, "apt-get install -y hiera=#{opts[:hiera_version]}-1puppetlabs1"
         end
 
-        puppet_pkg = opts[:version] ? "puppet=#{opts[:version]}-1puppetlabs1" : 'puppet'
-        on host, "apt-get install -y #{puppet_pkg}"
+        if opts[:version]
+          on host, "apt-get install -y puppet-common=#{opts[:version]}-1puppetlabs1"
+          on host, "apt-get install -y puppet=#{opts[:version]}-1puppetlabs1"
+        else
+          on host, 'apt-get install -y puppet'
+        end
       end
 
       # Installs Puppet and dependencies from msi


### PR DESCRIPTION
Previously some versions of apt would not resolve the puppet-common package
dependency for versions other than the latest release. This pins the
puppet-common package to the same version as puppet to prevent these issues.

Note: I haven't tested this yet....
