### PR TITLE
(QENG-1340) Add GH pull request refspec to install_from_git

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -115,7 +115,7 @@ module Beaker
           commands = ["cd #{target}",
                       "remote rm origin",
                       "remote add origin #{repo}",
-                      "fetch origin",
+                      "fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*",
                       "clean -fdx",
                       "checkout -f #{rev}"]
           on host, commands.join(" && git ")


### PR DESCRIPTION
- When testing out Jenkins job configuration tweaks that must coincide with source
  changes, it can be useful to have Beaker be aware of the GitHub refspec.  This
  allows SHA references to GitHub commits / PRs that have not yet been merged, 
  without having to jump through a number of additional job configurations to gain
  access to the appropriate commits.
- Note that this does have performance implications, as performing a fetch will take
  longer on the first time.
