### PR TITLE
(QENG-927) Beaker does not honor --fail-mode always fails fast

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -90,7 +90,7 @@ module Beaker
         rescue => e
           #post acceptance on failure
           #run post-suite if we are in fail-slow mode
-          if @options[:fail_mode] =~ /slow/
+          if @options[:fail_mode].to_s =~ /slow/
             run_suite(:post_suite)
           end
           raise e
@@ -101,7 +101,7 @@ module Beaker
       #cleanup phase
       rescue => e
         #cleanup on error
-        if @options[:preserve_hosts] =~ /(never)/
+        if @options[:preserve_hosts].to_s =~ /(never)/
           @logger.notify "Cleanup: cleaning up after failed run"
           if @network_manager
             @network_manager.cleanup
@@ -114,7 +114,7 @@ module Beaker
         exit 1
       else
         #cleanup on success
-        if @options[:preserve_hosts] =~ /(never)|(onfail)/
+        if @options[:preserve_hosts].to_s =~ /(never)|(onfail)/
           @logger.notify "Cleanup: cleaning up after successful run"
           if @network_manager
             @network_manager.cleanup

--- a/lib/beaker/junit.xsl
+++ b/lib/beaker/junit.xsl
@@ -75,12 +75,13 @@
             <xsl:variable name="testsuite_name"><xsl:value-of select="@name"/></xsl:variable>
 
             <xsl:variable name="testsuite_name_safe" select="translate($testsuite_name,'.','_')" />
-            <xsl:variable name="testsuite_tests"><xsl:value-of select="@tests"/></xsl:variable>
+            <xsl:variable name="testsuite_attempted"><xsl:value-of select="@tests"/></xsl:variable>
             <xsl:variable name="testsuite_errors"><xsl:value-of select="@errors"/></xsl:variable>
             <xsl:variable name="testsuite_failures"><xsl:value-of select="@failures"/></xsl:variable>
             <xsl:variable name="testsuite_time"><xsl:value-of select="@time"/></xsl:variable>
             <xsl:variable name="testsuite_skip"><xsl:value-of select="@skip"/></xsl:variable>
             <xsl:variable name="testsuite_pending"><xsl:value-of select="@pending"/></xsl:variable>
+            <xsl:variable name="testsuite_total"><xsl:value-of select="@total"/></xsl:variable>
             <xsl:variable name="testsuite_panel_type">
               <xsl:choose>
                 <xsl:when test="$testsuite_errors > 0 or $testsuite_failures > 0">danger</xsl:when>
@@ -103,7 +104,7 @@
                       <div class="col-md-2">
                       </div>
                       <div class="col-md-2">
-                        <h4>Total: <xsl:value-of select="$testsuite_tests" /></h4>
+                        <h4>Attempted: <xsl:value-of select="$testsuite_attempted" /></h4>
                       </div>
                       <div class="col-md-2">
                         <h4>Failed: <xsl:value-of select="$testsuite_errors + $testsuite_failures" /></h4>
@@ -113,6 +114,9 @@
                       </div>
                       <div class="col-md-2">
                         <h4>Pending: <xsl:value-of select="$testsuite_pending" /></h4>
+                      </div>
+                      <div class="col-md-2">
+                        <h4>Total: <xsl:value-of select="$testsuite_total" /></h4>
                       </div>
                     </div> <!-- row -->
                   </a>

--- a/spec/beaker/test_case_spec.rb
+++ b/spec/beaker/test_case_spec.rb
@@ -84,6 +84,16 @@ module Beaker
         testcase.should_receive( :log_and_fail_test ).once.with(kind_of(Timeout::Error))
         testcase.run_test
       end
+
+      it 'correctly handles CommandFailure' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write "raise Host::CommandFailure"
+        end
+        @path = path
+        testcase.should_receive( :log_and_fail_test ).once.with(kind_of(Host::CommandFailure))
+        testcase.run_test
+      end
     end
 
   end

--- a/spec/beaker/test_suite_spec.rb
+++ b/spec/beaker/test_suite_spec.rb
@@ -13,18 +13,89 @@ module Beaker
       let(:sh_test)  { File.expand_path(test_dir + '/my_shell_file.sh')   }
 
       it 'fails without test files' do
