### PR TITLE
(QENG-1209) scp in debug output shows far too much output

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -268,8 +268,8 @@ module Beaker
     # @param target [String] The destination path on the host
     # @param [Hash{Symbol=>String}] options Options to alter execution
     # @option options [Array<String>] :ignore An array of file/dir paths that will not be copied to the host
-    def do_scp_to source, target, options = {}
-      @logger.debug "localhost $ scp #{source} #{@name}:#{target}"
+    def do_scp_to source, target, options
+      @logger.notify "localhost $ scp #{source} #{@name}:#{target} {:ignore => #{options[:ignore]}}"
 
       result = Result.new(@name, [source, target])
       has_ignore = options[:ignore] and not options[:ignore].empty?
@@ -286,21 +286,24 @@ module Beaker
       if File.file?(source) or (File.directory?(source) and not has_ignore)
         source_file = source
         if has_ignore and (source =~ ignore_re)
-          @logger.debug "After rejecting ignored files/dirs, there is no file to copy"
+          @logger.trace "After rejecting ignored files/dirs, there is no file to copy"
           source_file = nil
           result.stdout = "No files to copy"
           result.exit_code = 1
         end
         if source_file
           result = connection.scp_to(source_file, target, options, $dry_run)
+          @logger.trace result.stdout
         end
       else # a directory with ignores
         dir_source = Dir.glob("#{source}/**/*").reject do |f|
           f =~ ignore_re
         end
-        @logger.debug "After rejecting ignored files/dirs, going to scp [#{dir_source.join(", ")}]"
+        @logger.trace "After rejecting ignored files/dirs, going to scp [#{dir_source.join(", ")}]"
 
         # create necessary directory structure on host
+        # run this quietly (no STDOUT)
+        @logger.quiet(true)
         required_dirs = (dir_source.map{ | dir | File.dirname(dir) }).uniq
         require 'pathname'
         source_path = Pathname.new(source)
@@ -312,6 +315,7 @@ module Beaker
             mkdir_p( File.join(target, dir) )
           end
         end
+        @logger.quiet(false)
 
         # copy each file to the host
         dir_source.each do |s|
@@ -322,10 +326,10 @@ module Beaker
             file_path = File.join(target, s)
           end
           result = connection.scp_to(s, file_path, options, $dry_run)
+          @logger.trace result.stdout
         end
       end
 
-      @logger.debug result.stdout
       return result
     end
 

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -120,6 +120,7 @@ module Beaker
           opts.on '--log-level LEVEL',
                   'Log level',
                   'Supported LEVEL keywords:',
+                  'trace   : all messages, full stack trace of errors, file copy details',
                   'debug   : all messages, plus full stack trace of errors',
                   'verbose : all messages',
                   'info    : info messages, notifications and warnings',

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -240,7 +240,7 @@ module Beaker
         args = [ 'source', 'target', {} ]
         conn_args = args + [ nil ]
 
-        logger.should_receive(:debug)
+        logger.should_receive(:trace)
         conn.should_receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
 
         host.do_scp_to *args
@@ -272,7 +272,7 @@ module Beaker
           host.instance_variable_set :@connection, conn
           args = [ source_path, target_path, {:ignore => ['tests', 'tests2']} ]
 
-          logger.should_receive(:debug)
+          logger.should_receive(:trace)
           host.should_receive( :mkdir_p ).exactly(0).times
           conn.should_receive(:scp_to).exactly(0).times
 
@@ -288,7 +288,7 @@ module Beaker
 
           Dir.stub( :glob ).and_return( @fileset1 + @fileset2 )
 
-          logger.should_receive(:debug)
+          logger.should_receive(:trace)
           host.should_receive( :mkdir_p ).with("#{target_path}/tests")
           host.should_receive( :mkdir_p ).with("#{target_path}/tests2")
           (@fileset1 + @fileset2).each do |file|
@@ -332,7 +332,7 @@ module Beaker
           host.instance_variable_set :@connection, conn
           args = [ 'tmp', 'target', {:ignore => ['tests', 'tests2']} ]
 
-          logger.should_receive(:debug)
+          logger.should_receive(:trace)
           host.should_receive( :mkdir_p ).exactly(0).times
           conn.should_receive(:scp_to).exactly(0).times
 
@@ -349,7 +349,7 @@ module Beaker
 
           Dir.stub( :glob ).and_return( @fileset1 + @fileset2 )
 
-          logger.should_receive(:debug)
+          logger.should_receive(:trace)
           host.should_receive( :mkdir_p ).with('target/tmp/tests')
           host.should_receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset1 + @fileset2).each do |file|
@@ -373,7 +373,7 @@ module Beaker
 
           Dir.stub( :glob ).and_return( @fileset1 + @fileset2 )
 
-          logger.should_receive(:debug)
+          logger.should_receive(:trace)
           host.should_receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset2).each do |file|
             file_args = [ file, File.join('target', file), {:ignore => [exclude_file]} ]

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -72,6 +72,32 @@ module Beaker
         colorized_logger.optionally_color "\e[00;30m", 'my string'
       end
 
+      context 'at trace log_level' do
+        subject( :trace_logger )  { Logger.new( my_io,
+                                              :log_level => 'trace',
+                                              :quiet => true,
+                                              :color => true )
+                                  }
+
+        its( :is_debug? ) { should be_true }
+        its( :is_trace? ) { should be_true }
+        its( :is_warn? )  { should be_true }
+
+        context 'but print' do
+          before do
+            my_io.stub :puts
+            my_io.should_receive( :print ).at_least :twice
+          end
+
+          it( 'warnings' )    { trace_logger.warn 'IMA WARNING!'    }
+          it( 'successes' )   { trace_logger.success 'SUCCESS!'     }
+          it( 'errors' )      { trace_logger.error 'ERROR!'         }
+          it( 'host_output' ) { trace_logger.host_output 'ERROR!'   }
+          it( 'debugs' )      { trace_logger.debug 'DEBUGGING!'     }
+          it( 'traces' )      { trace_logger.trace 'TRACING!'       }
+        end
+      end
+
       context 'at verbose log_level' do
         subject( :verbose_logger )  { Logger.new( my_io,
                                               :log_level => 'verbose',
@@ -79,6 +105,7 @@ module Beaker
                                               :color => true )
                                   }
 
+        its( :is_trace? ) { should be_false }
         its( :is_debug? ) { should be_false }
         its( :is_verbose? ) { should be_true }
         its( :is_warn? )  { should be_true }
@@ -104,6 +131,7 @@ module Beaker
                                               :color => true )
                                   }
 
+        its( :is_trace? ) { should be_false }
         its( :is_debug? ) { should be_true }
         its( :is_warn? )  { should be_true }
 
@@ -129,6 +157,7 @@ module Beaker
                                   }
 
         its( :is_debug? ) { should be_false }
+        its( :is_trace? ) { should be_false }
 
 
         context 'skip' do
@@ -138,6 +167,7 @@ module Beaker
           end
 
           it( 'debugs' )    { info_logger.debug 'NOT DEBUGGING!' }
+          it( 'traces' )    { info_logger.debug 'NOT TRACING!'   }
         end
 
 


### PR DESCRIPTION
- move detailed output into a new log level called 'trace', could still
  be useful for tracking networking failures - but will be disabled by
  default
- add ability to flip on/off quiet output to logging
