### PR TITLE
(QENG-1186) Fix Beaker::DSL:Helpers.puppet_{user,group}

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -476,7 +476,7 @@ module Beaker
       # @note This method assumes puppet is installed on the host.
       #
       def puppet_user(host)
-        return host.puppet('master')['group']
+        return host.puppet('master')['user']
       end
 
       # Return the name of the puppet group.
@@ -486,7 +486,7 @@ module Beaker
       # @note This method assumes puppet is installed on the host.
       #
       def puppet_group(host)
-        return host.puppet('master')['user']
+        return host.puppet('master')['group']
       end
 
       # @!visibility private


### PR DESCRIPTION
Looks like the contents of these methods were mixed upwhen originally written.
Luckily the puppet user is usually the same as the puppet group.

Signed-off-by: Wayne wayne@puppetlabs.com
