### PR TITLE
Adding a new powershell wrapper

### DIFF
--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -95,6 +95,32 @@ module Beaker
       def puppet_filebucket(*args)
         puppet( 'filebucket', *args )
       end
+
+      # Returns a {Beaker::Command} object for executing powershell commands on a host
+      #
+      # @param [String]   command   The powershell command to execute
+      # @param [Hash]     args      The commandline paramaeters to be passed to powershell
+      #
+      # @example Setting the contents of a file
+      #     powershell("Set-Content -path 'fu.txt' -value 'fu'")
+      #
+      # @example Using an alternative execution policy
+      #     powershell("Set-Content -path 'fu.txt' -value 'fu'", {'ExecutionPolicy' => 'Unrestricted'})
+      #
+      # @return [Command]
+      def powershell(command, args={})
+        ps_opts = {
+          'ExecutionPolicy' => 'Bypass',
+          'InputFormat'     => 'None',
+          'NoLogo'          => '',
+          'NoProfile'       => '',
+          'NonInteractive'  => ''
+        }
+        ps_opts.merge!(args)
+
+        arguments = " #{ps_opts.sort.map{|k,v| v.eql?('') ? "-#{k}" : "-#{k} #{v}" }.join(' ')} -Command \"#{command}\""
+        Command.new('powershell.exe', arguments, {})
+      end
     end
   end
 end

--- a/spec/beaker/dsl/wrappers_spec.rb
+++ b/spec/beaker/dsl/wrappers_spec.rb
@@ -49,4 +49,20 @@ describe ClassMixedWithDSLWrappers do
       end
     end
   end
+
+  describe '#powershell' do
+    it 'should pass "powershell.exe <args> -Command <command>" to Command' do
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'")
+      command.command.should == 'powershell.exe'
+      command.args.should == ' -ExecutionPolicy Bypass -InputFormat None -NoLogo -NoProfile -NonInteractive -Command "Set-Content -path \'fu.txt\' -value \'fu\'"'
+      command.options.should == {}
+    end
+
+    it 'should merge the arguments provided with the defaults' do
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'ExecutionPolicy' => 'Unrestricted'})
+      command.command.should == 'powershell.exe'
+      command.args.should == ' -ExecutionPolicy Unrestricted -InputFormat None -NoLogo -NoProfile -NonInteractive -Command "Set-Content -path \'fu.txt\' -value \'fu\'"'
+      command.options.should == {}
+    end
+  end
 end


### PR DESCRIPTION
When working with windows there are many times when you will want to execute powershell commands or scripts. 

This is not always as easy as it might seem and there are issues such as passing the correct parameters to make sure it's run silently and making sure that your using the correct powershell.exe (if it's not in your path).

Most of these edge cases have already been covered in [puppetlabs-powershell](https://github.com/puppetlabs/puppetlabs-powershell/blob/master/lib/puppet/provider/exec/powershell.rb).

It would be useful to have a wrapper that deals with all this makes it simple to execute powershell commands on a host.

Something like:
 `on host, powershell('command to run here')`
