### PR TITLE
(QENG-1032) Fix for tests without a master host

### DIFF
--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -149,7 +149,7 @@ module Beaker
           if not master.empty? and master.length == 1
             default_host_name = master[0]
           elsif hosts.length == 1
-            default_host_name = hosts[0].keys[0]
+            default_host_name = hosts.keys[0]
           end
           if default_host_name
             hosts[default_host_name][:roles] << 'default'

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -200,6 +200,12 @@ module Beaker
           expect( hosts[:node1][:roles].include?('default') ).to be === true
         end
 
+        it "makes a single non-master node default" do
+          @roles = [ ["database", "dashboard", "agent"] ]
+          parser.set_default_host!(node1)
+          expect( hosts[:node1][:roles].include?('default') ).to be === true
+        end
+
         it "raises an error if two nodes are defined as default" do
           @roles = [ ["master", "default"], ["default"] ]
           expect{ parser.set_default_host!(hosts) }.to raise_error(ArgumentError)


### PR DESCRIPTION
If a master role is not defined in the current test's config, then
setting a default node will fail. The code is expecting "hosts" to be a
list, but it is actually a hash. This commit fixes this issue and
adds a new spec test to validate a non-master single node is set as
default.
