### PR TITLE
(QENG-1134) Remove 'jvm-puppet' references left in Beaker.

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -571,7 +571,7 @@ module Beaker
         curl_retries = host['master-start-curl-retries'] || options['master-start-curl-retries']
         logger.debug "Setting curl retries to #{curl_retries}"
 
-        if options[:is_jvm_puppet]
+        if options[:is_puppetserver]
           confdir = host.puppet('master')['confdir']
           vardir = host.puppet('master')['vardir']
 
@@ -588,13 +588,13 @@ module Beaker
             end
           end
 
-          jvm_puppet_opts = { "jruby-puppet" => {
+          puppetserver_opts = { "jruby-puppet" => {
             "master-conf-dir" => confdir,
             "master-var-dir" => vardir,
           }}
 
-          jvm_puppet_conf = File.join("#{host['jvm-puppet-confdir']}", "jvm-puppet.conf")
-          modify_tk_config(host, jvm_puppet_conf, jvm_puppet_opts)
+          puppetserver_conf = File.join("#{host['puppetserver-confdir']}", "puppetserver.conf")
+          modify_tk_config(host, puppetserver_conf, puppetserver_opts)
         end
 
         begin

--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -19,7 +19,7 @@ module Unix
       h.merge({
         'user'          => 'root',
         'group'         => 'pe-puppet',
-        'jvm-puppet-confdir' => '/etc/puppetlabs/jvm-puppet/conf.d',
+        'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
         'puppetservice'    => 'pe-httpd',
         'puppetpath'       => '/etc/puppetlabs/puppet',
         'puppetbin'        => '/opt/puppet/bin/puppet',
@@ -39,7 +39,7 @@ module Unix
       h.merge({
         'user'              => 'root',
         'group'             => 'puppet',
-        'jvm-puppet-confdir' => '/etc/jvm-puppet/conf.d',
+        'puppetserver-confdir' => '/etc/puppetserver/conf.d',
         'puppetservice'     => 'puppetmaster',
         'puppetpath'        => '/etc/puppet',
         'puppetvardir'      => '/var/lib/puppet',

--- a/spec/beaker/dsl/ezbake_utils_spec.rb
+++ b/spec/beaker/dsl/ezbake_utils_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 EZBAKE_CONFIG_EXAMPLE= { 
-  :project => 'jvm-puppet',
-  :real_name => 'jvm-puppet',
+  :project => 'puppetserver',
+  :real_name => 'puppetserver',
   :user => 'puppet',
   :group => 'puppet',
-  :uberjar_name => 'jvm-puppet-release.jar',
+  :uberjar_name => 'puppetserver-release.jar',
   :config_files => [],
   :terminus_info => {},
   :debian => { :additional_dependencies => ["puppet (= 3.6.1-puppetlabs1)"], },

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -853,7 +853,7 @@ describe ClassMixedWithDSLHelpers do
       }.to raise_error(RuntimeError, /puppet conf backup failed/)
     end
 
-    describe 'with jvm puppet' do
+    describe 'with puppet-server' do
       let(:default_confdir) { "/etc/puppet" }
       let(:default_vardir) { "/var/lib/puppet" }
 
@@ -862,19 +862,19 @@ describe ClassMixedWithDSLHelpers do
 
       let(:command_line_args) {"--vardir=#{custom_vardir} --confdir=#{custom_confdir}"}
       let(:conf_opts) { {:__commandline_args__ => command_line_args,
-                         :is_jvm_puppet => true}}
+                         :is_puppetserver => true}}
 
-      let(:default_jvm_puppet_opts) {{ "jruby-puppet" => {
+      let(:default_puppetserver_opts) {{ "jruby-puppet" => {
         "master-conf-dir" => default_confdir,
         "master-var-dir" => default_vardir,
       }}}
 
-      let(:custom_jvm_puppet_opts) {{ "jruby-puppet" => {
+      let(:custom_puppetserver_opts) {{ "jruby-puppet" => {
         "master-conf-dir" => custom_confdir,
         "master-var-dir" => custom_vardir,
       }}}
 
-      let(:jvm_puppet_conf) { "/etc/jvm-puppet/conf.d/jvm-puppet.conf" }
+      let(:puppetserver_conf) { "/etc/puppetserver/conf.d/puppetserver.conf" }
       let(:logger) { double }
 
       def stub_post_setup
@@ -893,7 +893,7 @@ describe ClassMixedWithDSLHelpers do
 
       before do
         stub_post_setup
-        subject.stub( :options) .and_return( {:is_jvm_puppet => true})
+        subject.stub( :options) .and_return( {:is_puppetserver => true})
         subject.stub( :modify_tk_config)
         host.stub(:puppet).with('master') .and_return({'confdir' => default_confdir,
                                                        'vardir' => default_vardir})
@@ -901,8 +901,8 @@ describe ClassMixedWithDSLHelpers do
 
       describe 'and command line args passed' do
         it 'modifies SUT trapperkeeper configuration w/ command line args' do
-          subject.should_receive( :modify_tk_config).with(host, jvm_puppet_conf,
-                                                          custom_jvm_puppet_opts)
+          subject.should_receive( :modify_tk_config).with(host, puppetserver_conf,
+                                                          custom_puppetserver_opts)
           subject.with_puppet_running_on(host, conf_opts)
         end
       end
@@ -910,8 +910,8 @@ describe ClassMixedWithDSLHelpers do
       describe 'and no command line args passed' do
         let(:command_line_args) { nil }
         it 'modifies SUT trapperkeeper configuration w/ puppet defaults' do
-          subject.should_receive( :modify_tk_config).with(host, jvm_puppet_conf,
-                                                          default_jvm_puppet_opts)
+          subject.should_receive( :modify_tk_config).with(host, puppetserver_conf,
+                                                          default_puppetserver_opts)
           subject.with_puppet_running_on(host, conf_opts)
         end
       end


### PR DESCRIPTION
Recently the `jvm-puppet` name was changed to `puppet-server`, this patch
addresses that in both `lib/` and `spec/`

Signed-off-by: Wayne wayne@puppetlabs.com
