### PR TITLE
(QENG-6) Beaker DSL `scp_*` commands print the options hash as if...

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -207,14 +207,14 @@ module Beaker
     end
 
     def do_scp_to source, target, options
-      @logger.debug "localhost $ scp #{source} #{@name}:#{target} #{options.to_s}"
+      @logger.debug "localhost $ scp #{source} #{@name}:#{target}"
       result = connection.scp_to(source, target, options, $dry_run)
       return result
     end
 
     def do_scp_from source, target, options
 
-      @logger.debug "localhost $ scp #{@name}:#{source} #{target} #{options.to_s}"
+      @logger.debug "localhost $ scp #{@name}:#{source} #{target}"
       result = connection.scp_from(source, target, options, $dry_run)
       return result
     end


### PR DESCRIPTION
... it were executed on the command line
- simply remove the option hash from the debug line, it isn't
  appropriate there.
