### PR TITLE
(QENG-1037) Install from git should accept depth

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -101,14 +101,25 @@ module Beaker
       #
       # @see #find_git_repo_versions
       def install_from_git host, path, repository
-        name   = repository[:name]
-        repo   = repository[:path]
-        rev    = repository[:rev]
-        target = "#{path}/#{name}"
+        name          = repository[:name]
+        repo          = repository[:path]
+        rev           = repository[:rev]
+        depth         = repository[:depth]
+        depth_branch  = repository[:depth_branch]
+        target        = "#{path}/#{name}"
+
+        if (depth_branch.nil?)
+          depth_branch = rev
+        end
+
+        clone_cmd = "git clone #{repo} #{target}"
+        if (depth)
+          clone_cmd = "git clone --branch #{depth_branch} --depth #{depth} #{repo} #{target}"
+        end
 
         step "Clone #{repo} if needed" do
           on host, "test -d #{path} || mkdir -p #{path}"
-          on host, "test -d #{target} || git clone #{repo} #{target}"
+          on host, "test -d #{target} || #{clone_cmd}"
         end
 
         step "Update #{name} and check out revision #{rev}" do

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -87,6 +87,47 @@ describe ClassMixedWithDSLInstallUtils do
 
       subject.install_from_git( host, path, repo )
     end
+
+    it 'allows a checkout depth of 1' do
+      repo   = { :name => 'puppet',
+                 :path => 'git://my.server.net/puppet.git',
+                 :rev => 'master',
+                 :depth => 1 }
+
+      path   = '/path/to/repos'
+      cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:rev]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
+      host   = { 'platform' => 'debian' }
+      logger = double.as_null_object
+      subject.should_receive( :logger ).exactly( 3 ).times.and_return( logger )
+      subject.should_receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
+      # this is the the command we want to test
+      subject.should_receive( :on ).with( host, cmd ).exactly( 1 ).times
+      subject.should_receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin && git clean -fdx && git checkout -f #{repo[:rev]}" ).exactly( 1 ).times
+      subject.should_receive( :on ).with( host, "cd #{path}/#{repo[:name]} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi" ).exactly( 1 ).times
+
+      subject.install_from_git( host, path, repo )
+    end
+
+    it 'allows a checkout depth with a rev from a specific branch' do
+      repo   = { :name => 'puppet',
+                 :path => 'git://my.server.net/puppet.git',
+                 :rev => 'a2340acddadfeafd234230faf',
+                 :depth => 50,
+                 :depth_branch => 'master' }
+
+      path   = '/path/to/repos'
+      cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:depth_branch]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
+      host   = { 'platform' => 'debian' }
+      logger = double.as_null_object
+      subject.should_receive( :logger ).exactly( 3 ).times.and_return( logger )
+      subject.should_receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
+      # this is the the command we want to test
+      subject.should_receive( :on ).with( host, cmd ).exactly( 1 ).times
+      subject.should_receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin && git clean -fdx && git checkout -f #{repo[:rev]}" ).exactly( 1 ).times
+      subject.should_receive( :on ).with( host, "cd #{path}/#{repo[:name]} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi" ).exactly( 1 ).times
+
+      subject.install_from_git( host, path, repo )
+    end
    end
 
   describe 'sorted_hosts' do


### PR DESCRIPTION
When installing from larger repositories, being able to specify depth can cut
the time of git checkout in half. This becomes especially helpful when you are
checking out multiple repositories.
Due to the older git on some of the templates, this provides the older
--branch name --depth 1 commands, which means when using depth, one should
ensure the rev passed is a branch and not a single commit. Alternatively one
can add depth_branch => 'name' to repository and have that used instead of rev.
