### PR TITLE
(QENG-968) automate cleanup of zombie ec2 beaker instances generated by jenkins smoketests

### DIFF
--- a/lib/beaker/options/hosts_file_parser.rb
+++ b/lib/beaker/options/hosts_file_parser.rb
@@ -12,12 +12,16 @@ module Beaker
       #
       # @return [OptionsHash] The contents of the hosts file as an OptionsHash
       # @raise [ArgumentError] Raises if hosts_file_path is not a path to a file, or is not a valid YAML file
-      def self.parse_hosts_file(hosts_file_path)
+      def self.parse_hosts_file(hosts_file_path = nil)
+        host_options = Beaker::Options::OptionsHash.new
+        host_options['HOSTS'] ||= {}
+        unless hosts_file_path
+           return host_options
+        end
         hosts_file_path = File.expand_path(hosts_file_path)
         unless File.exists?(hosts_file_path)
-          raise ArgumentError, "Required host file '#{hosts_file_path}' does not exist!"
+          raise ArgumentError, "Host file '#{hosts_file_path}' does not exist!"
         end
-        host_options = Beaker::Options::OptionsHash.new
         begin
           host_options = host_options.merge(YAML.load_file(hosts_file_path))
         rescue Psych::SyntaxError => e
@@ -25,7 +29,6 @@ module Beaker
         end
 
         # Make sure the roles array is present for all hosts
-        host_options['HOSTS'] ||= {}
         host_options['HOSTS'].each_key do |host|
           host_options['HOSTS'][host]['roles'] ||= []
         end

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -64,7 +64,6 @@ module Beaker
           :log_level           => 'verbose',
           :trace_limit         => 10,
           :"master-start-curl-retries" => 0,
-          :hosts_file          => 'sample.cfg',
           :options_file        => nil,
           :type                => 'pe',
           :provision           => true,

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Beaker
   describe Vagrant do
-    let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
+    let( :options ) { make_opts.merge({ 'logger' => double().as_null_object, :hosts_file => 'sample.cfg' }) }
     let( :vagrant ) { Beaker::Vagrant.new( @hosts, options ) }
 
     before :each do

--- a/spec/beaker/options/hosts_file_parser_spec.rb
+++ b/spec/beaker/options/hosts_file_parser_spec.rb
@@ -20,6 +20,11 @@ module Beaker
         expect(config['consoleport']).to be === 443
       end
 
+      it "returns empty configuration when no file provided" do
+        FakeFS.deactivate!
+        expect(parser.parse_hosts_file()).to be === { :HOSTS => {} }
+      end
+
       it "raises an error on no file found" do
         FakeFS.deactivate!
         expect{parser.parse_hosts_file("not a valid path")}.to raise_error(ArgumentError)


### PR DESCRIPTION
- add support to aws_sdk hypervisor to kill zombies that have alive
  longer than a given amount of hours
- make it possible to run beaker without a hosts_file, thus making it a
  script executor
