### PR TITLE
(QENG-1192) Use hostname specified by hypervisor everywhere.

### DIFF
--- a/lib/beaker/answers.rb
+++ b/lib/beaker/answers.rb
@@ -9,25 +9,24 @@ module Beaker
     #
     # @param [String] version Puppet Enterprise version to generate answer data for
     # @param [Array<Beaker::Host>] hosts An array of host objects.
-    # @param [String] master_certname Hostname of the puppet master.
     # @param [Hash] options options for answer files
     # @option options [Symbol] :type Should be one of :upgrade or :install.
     # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
     #   data.
-    def self.create version, hosts, master_certname, options
+    def self.create version, hosts, options
       case version
       when /\A3\.4/
-        return Version34.new(version, hosts, master_certname, options)
+        return Version34.new(version, hosts, options)
       when /\A3\.[2-3]/
-        return Version32.new(version, hosts, master_certname, options)
+        return Version32.new(version, hosts, options)
       when /\A3\.1/
-        return Version30.new(version, hosts, master_certname, options)
+        return Version30.new(version, hosts, options)
       when /\A3\.0/
-        return Version30.new(version, hosts, master_certname, options)
+        return Version30.new(version, hosts, options)
       when /\A2\.8/
-        return Version28.new(version, hosts, master_certname, options)
+        return Version28.new(version, hosts, options)
       when /\A2\.0/
-        return Version20.new(version, hosts, master_certname, options)
+        return Version20.new(version, hosts, options)
       else
         raise NotImplementedError, "Don't know how to generate answers for #{version}"
       end
@@ -48,15 +47,13 @@ module Beaker
     #
     # @param [String] version Puppet Enterprise version to generate answer data for
     # @param [Array<Beaker::Host>] hosts An array of host objects.
-    # @param [String] master_certname Hostname of the puppet master.
     # @param [Hash] options options for answer files
     # @option options [Symbol] :type Should be one of :upgrade or :install.
     # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
     #   data.
-    def initialize(version, hosts, master_certname, options)
+    def initialize(version, hosts, options)
       @version = version
       @hosts = hosts
-      @master_certname = master_certname
       @options = options
     end
 

--- a/lib/beaker/answers/version28.rb
+++ b/lib/beaker/answers/version28.rb
@@ -7,14 +7,13 @@ module Beaker
     # Return answer data for a host
     #
     # @param [Beaker::Host] host Host to return data for
-    # @param [String] master_certname Hostname of the puppet master.
     # @param [Beaker::Host] master Host object representing the master
     # @param [Beaker::Host] dashboard Host object representing the dashboard
     # @param [Hash] options options for answer files
     # @option options [Symbol] :type Should be one of :upgrade or :install.
     # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
     #   data.
-    def host_answers(host, master_certname, master, dashboard, options)
+    def host_answers(host, master, dashboard, options)
       return nil if host['platform'] =~ /windows/
 
       agent_a = {
@@ -32,19 +31,16 @@ module Beaker
         :q_puppet_enterpriseconsole_install => 'n',
       }
 
+      master_dns_altnames = [master.to_s, master['ip'], 'puppet'].compact.uniq.join(',')
       master_a = {
         :q_puppetmaster_install => 'y',
-        :q_puppetmaster_certname => master_certname,
+        :q_puppetmaster_certname => master,
         :q_puppetmaster_install => 'y',
-        :q_puppetmaster_dnsaltnames => master_certname+",puppet",
+        :q_puppetmaster_dnsaltnames => master_dns_altnames,
         :q_puppetmaster_enterpriseconsole_hostname => dashboard,
         :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),
         :q_puppetmaster_forward_facts => 'y',
       }
-
-      if master['ip']
-        master_a[:q_puppetmaster_dnsaltnames]+=","+master['ip']
-      end
 
       dashboard_user = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_user_email)}'"
       smtp_host = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_host, dashboard)}'"
@@ -113,7 +109,7 @@ module Beaker
       dashboard = only_host_with_role(@hosts, 'dashboard')
       master = only_host_with_role(@hosts, 'master')
       @hosts.each do |h|
