### PR TITLE
(QENG-1086) The master-start-curl-retries is preset to...

### DIFF
--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -19,7 +19,6 @@ module Unix
       h.merge({
         'user'          => 'root',
         'group'         => 'pe-puppet',
-        'master-start-curl-retries' => 120,
         'jvm-puppet-confdir' => '/etc/puppetlabs/jvm-puppet/conf.d',
         'puppetservice'    => 'pe-httpd',
         'puppetpath'       => '/etc/puppetlabs/puppet',
@@ -40,7 +39,6 @@ module Unix
       h.merge({
         'user'              => 'root',
         'group'             => 'puppet',
-        'master-start-curl-retries' => 120,
         'jvm-puppet-confdir' => '/etc/jvm-puppet/conf.d',
         'puppetservice'     => 'puppetmaster',
         'puppetpath'        => '/etc/puppet',

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -97,7 +97,7 @@ module Beaker
           :forge_host           => 'vulcan-acceptance.delivery.puppetlabs.net',
           :log_level            => 'verbose',
           :trace_limit          => 10,
-          :"master-start-curl-retries" => 0,
+          :"master-start-curl-retries" => 120,
           :options_file         => nil,
           :type                 => 'pe',
           :provision            => true,


### PR DESCRIPTION
...0, which causes default hosts not to retry verifying a bounced master.
- host value being overwritten by default presets
