### PR TITLE
(QENG-912) Beaker 1.14 breaks PE Puppet Acceptance

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -143,8 +143,9 @@ module Beaker
       else
         if string.respond_to?( :encode )
           # We're running in >= 1.9 and we'll need to convert
-          # Remove invalide and undefined UTF-8 character encodings
-          string.encode('UTF-8', 'binary', :invalid => :replace, :undef => :replace, :replace => '')
+          # Remove invalid and undefined UTF-8 character encodings
+          encoding = Encoding ? Encoding.default_external : "UTF-8"
+          return string.encode(encoding, string.encoding, :invalid => :replace, :undef => :replace, :replace => '')
         else
           # We're running 1.8, do nothing
           string

--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -33,8 +33,9 @@ module Beaker
     def convert string
       if string.respond_to?( :encode )
         # We're running in >= 1.9 and we'll need to convert
-        # Remove invalide and undefined UTF-8 character encodings
-        return string.encode('UTF-8', 'binary', :invalid => :replace, :undef => :replace, :replace => '')
+        # Remove invalid and undefined UTF-8 character encodings
+        encoding = Encoding ? Encoding.default_external : "UTF-8"
+        return string.encode(encoding, string.encoding, :invalid => :replace, :undef => :replace, :replace => '')
       else
         # We're running in < 1.9 and Ruby doesn't care
         return string


### PR DESCRIPTION
- seems to be an issue with string encoding
- ensure that we convert from current encoding to utf-8, doesn't mangle
  utf-8 strings and correctly converts binary strings
