### PR TITLE
(QENG-1126) Help FOSS testing flexibility in Beaker-Rspec

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -65,7 +65,13 @@ module Beaker
           found_env_vars[:answers][key] = value if key.to_s =~ /q_/
         end
         found_env_vars[:consoleport] &&= found_env_vars[:consoleport].to_i
-        found_env_vars[:type] = found_env_vars[:is_pe] == 'true' || found_env_vars[:is_pe] == 'yes' ? 'pe' : nil
+        if found_env_vars[:is_pe] == 'true' || found_env_vars[:is_pe] == 'yes'
+          found_env_vars[:type] = 'pe'
+        elsif found_env_vars[:is_pe] == 'false' || found_env_vars[:is_pe] == 'no'
+          found_env_vars[:type] = 'foss'
+        else
+          found_env_vars[:type] = nil
+        end
         found_env_vars[:pe_version_file_win] = found_env_vars[:pe_version_file]
         found_env_vars[:answers].delete_if {|key, value| value.nil? or value.empty? }
         found_env_vars.delete_if {|key, value| value.nil? or value.empty? }


### PR DESCRIPTION
Add logic to allow for IS_PE='no' or 'false' to mean FOSS testing, defaults to nil which means PE, only way to do this outside of host config in Beaker-Rspec