-        the_answers[h.name] = host_answers(h, @master_certname, master, dashboard, @options)
+        the_answers[h.name] = host_answers(h, master, dashboard, @options)
         if h[:custom_answers]
           the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
         end

--- a/lib/beaker/answers/version32.rb
+++ b/lib/beaker/answers/version32.rb
@@ -17,7 +17,7 @@ module Beaker
       the_answers = super
       if dashboard != master
         # in 3.2, dashboard needs the master certname
-        the_answers[dashboard.name][:q_puppetmaster_certname] = @master_certname
+        the_answers[dashboard.name][:q_puppetmaster_certname] = master
       end
 
       if @options[:type] == :upgrade && dashboard != database

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -428,8 +428,6 @@ module Beaker
       #
       def do_install hosts, opts = {}
         opts[:type] = opts[:type] || :install
-        hostcert='uname | grep -i sunos > /dev/null && hostname || hostname -s'
-        master_certname = on(master, hostcert).stdout.strip
         pre30database = version_is_less(opts[:pe_ver] || database['pe_ver'], '3.0')
         pre30master = version_is_less(opts[:pe_ver] || master['pe_ver'], '3.0')
 
@@ -479,7 +477,7 @@ module Beaker
             # We only need answers if we're using the classic installer
             version = host['pe_ver'] || opts[:pe_ver]
             if (! host['roles'].include? 'frictionless') || version_is_less(version, '3.2.0')
-              answers = Beaker::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, master_certname, opts)
+              answers = Beaker::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, opts)
               create_remote_file host, "#{host['working_dir']}/answers", answers.answer_string(host)
             else
               # If We're *not* running the classic installer, we want

--- a/lib/beaker/hypervisor/vcloud_pooled.rb
+++ b/lib/beaker/hypervisor/vcloud_pooled.rb
@@ -76,7 +76,9 @@ module Beaker
           response = http.request(request)
           parsed_response = JSON.parse(response.body)
           if parsed_response[h['template']] && parsed_response[h['template']]['ok'] && parsed_response[h['template']]['hostname']
-            h['vmhostname'] = parsed_response[h['template']]['hostname']
+            hostname = parsed_response[h['template']]['hostname']
+            domain = parsed_response['domain']
+            h['vmhostname'] = domain ? "#{hostname}.#{domain}" : hostname
           else
             raise "VcloudPooled.provision - no vCloud host free for #{h.name} in pool"
           end

--- a/spec/beaker/answers_spec.rb
+++ b/spec/beaker/answers_spec.rb
@@ -7,8 +7,7 @@ module Beaker
     let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
                           basic_hosts[1]['platform'] = 'windows'
                           basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
 
     it 'generates 3.4 answers for 3.4 hosts' do
       @ver = '3.4'
@@ -59,8 +58,7 @@ module Beaker
                     basic_hosts[1]['roles'] = ['dashboard', 'agent']
                     basic_hosts[2]['roles'] = ['database', 'agent']
                     basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
 
     before :each do
       @ver = '3.4'
@@ -88,9 +86,8 @@ module Beaker
                     basic_hosts[1]['roles'] = ['dashboard', 'agent']
                     basic_hosts[2]['roles'] = ['database', 'agent']
                     basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
-    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options.merge( {:type => :upgrade}) ) }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
+    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, options.merge( {:type => :upgrade}) ) }
 
     before :each do
       @ver = '3.2'
@@ -122,9 +119,8 @@ module Beaker
                           basic_hosts[1]['platform'] = 'windows'
                           basic_hosts[2][:custom_answers] = { :q_custom => 'LOOKLOOKLOOK' }
                           basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
-    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options.merge( {:type => :upgrade}) ) }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
+    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, options.merge( {:type => :upgrade}) ) }
 
     before :each do
       @ver = '3.0'
@@ -138,12 +134,12 @@ module Beaker
 
     it 'sets correct answers for an agent' do
       @ver = '3.0'
