### PR TITLE
(GH-425) Sleep briefly after killing processes - Docker

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -64,6 +64,7 @@ module Beaker
           @logger.debug("stop container #{container.id}")
           begin
             container.stop
+            sleep 2 # avoid a race condition where the root FS can't unmount
           rescue Excon::Errors::ClientError => e
             @logger.warn("stop of container #{container.id} failed: #{e.response.body}")
           end


### PR DESCRIPTION
This avoids a race condition in which the killed processes haven't
exited by the time we try and unmount the root fs and the call to
container.delete errors.
