### PR TITLE
Adding a utility method for configuring the puppet.conf file

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -653,6 +653,52 @@ module Beaker
         end
         nil
       end
+      
+      # Configure puppet.conf on the given host based upon a provided hash
+      # @example will configure /etc/puppet.conf on the puppet master.
+      #   config = { 
+      #     'main' => {
+      #       'server'   => 'testbox.test.local',
+      #       'certname' => 'testbox.test.local',
+      #       'logdir'   => '/var/log/puppet',
+      #       'vardir'   => '/var/lib/puppet',
+      #       'ssldir'   => '/var/lib/puppet/ssl',
+      #       'rundir'   => '/var/run/puppet'
+      #     },
+      #     'agent' => {
+      #       'environment' => 'dev'
+      #     }
+      #   }
+      #   configure_puppet(master, config)
+      #
+      # @api dsl
+      # @return nil
+      def configure_puppet(host, opts = {})
+          if host['platform'] =~ /windows/
+            puppet_conf = "#{host['puppetpath']}\\puppet.conf"
+            powershell_pre = "powershell.exe -InputFormat None -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass"
+            conf_data = ''
+            opts.each do |section,options|
+              conf_data << "[#{section}]`n"
+              options.each do |option,value|
+                conf_data << "#{option}=#{value}`n"
+              end
+              conf_data << "`n"
+            end
+            on host, "#{powershell_pre} -Command \"\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text\""
+          else
+            puppet_conf = "#{host['puppetpath']}/puppet.conf"
+            conf_data = ''
+            opts.each do |section,options|
+              conf_data << "[#{section}]\n"
+              options.each do |option,value|
+                conf_data << "#{option}=#{value}\n"
+              end
+              conf_data << "\n"
+            end
+            on host, "echo \"#{conf_data}\" > #{puppet_conf}"
+          end
+      end
 
       # Installs Puppet and dependencies using rpm
       #

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -676,7 +676,6 @@ module Beaker
       def configure_puppet(host, opts = {})
           if host['platform'] =~ /windows/
             puppet_conf = "#{host['puppetpath']}\\puppet.conf"
-            powershell_pre = "powershell.exe -InputFormat None -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass"
             conf_data = ''
             opts.each do |section,options|
               conf_data << "[#{section}]`n"
@@ -685,7 +684,7 @@ module Beaker
               end
               conf_data << "`n"
             end
-            on host, "#{powershell_pre} -Command \"\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text\""
+            on host, powershell("\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text")
           else
             puppet_conf = "#{host['puppetpath']}/puppet.conf"
             conf_data = ''

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -653,10 +653,10 @@ module Beaker
         end
         nil
       end
-      
+
       # Configure puppet.conf on the given host based upon a provided hash
       # @example will configure /etc/puppet.conf on the puppet master.
-      #   config = { 
+      #   config = {
       #     'main' => {
       #       'server'   => 'testbox.test.local',
       #       'certname' => 'testbox.test.local',
@@ -686,6 +686,51 @@ module Beaker
               conf_data << "`n"
             end
             on host, "#{powershell_pre} -Command \"\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text\""
+          else
+            puppet_conf = "#{host['puppetpath']}/puppet.conf"
+            conf_data = ''
+            opts.each do |section,options|
+              conf_data << "[#{section}]\n"
+              options.each do |option,value|
+                conf_data << "#{option}=#{value}\n"
+              end
+              conf_data << "\n"
+            end
+            on host, "echo \"#{conf_data}\" > #{puppet_conf}"
+          end
+      end
+
+      # Configure puppet.conf on the given host based upon a provided hash
+      # @example will configure /etc/puppet.conf on the puppet master.
+      #   config = {
+      #     'main' => {
+      #       'server'   => 'testbox.test.local',
+      #       'certname' => 'testbox.test.local',
+      #       'logdir'   => '/var/log/puppet',
+      #       'vardir'   => '/var/lib/puppet',
+      #       'ssldir'   => '/var/lib/puppet/ssl',
+      #       'rundir'   => '/var/run/puppet'
+      #     },
+      #     'agent' => {
+      #       'environment' => 'dev'
+      #     }
+      #   }
+      #   configure_puppet(master, config)
+      #
+      # @api dsl
+      # @return nil
+      def configure_puppet(host, opts = {})
+          if host['platform'] =~ /windows/
+            puppet_conf = "#{host['puppetpath']}\\puppet.conf"
+            conf_data = ''
+            opts.each do |section,options|
+              conf_data << "[#{section}]`n"
+              options.each do |option,value|
+                conf_data << "#{option}=#{value}`n"
+              end
+              conf_data << "`n"
+            end
+            on host, powershell("\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text")
           else
             puppet_conf = "#{host['puppetpath']}/puppet.conf"
             conf_data = ''

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -699,51 +699,6 @@ module Beaker
           end
       end
 
