### PR TITLE
Revert "(QENG-997) Add PE installer answer for jvm puppet."

### DIFF
--- a/lib/beaker/answers/version34.rb
+++ b/lib/beaker/answers/version34.rb
@@ -4,11 +4,7 @@ module Beaker
   module Answers
     module Version34
       def self.answers(hosts, master_certname, options)
-        master = only_host_with_role(hosts, 'master')
-
         the_answers = Version32.answers(hosts, master_certname, options)
-        the_answers[master.name][:q_jvm_puppetmaster] = 'y'
-
         return the_answers
       end
     end

--- a/spec/beaker/answers_spec.rb
+++ b/spec/beaker/answers_spec.rb
@@ -73,13 +73,6 @@ module Beaker
           expect( host[:answers] ).to be === answers[host.name]
         end
       end
-
-      it 'should add q_jvm_puppetmaster to the master answers' do
-        @ver = '3.4'
-        answers = subject.answers( hosts, master_certname, options )
-        expect( subject.answers( hosts, master_certname, options )['vm1']).to include :q_jvm_puppetmaster
-      end
-
     end
 
     describe Version32 do


### PR DESCRIPTION
This reverts commit b06b6313de24da82a031b6b04dc95042812b4445.

The installer doesn't actually function with this answer set, so we certainly
shouldn't be making it the default.
