### PR TITLE
(MAINT) Add --debug option to `apply_manifest_on` helper

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -912,18 +912,25 @@ module Beaker
       #                         path separator character. (The POSIX path separator
       #                         is ‘:’, and the Windows path separator is ‘;’.)
       #
+      # @option opts [String]   :debug (false) If this option exists,
+      #                         the "--debug" command line parameter
+      #                         will be passed to the 'puppet apply' command.
+      #
       # @param [Block] block This method will yield to a block of code passed
       #                      by the caller; this can be used for additional
       #                      validation, etc.
       #
       def apply_manifest_on(host, manifest, opts = {}, &block)
         block_on host do | host |
-
           on_options = {}
           on_options[:acceptable_exit_codes] = Array(opts[:acceptable_exit_codes])
 
           puppet_apply_opts = {}
-          puppet_apply_opts[:verbose] = nil
+          if opts[:debug]
+            puppet_apply_opts[:debug] = nil
+          else
+            puppet_apply_opts[:verbose] = nil
+          end
           puppet_apply_opts[:parseonly] = nil if opts[:parseonly]
           puppet_apply_opts[:trace] = nil if opts[:trace]
           puppet_apply_opts[:parser] = 'future' if opts[:future_parser]

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -618,6 +618,23 @@ describe ClassMixedWithDSLHelpers do
     end
   end
 
+  it 'can set the --debug flag' do
+    subject.stub( :hosts ).and_return( hosts )
+    subject.should_receive( :create_remote_file ).and_return( true )
+    expect( subject ).to receive( :on ).with {|h, command, opts|
+      cmdline = command.cmd_line( h )
+      expect( h ).to be == agent
+      expect( cmdline ).to include('puppet apply')
+      expect( cmdline ).not_to include('--verbose')
+      expect( cmdline ).to include('--debug')
+    }
+    subject.apply_manifest_on(
+      agent,
+      'class { "boo": }',
+      :debug => true,
+    )
+  end
+
   describe "#apply_manifest" do
     it "delegates to #apply_manifest_on with the default host" do
       subject.stub( :hosts ).and_return( hosts )


### PR DESCRIPTION
Before every 'puppet apply' command was executed with --verbose.
Now you can pass `debug: true`, which executes 'puppet apply' with the
--debug flag.