-      # Configure puppet.conf on the given host based upon a provided hash
-      # @example will configure /etc/puppet.conf on the puppet master.
-      #   config = {
-      #     'main' => {
-      #       'server'   => 'testbox.test.local',
-      #       'certname' => 'testbox.test.local',
-      #       'logdir'   => '/var/log/puppet',
-      #       'vardir'   => '/var/lib/puppet',
-      #       'ssldir'   => '/var/lib/puppet/ssl',
-      #       'rundir'   => '/var/run/puppet'
-      #     },
-      #     'agent' => {
-      #       'environment' => 'dev'
-      #     }
-      #   }
-      #   configure_puppet(master, config)
-      #
-      # @api dsl
-      # @return nil
-      def configure_puppet(host, opts = {})
-          if host['platform'] =~ /windows/
-            puppet_conf = "#{host['puppetpath']}\\puppet.conf"
-            conf_data = ''
-            opts.each do |section,options|
-              conf_data << "[#{section}]`n"
-              options.each do |option,value|
-                conf_data << "#{option}=#{value}`n"
-              end
-              conf_data << "`n"
-            end
-            on host, powershell("\$text = \\\"#{conf_data}\\\"; Set-Content -path '#{puppet_conf}' -value \$text")
-          else
-            puppet_conf = "#{host['puppetpath']}/puppet.conf"
-            conf_data = ''
-            opts.each do |section,options|
-              conf_data << "[#{section}]\n"
-              options.each do |option,value|
-                conf_data << "#{option}=#{value}\n"
-              end
-              conf_data << "\n"
-            end
-            on host, "echo \"#{conf_data}\" > #{puppet_conf}"
-          end
-      end
-
       # Installs Puppet and dependencies using rpm
       #
       # @param [Host] host The host to install packages on

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -508,6 +508,30 @@ describe ClassMixedWithDSLInstallUtils do
       end
     end
   end
+  
+  describe 'configure_puppet' do
+    before do
+      subject.stub(:on).and_return(Beaker::Result.new({},''))
+    end
+    context 'on debian' do
+      let(:platform) { 'debian-7-amd64' }
+      let(:host) { make_host('testbox.test.local', :platform => 'debian-7-amd64') }
+      it 'it sets the puppet.conf file to the provided config' do
+        config = { 'main' => {'server' => 'testbox.test.local'} }
+        expect(subject).to receive(:on).with(host, "echo \"[main]\nserver=testbox.test.local\n\n\" > /etc/puppet/puppet.conf")
+        subject.configure_puppet(host, config)
+      end
+    end
+    context 'on windows' do
+      let(:platform) { 'windows-2008R2-amd64' }
+      let(:host) { make_host('testbox.test.local', :platform => 'windows-2008R2-amd64') }
+      it 'it sets the puppet.conf file to the provided config' do
+        config = { 'main' => {'server' => 'testbox.test.local'} }
+        expect(subject).to receive(:on).with(host, "powershell.exe -InputFormat None -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$text = \\\"[main]`nserver=testbox.test.local`n`n\\\"; Set-Content -path '`cygpath -smF 35`/PuppetLabs/puppet/etc\\puppet.conf' -value $text\"")
+        subject.configure_puppet(host, config)
+      end
+    end
+  end
 
   describe 'install_pe' do
 

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -508,7 +508,7 @@ describe ClassMixedWithDSLInstallUtils do
       end
     end
   end
-  
+
   describe 'configure_puppet' do
     before do
       subject.stub(:on).and_return(Beaker::Result.new({},''))
@@ -527,7 +527,10 @@ describe ClassMixedWithDSLInstallUtils do
       let(:host) { make_host('testbox.test.local', :platform => 'windows-2008R2-amd64') }
       it 'it sets the puppet.conf file to the provided config' do
         config = { 'main' => {'server' => 'testbox.test.local'} }
-        expect(subject).to receive(:on).with(host, "powershell.exe -InputFormat None -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command \"$text = \\\"[main]`nserver=testbox.test.local`n`n\\\"; Set-Content -path '`cygpath -smF 35`/PuppetLabs/puppet/etc\\puppet.conf' -value $text\"")
+        expect(subject).to receive(:on) do |host, command|
+          expect(command.command).to eq('powershell.exe')
+          expect(command.args).to eq(" -ExecutionPolicy Bypass -InputFormat None -NoLogo -NoProfile -NonInteractive -Command \"$text = \\\"[main]`nserver=testbox.test.local`n`n\\\"; Set-Content -path '`cygpath -smF 35`/PuppetLabs/puppet/etc\\puppet.conf' -value $text\"")
+        end
         subject.configure_puppet(host, config)
       end
     end
@@ -966,7 +969,3 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 end
-
-
-
-


### PR DESCRIPTION
There are many use cases for this, testing non-standard puppet
installations, testing switching environments etc.