### PR TITLE
Fix bug connecting to windows vagrant host

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -71,6 +71,9 @@ module Beaker
         end
         #replace hostname with ip
         ssh_config = ssh_config.gsub(/#{host.name}/, host['ip']) unless not host['ip']
+        if host['platform'] =~ /windows/
+          ssh_config = ssh_config.gsub(/127\.0\.0\.1/, host['ip']) unless not host['ip']
+        end
         #set the user
         ssh_config = ssh_config.gsub(/User vagrant/, "User #{user}")
         f.write(ssh_config)


### PR DESCRIPTION
When running multiple hosts in vagrant with an linux master and windows
agent it seems that vagrant has difficulty connecting to box when the
ssh_config file contains 127.0.0.1 for the host. This change fixes the
issue by replacing it with the host ip if it has been specified in the
nodeset.

This might need a little more manual testing.
