### PR TITLE
(QENG-923) Ensure @codename is set if platform string has codename

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -63,6 +63,7 @@ module Beaker
 
       if codename_version_hash
         if codename_version_hash[version]
+          @codename = version
           @version = codename_version_hash[version]
         else
           version = version.delete('.')

--- a/spec/beaker/platform_spec.rb
+++ b/spec/beaker/platform_spec.rb
@@ -36,11 +36,24 @@ module Beaker
 
         it "sets codename to nil" do
           @name = "centos-6.5-x86_64"
-          expect{ platform.codename }.to be { nil }
+          expect(platform.codename).to be_nil
         end
 
       end
 
+      describe "platforms with version and codename" do
+        it "intializes both version and codename if given version" do
+          @name = "debian-7-x86_64"
+          expect(platform.version).to eq('7')
+          expect(platform.codename).to eq('wheezy')
+        end
+
+        it "intializes both version and codename if given codename" do
+          @name = "debian-wheezy-x86_64"
+          expect(platform.version).to eq('7')
+          expect(platform.codename).to eq('wheezy')
+        end
+      end
     end
 
     context 'to_array' do


### PR DESCRIPTION
Beaker 1.14.0 and up has a change to Beaker::Platform which ensures that
@version and @codename is set if the platform string contains the
version number, and that @version is set if platform string contains the
codename, but it fails to set the @codename in this later case.

Puppet currently has debian/ubuntu configs checked (used in ci) which
use platform strings of the form debian-wheezy-x86_64. We could change
these, but it looks like the intention of the Beaker::Platform object is
to provide @version and @codename (where codenames are used).

This patch ensures that @codename is set along with @version in these
cases.