-      expect( @answers['vm3'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"n", :q_all_in_one_install=>"n", :q_puppet_enterpriseconsole_install=>"n", :q_puppetdb_install=>"n", :q_database_install=>"n", :q_custom=>"LOOKLOOKLOOK" }
+      expect( @answers['vm3'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"n", :q_all_in_one_install=>"n", :q_puppet_enterpriseconsole_install=>"n", :q_puppetdb_install=>"n", :q_database_install=>"n", :q_custom=>"LOOKLOOKLOOK" }
     end
 
     it 'sets correct answers for a master' do
       @ver = '3.0'
-      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"y", :q_all_in_one_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetdb_install=>"y", :q_database_install=>"y", :q_puppetdb_hostname=>hosts[0], :q_puppetdb_port=>8081, :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_certname=>"master_certname", :q_puppetdb_database_name=>"pe-puppetdb", :q_puppetdb_database_user=>"mYpdBu3r", :q_puppetdb_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_database_host=>hosts[0], :q_database_port=>5432, :q_pe_database=>"y", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_database_root_password=>"'=ZYdjiP3jCwV5eo9s1MBd'", :q_database_root_user=>"pe-postgres" }
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_all_in_one_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetdb_install=>"y", :q_database_install=>"y", :q_puppetdb_hostname=>hosts[0], :q_puppetdb_port=>8081, :q_puppetmaster_dnsaltnames=>"#{hosts[0]},#{hosts[0][:ip]},puppet", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_certname=>hosts[0], :q_puppetdb_database_name=>"pe-puppetdb", :q_puppetdb_database_user=>"mYpdBu3r", :q_puppetdb_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_database_host=>hosts[0], :q_database_port=>5432, :q_pe_database=>"y", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_database_root_password=>"'=ZYdjiP3jCwV5eo9s1MBd'", :q_database_root_user=>"pe-postgres" }
     end
 
     it 'generates nil answers for a windows host' do
@@ -172,8 +168,7 @@ module Beaker
     let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
                           basic_hosts[1]['platform'] = 'windows'
                           basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
 
     before :each do
       @ver = '2.8'
@@ -185,7 +180,7 @@ module Beaker
     end
 
     it 'sets correct answers for a master' do
-      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>hosts[0], :q_puppetmaster_dnsaltnames=>"#{hosts[0]},#{hosts[0][:ip]},puppet", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
     end
 
     it 'generates nil answers for a windows host' do
@@ -205,8 +200,8 @@ module Beaker
     let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
                           basic_hosts[1]['platform'] = 'windows'
                           basic_hosts }
-    let( :master_certname ) { 'master_certname' }
-    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, options) }
 
     before :each do
       @ver = '2.0'
@@ -218,7 +213,7 @@ module Beaker
     end
 
     it 'sets correct answers for a master' do
-      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_root_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>hosts[0], :q_puppetmaster_dnsaltnames=>"#{hosts[0]},#{hosts[0][:ip]},puppet", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_root_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
     end
 
     it 'generates nil answers for a windows host' do

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -326,8 +326,6 @@ describe ClassMixedWithDSLInstallUtils do
       end
 
       subject.stub( :hosts ).and_return( hosts )
-      #determine mastercert
-      subject.should_receive( :on ).with( hosts[0], /uname/ ).once
       #create answers file per-host, except windows
       subject.should_receive( :create_remote_file ).with( hosts[0], /answers/, /q/ ).once
       #run installer on all hosts

--- a/spec/mocks.rb
+++ b/spec/mocks.rb
@@ -17,7 +17,11 @@ module MockNet
     class Response
       class ResponseHash
         def []key
-          { 'ok' => true, 'hostname' => 'pool' }
+          if key == "domain"
+            nil
+          else
+            { 'ok' => true, 'hostname' => 'pool' }
+          end
         end
 
       end


### PR DESCRIPTION
Previously, we would call out to `hostname` on the SUT when deploying
PE. This may give us a name that isn't resolvable or routable by
every host in the configuration. We should instead just use whatever
the hypervisor tells us is the correct way to connect to the host.

This also sneaks in a small change to the vmpooler hypervisor, to make
it return FQDNs. Using these FQDNs is really what this is all about.
