### PR TITLE
(QENG-846) Add timestamp to options hash.

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -15,6 +15,7 @@ module Beaker
       @options = @options_parser.parse_args
       @logger = Beaker::Logger.new(@options)
       @options[:logger] = @logger
+      @options[:timestamp] = @timestamp
       @execute = true
 
       if @options[:help]


### PR DESCRIPTION
This is not essential for Green Team, just to be clear, just something I need to be able to send data retrieved from the SUT somewhere for later inspection when running multiple instances of Beaker concurrently.