-        expect { Beaker::TestSuite.new 'name', 'hosts',
-                  Hash.new, :stop_on_error }.to raise_error
+        expect { Beaker::TestSuite.new('name', 'hosts', Hash.new, Time.now, :stop_on_error) }.to raise_error
       end
 
       it 'includes specific files as test file when explicitly passed' do
         @files = [ rb_test ]
-        ts = Beaker::TestSuite.new 'name', 'hosts', options,
-                                             :stop_on_error
+        ts = Beaker::TestSuite.new('name', 'hosts', options, Time.now, :stop_on_error)
 
         expect { ts.instance_variable_get(:@test_files).
                   include? rb_test }.to be_true
       end
+
+    end
+
+    context 'run', :use_fakefs => true do
+
+      let( :options )     { make_opts.merge({ :logger => double().as_null_object, 'name' => create_files(@files), :log_dir => '.' }) }
+      let(:broken_script) { "raise RuntimeError" }
+      let(:fail_script)   { "raise Beaker::DSL::Outcomes::FailTest" }
+      let(:okay_script)   { "true" }
+      let(:rb_test)       { 'my_ruby_file.rb'     }
+      let(:pl_test)       { '/my_perl_file.pl'    }
+      let(:sh_test)       { '/my_shell_file.sh'   }
+
+      it 'fails fast if fail_mode != :slow and runtime error is raised' do
+        Logger.stub('new')
+        @files = [ rb_test, pl_test, sh_test]
+        File.open(rb_test, 'w') { |file| file.write(broken_script) }
+        File.open(pl_test, 'w') { |file| file.write(okay_script) }
+        File.open(sh_test, 'w') { |file| file.write(okay_script) }
+
+        ts = Beaker::TestSuite.new( 'name', 'hosts', options, Time.now, :stop )
+        tsr = ts.instance_variable_get( :@test_suite_results )
+        tsr.stub(:write_junit_xml).and_return( true )
+        tsr.stub(:summarize).and_return( true )
+
+        ts.run
+        expect( tsr.errored_tests ).to be === 1
+        expect( tsr.failed_tests ).to be === 0
+        expect( tsr.test_count ).to be === 1
+        expect( tsr.passed_tests).to be === 0
+
+      end
+
+      it 'fails fast if fail_mode != :slow and fail test is raised' do
+        Logger.stub('new')
+        @files = [ rb_test, pl_test, sh_test]
+        File.open(rb_test, 'w') { |file| file.write(fail_script) }
+        File.open(pl_test, 'w') { |file| file.write(okay_script) }
+        File.open(sh_test, 'w') { |file| file.write(okay_script) }
+
+        ts = Beaker::TestSuite.new( 'name', 'hosts', options, Time.now, :stop )
+        tsr = ts.instance_variable_get( :@test_suite_results )
+        tsr.stub(:write_junit_xml).and_return( true )
+        tsr.stub(:summarize).and_return( true )
+
+        ts.run
+        expect( tsr.errored_tests ).to be === 0
+        expect( tsr.failed_tests ).to be === 1
+        expect( tsr.test_count ).to be === 1
+        expect( tsr.passed_tests).to be === 0
+
+      end
+
+      it 'fails slow if fail_mode = :slow, even if a test fails and there is a runtime error' do
+        Logger.stub('new')
+        @files = [ rb_test, pl_test, sh_test]
+        File.open(rb_test, 'w') { |file| file.write(broken_script) }
+        File.open(pl_test, 'w') { |file| file.write(fail_script) }
+        File.open(sh_test, 'w') { |file| file.write(okay_script) }
+
+        ts = Beaker::TestSuite.new( 'name', 'hosts', options, Time.now, :slow )
+        tsr = ts.instance_variable_get( :@test_suite_results )
+        tsr.stub(:write_junit_xml).and_return( true )
+        tsr.stub(:summarize).and_return( true )
+
+        ts.run
+        expect( tsr.errored_tests ).to be === 1
+        expect( tsr.failed_tests ).to be === 1
+        expect( tsr.test_count ).to be === 3
+        expect( tsr.passed_tests).to be === 1
+
+      end
+
 
     end
 


### PR DESCRIPTION
- bug comes from regex comparison with a symbol not being coerced to a
  string in ruby 1.8, simple adding a 'to_s' resolves this
