### PR TITLE
(maint) Use `#check_for_command` instead of `#check_for_package`

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -603,7 +603,7 @@ module Beaker
           host.install_package('lsb-release')
         end
 
-        if ! host.check_for_package 'curl'
+        if ! host.check_for_command 'curl'
           on host, 'apt-get install -y curl'
         end
 
@@ -688,7 +688,7 @@ module Beaker
       # @raise [StandardError] if gem does not exist on target host
       # @api private
       def install_puppet_from_gem( host, opts )
-        if host.check_for_package( 'gem' )
+        if host.check_for_command( 'gem' )
           if opts[:facter_version]
             on host, "gem install facter -v#{opts[:facter_version]}"
           end


### PR DESCRIPTION
where appropriate in `#install_puppet`

Previously there was no `Host#check_for_command` method, but `Host#check_for_package`
did a `which` (it effectively was checking for the command). Now that we've
separated out that behavior we need to use the ones we mean in
`InstallUtils#install_puppet()`. This is important because when we fall back
to a gem install of Puppet we ensure there is a command `gem` available from
(often) the package `rubygems`.
