### PR TITLE
(QENG-1182) Add node to classifier prior to adding pe_repo class

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -390,6 +390,7 @@ module Beaker
         klass = host['platform'].gsub(/-/, '_').gsub(/\./,'')
         klass = "pe_repo::platform::#{klass}"
         on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec /opt/puppet/bin/rake nodeclass:add[#{klass},skip]"
+        on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec /opt/puppet/bin/rake node:add[#{master}]"
         on dashboard, "cd /opt/puppet/share/puppet-dashboard && /opt/puppet/bin/bundle exec /opt/puppet/bin/rake node:addclass[#{master},#{klass}]"
         on master, "puppet agent -t", :acceptable_exit_codes => [0,2]
       end


### PR DESCRIPTION
Prior to this commit, beaker would make the assumption that a node had
already checked into the classifier. This commit changes that by
ensuring that the node is in the classifier before giving it the pe_repo
class.
