### PR TITLE
(QENG-1128) Beaker no long auto recursively scps directories to systems under test

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -263,13 +263,12 @@ module Beaker
       result.exit_code == 0
     end
 
-    # scp files from the localhost to this test host
+    # scp files from the localhost to this test host, if a directory is provided it is recursively copied
     # @param source [String] The path to the file/dir to upload
     # @param target [String] The destination path on the host
     # @param [Hash{Symbol=>String}] options Options to alter execution
-    # @option options [Boolean] :recursive Should we copy recursively?  Defaults to 'True' in case of a directory source.
     # @option options [Array<String>] :ignore An array of file/dir paths that will not be copied to the host
-    def do_scp_to source, target, options
+    def do_scp_to source, target, options = {}
       @logger.debug "localhost $ scp #{source} #{@name}:#{target}"
 
       result = Result.new(@name, [source, target])

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -166,7 +166,7 @@ module Beaker
     def scp_to source, target, options = {}, dry_run = false
       return if dry_run
 
-      options[:recursive]  = File.directory?(source) if options[:recursive].nil?
+      options[:recursive]  = File.directory?(source)
       options[:chunk_size] = options[:chunk_size] || 16384
 
       result = Result.new(@hostname, [source, target])
@@ -188,7 +188,7 @@ module Beaker
     def scp_from source, target, options = {}, dry_run = false
       return if dry_run
 
-      options[:recursive] = true if options[:recursive].nil?
+      options[:recursive] = true
       options[:chunk_size] = options[:chunk_size] || 16384
 
       result = Result.new(@hostname, [source, target])


### PR DESCRIPTION
- issue was :recursive variable was being carried over successive calls
  to scp_to.  To prevent this, just set it based upon the file type
  being called
- ride along spec test updates/fixes
