### PR TITLE
(QENG-819) stderr collected for each testcase is incorrect...

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -4,6 +4,10 @@ module Beaker
     # to a given destination (be it a string or file)
     #
   class Logger
+
+    #The results of the most recently run command
+    attr_accessor :last_result
+
     NORMAL         = "\e[00;00m"
     BRIGHT_NORMAL  = "\e[00;01m"
     BLACK          = "\e[00;30m"
@@ -65,6 +69,9 @@ module Beaker
       else
         @log_level = :verbose
       end
+
+      @last_result = nil
+
       @destinations = []
 
       dests = args

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -94,6 +94,7 @@ module Beaker
       @ssh.loop
 
       result.finalize!
+      @logger.last_result = result
       result
     end
 

--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -55,6 +55,9 @@ module Beaker
     #The full log for this test
     attr_accessor :sublog
 
+    #The result for the last command run
+    attr_accessor :last_result
+
     # A Hash of 'product name' => 'version installed', only set when
     # products are installed via git or PE install steps. See the 'git' or
     # 'pe' directories within 'ROOT/setup' for examples.
@@ -121,6 +124,7 @@ module Beaker
       class << self
         def run_test
           @logger.start_sublog
+          @logger.last_result = nil
           @runtime = Benchmark.realtime do
             begin
               test = File.read(path)
@@ -145,6 +149,7 @@ module Beaker
             end
           end
           @sublog = @logger.get_sublog
+          @last_result = @logger.last_result
           return self
         end
 

--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -240,9 +240,9 @@ module Beaker
               item.add_child(stdout)
             end
 
-            if test.stderr then
+            if test.last_result and test.last_result.stderr and not test.last_result.stderr.empty? then
               stderr = Nokogiri::XML::Node.new('system-err', doc)
-              stderr.add_child(stderr.document.create_cdata(strip_color_codes(test.stderr)))
+              stderr.add_child(stderr.document.create_cdata(strip_color_codes(test.last_result.stderr)))
               item.add_child(stderr)
             end
 


### PR DESCRIPTION
...(as seen in beaker xml output)
- keep track of the last result generated through the ssh connection
- add the last stderr to the junit xml output
- clear the collected last result before each test case
