### PR TITLE
(QENG-912) Beaker 1.14 breaks PE Puppet Acceptance

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -141,11 +141,11 @@ module Beaker
           convert s
         end
       else
-        if string.respond_to?( :encode )
+        if string.respond_to?( :force_encoding )
           # We're running in >= 1.9 and we'll need to convert
           # Remove invalid and undefined UTF-8 character encodings
-          encoding = Encoding ? Encoding.default_external : "UTF-8"
-          return string.encode(encoding, string.encoding, :invalid => :replace, :undef => :replace, :replace => '')
+          string.force_encoding('UTF-8')
+          return string.chars.select{|i| i.valid_encoding?}.join
         else
           # We're running 1.8, do nothing
           string

--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -31,11 +31,11 @@ module Beaker
     end
 
     def convert string
-      if string.respond_to?( :encode )
+      if string.respond_to?( :force_encoding )
         # We're running in >= 1.9 and we'll need to convert
         # Remove invalid and undefined UTF-8 character encodings
-        encoding = Encoding ? Encoding.default_external : "UTF-8"
-        return string.encode(encoding, string.encoding, :invalid => :replace, :undef => :replace, :replace => '')
+        string.force_encoding('UTF-8')
+        return string.chars.select{|i| i.valid_encoding?}.join
       else
         # We're running in < 1.9 and Ruby doesn't care
         return string

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'spec_helper'
 
 module Beaker
@@ -5,6 +6,23 @@ module Beaker
     let(:my_io)  { MockIO.new                         }
     let(:logger) { Logger.new(my_io, :quiet => true)  }
 
+
+    context '#convert' do
+      let(:valid_utf8)  { "/etc/puppet/modules\n├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)\n├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)\n└── jimmy-thelock (\e[0;36mv1.0.0\e[0m)\n" }
+      let(:invalid_utf8) {"/etc/puppet/modules\n├── jimmy-appleseed (\e[0;36mv1.1.0\e[0m)\n├── jimmy-crakorn (\e[0;36mv0.4.0\e[0m)\n└── jimmy-thelock (\e[0;36mv1.0.0\e[0m)\xAD\n"}
+
+      it 'preserves valid utf-8 strings' do
+        expect( logger.convert(valid_utf8) ).to be === valid_utf8
+      end
+      it 'strips out invalid utf-8 characters' do
+        #this is 1.9 behavior only
+        if RUBY_VERSION.to_f >= 1.9
+          expect( logger.convert(invalid_utf8) ).to be === valid_utf8
+        else
+          pending "not supported in ruby 1.8 (using #{RUBY_VERSION})"
+        end
+      end
+    end
 
     context 'new' do
       it 'does not duplicate STDOUT when directly passed to it' do


### PR DESCRIPTION
- was too conservative in removing non utf-8 compliant characters -
  ended up removing compliant characters along with undef/invalid
  character codes
- tested locally and it preserved messages like:
  /etc/puppet/modules
  ├── jimmy-appleseed (v1.1.0)
  ├── jimmy-crakorn (v0.4.0)
  └── jimmy-thelock (v1.0.0)
- correctly removed actual undef/invalid characters so that string
  methods can be run (ie, split, gsub)
