### PR TITLE
(QENG-1090) beaker: exception when waiting for instance running in ec2

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -223,12 +223,16 @@ module Beaker
         # exponential backoff for each poll.
         # TODO: should probably be a in a shared method somewhere
         for tries in 1..10
-          if instance.status == status
-            # Always sleep, so the next command won't cause a throttle
-            backoff_sleep(tries)
-            break
-          elsif tries == 10
-            raise "Instance never reached state #{status}"
+          begin
+            if instance.status == status
+              # Always sleep, so the next command won't cause a throttle
+              backoff_sleep(tries)
+              break
+            elsif tries == 10
+              raise "Instance never reached state #{status}"
+            end
+          rescue AWS::EC2::Errors::InvalidInstanceID::NotFound => e
+            @logger.debug("Instance #{name} not yet available (#{e})")
           end
           backoff_sleep(tries)
         end


### PR DESCRIPTION
- correctly capture AWS::EC2::Errors::InvalidInstanceID::NotFound when
  checking status of newly created instance, deal with it as another
  case that requires a retry
