### PR TITLE
(QENG-967) Disable iptables on el hosts bringup.

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -91,6 +91,9 @@ module Beaker
       if @options[:package_proxy]
         package_proxy(@hosts, @options)
       end
+      if @options[:disable_iptables]
+        disable_iptables @hosts, @options
+      end
     end
 
     #Default validation steps to be run for a given hypervisor

--- a/lib/beaker/hypervisor/google_compute.rb
+++ b/lib/beaker/hypervisor/google_compute.rb
@@ -83,7 +83,6 @@ module Beaker
         host['user'] = 'google_compute'
 
         disable_se_linux(host, @options)
-        disable_iptables(host, @options)
         copy_ssh_to_root(host, @options)
         enable_root_login(host, @options)
         host['user'] = default_user

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -114,6 +114,7 @@ module Beaker
           :timeout              => 300,
           :fail_mode            => 'slow',
           :timesync             => false,
+          :disable_iptables     => true,
           :repo_proxy           => false,
           :package_proxy        => false,
           :add_el_extras        => false,

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -61,6 +61,27 @@ module Beaker
       expect( hypervisor.create( 'blimpy', [], make_opts() ) ).to be === blimpy
     end
 
+    context "#configure" do
+      let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
+      let( :hosts ) { make_hosts( { :platform => 'el-5' } ) }
+      let( :hypervisor ) { Beaker::Hypervisor.new( hosts, options ) }
+
+      context "if :disable_iptables option set false" do
+        it "does not call disable_iptables" do
+          options[:disable_iptables] = false
+          hypervisor.should_receive( :disable_iptables ).never
+          hypervisor.configure
+        end
+      end
+
+      context "if :disable_iptables option set true" do
+        it "calls disable_iptables once" do
+          hypervisor.should_receive( :disable_iptables ).exactly( 1 ).times
+          hypervisor.configure
+        end
+      end
+
+    end
 
   end
 end


### PR DESCRIPTION
Also fixes bug in `disable_iptables` where per-array-element was invoking wrong
method. Looks like `disable_iptables` was originally copied from
`copy_ssh_to_root`

Also adds rspec for Beaker::Hypervisor.configure

Signed-off-by: Wayne wayne@puppetlabs.com
