### PR TITLE
(MAINT) broken spec fixes (docker + copy_module_to)

### DIFF
--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -1232,7 +1232,7 @@ describe ClassMixedWithDSLHelpers do
   end
 
   describe 'copy_module_to' do
-    let(:ignore_list){%w(.git .idea .vagrant .vendor acceptance spec tests log . ..)}
+    let(:ignore_list) { Beaker::DSL::Helpers::PUPPET_MODULE_INSTALL_IGNORE }
     let(:source){'./'}
     let(:target){'/etc/puppetlabs/puppet/modules/testmodule'}
     let(:module_parse_name){'testmodule'}

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -171,21 +171,25 @@ module Beaker
       end
 
       it 'should stop the containers' do
+        docker.stub( :sleep ).and_return(true)
         container.should_receive(:stop)
         docker.cleanup
       end
 
       it 'should delete the containers' do
+        docker.stub( :sleep ).and_return(true)
         container.should_receive(:delete)
         docker.cleanup
       end
 
       it 'should delete the images' do
+        docker.stub( :sleep ).and_return(true)
         image.should_receive(:delete)
         docker.cleanup
       end
 
       it 'should not delete the image if docker_preserve_image is set to true' do
+        docker.stub( :sleep ).and_return(true)
         hosts.each do |host|
           host['docker_preserve_image']=true
         end
@@ -194,6 +198,7 @@ module Beaker
       end
 
       it 'should delete the image if docker_preserve_image is set to false' do
+        docker.stub( :sleep ).and_return(true)
         hosts.each do |host|
           host['docker_preserve_image']=false
         end


### PR DESCRIPTION
- docker spec was still allowing sleeps to execute making things run
  slow
- update copy_module_to spec test to use correct ignore list
