### PR TITLE
(QENG-1054) Add functionality to install_pe to modify answers...

### DIFF
--- a/lib/beaker/answers.rb
+++ b/lib/beaker/answers.rb
@@ -1,11 +1,46 @@
-[ 'version34', 'version32', 'version30', 'version28', 'version20' ].each do |lib|
-  require "beaker/answers/#{lib}"
-end
-
 module Beaker
-  # This module provides static methods for accessing PE answer file
+  # This class provides methods for generating PE answer file
   # information.
-  module Answers
+  class Answers
+
+    # When given a Puppet Enterprise version, a list of hosts and other
+    # qualifying data this method will return the appropriate object that can be used
+    # to generate answer file data.
+    #
+    # @param [String] version Puppet Enterprise version to generate answer data for
+    # @param [Array<Beaker::Host>] hosts An array of host objects.
+    # @param [String] master_certname Hostname of the puppet master.
+    # @param [Hash] options options for answer files
+    # @option options [Symbol] :type Should be one of :upgrade or :install.
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def self.create version, hosts, master_certname, options
+      case version
+      when /\A3\.4/
+        return Version34.new(version, hosts, master_certname, options)
+      when /\A3\.[2-3]/
+        return Version32.new(version, hosts, master_certname, options)
+      when /\A3\.1/
+        return Version30.new(version, hosts, master_certname, options)
+      when /\A3\.0/
+        return Version30.new(version, hosts, master_certname, options)
+      when /\A2\.8/
+        return Version28.new(version, hosts, master_certname, options)
+      when /\A2\.0/
+        return Version20.new(version, hosts, master_certname, options)
+      else
+        raise NotImplementedError, "Don't know how to generate answers for #{version}"
+      end
+    end
+
+    # The answer value for a provided question.  Use the user answer when available, otherwise return the default
+    # @param [Hash] options options for answer file
+    # @option options [Symbol] :answer Contains a hash of user provided question name and answer value pairs.
+    # @param [String] default Should there be no user value for the provided question name return this default
+    # @return [String] The answer value
+    def answer_for(options, q, default = nil)
+      options[:answers][q] ? options[:answers][q] : default
+    end
 
     # When given a Puppet Enterprise version, a list of hosts and other
     # qualifying data this method will return a hash (keyed from the hosts)
@@ -18,24 +53,23 @@ module Beaker
     # @option options [Symbol] :type Should be one of :upgrade or :install.
     # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
     #   data.
-    def self.answers(version, hosts, master_certname, options)
+    def initialize(version, hosts, master_certname, options)
+      @version = version
+      @hosts = hosts
+      @master_certname = master_certname
+      @options = options
+    end
 
-      case version
-      when /\A3\.4/
-        Version34.answers(hosts, master_certname, options)
-      when /\A3\.[2-3]/
-        Version32.answers(hosts, master_certname, options)
-      when /\A3\.1/
-        Version30.answers(hosts, master_certname, options)
-      when /\A3\.0/
-        Version30.answers(hosts, master_certname, options)
-      when /\A2\.8/
-        Version28.answers(hosts, master_certname, options)
-      when /\A2\.0/
-        Version20.answers(hosts, master_certname, options)
-      else
-        raise NotImplementedError, "Don't know how to generate answers for #{version}"
-      end
+    # Generate the answers hash based upon version, host and option information
+    def generate_answers
+      raise "This should be handled by subclasses!"
+    end
+
+    # Access the answers hash for this version, host and option information.  If the answers
+    # have not yet been calculated, generate them.
+    # @return [Hash] A hash of answers keyed by host.name
+    def answers
+      @answers ||= generate_answers
     end
 
     # This converts a data hash provided by answers, and returns a Puppet
@@ -43,16 +77,19 @@ module Beaker
     #
     # @param [Beaker::Host] host Host object in question to generate the answer
     #   file for.
-    # @param [Hash] answers Answers hash as returned by #answers
     # @return [String] a string of answers
     # @example Generating an answer file for a series of hosts
     #   hosts.each do |host|
-    #     answers = Beaker::Answers.answers("2.0", hosts, "master")
-    #     create_remote_file host, "/mypath/answer", Beaker::Answers.answer_string(host, answers)
+    #     answers = Beaker::Answers.new("2.0", hosts, "master")
+    #     create_remote_file host, "/mypath/answer", answers.answer_string(host, answers)
     #  end
-    def self.answer_string(host, answers)
+    def answer_string(host)
       answers[host.name].map { |k,v| "#{k}=#{v}" }.join("\n")
     end
 
+  end
+
+  [ 'version34', 'version32', 'version30', 'version28', 'version20' ].each do |lib|
+    require "beaker/answers/#{lib}"
   end
 end

--- a/lib/beaker/answers/version20.rb
+++ b/lib/beaker/answers/version20.rb
@@ -1,125 +1,125 @@
 module Beaker
-  module Answers
-    # This class provides answer file information for PE version 2.0
+  # This class provides answer file information for PE version 2.0
+  #
+  # @api private
+  class Version20 < Answers
+    # Return answer data for a host
     #
-    # @api private
-    module Version20
-      # Return answer data for a host
-      #
-      # @param [Beaker::Host] host Host to return data for
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Beaker::Host] master Host object representing the master
-      # @param [Beaker::Host] dashboard Host object representing the dashboard
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.host_answers(host, master_certname, master, dashboard, options)
-        return nil if host['platform'] =~ /windows/
+    # @param [Beaker::Host] host Host to return data for
+    # @param [String] master_certname Hostname of the puppet master.
+    # @param [Beaker::Host] master Host object representing the master
+    # @param [Beaker::Host] dashboard Host object representing the dashboard
+    # @param [Hash] options options for answer files
+    # @option options [Symbol] :type Should be one of :upgrade or :install.
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def host_answers(host, master_certname, master, dashboard, options)
+      return nil if host['platform'] =~ /windows/
 
-        agent_a = {
-          :q_install => 'y',
-          :q_puppetagent_install => 'y',
-          :q_puppet_cloud_install => 'y',
-          :q_puppet_symlinks_install => 'y',
-          :q_vendor_packages_install => 'y',
-          :q_puppetagent_certname => host,
-          :q_puppetagent_server => master,
+      agent_a = {
+        :q_install => 'y',
+        :q_puppetagent_install => 'y',
+        :q_puppet_cloud_install => 'y',
+        :q_puppet_symlinks_install => 'y',
+        :q_vendor_packages_install => 'y',
+        :q_puppetagent_certname => host,
+        :q_puppetagent_server => master,
 
-          # Disable console and master by default
-          # This will be overridden by other blocks being merged in
-          :q_puppetmaster_install => 'n',
-          :q_puppet_enterpriseconsole_install => 'n',
-        }
+        # Disable console and master by default
+        # This will be overridden by other blocks being merged in
+        :q_puppetmaster_install => 'n',
+        :q_puppet_enterpriseconsole_install => 'n',
+      }
 
-        master_a = {
-          :q_puppetmaster_install => 'y',
-          :q_puppetmaster_certname => master_certname,
-          :q_puppetmaster_install => 'y',
-          :q_puppetmaster_dnsaltnames => master_certname+",puppet",
-          :q_puppetmaster_enterpriseconsole_hostname => dashboard,
-          :q_puppetmaster_enterpriseconsole_port => 443,
-          :q_puppetmaster_forward_facts => 'y',
-        }
+      master_a = {
+        :q_puppetmaster_install => 'y',
+        :q_puppetmaster_certname => master_certname,
+        :q_puppetmaster_install => 'y',
+        :q_puppetmaster_dnsaltnames => master_certname+",puppet",
+        :q_puppetmaster_enterpriseconsole_hostname => dashboard,
+        :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),
+        :q_puppetmaster_forward_facts => 'y',
+      }
 
-        if master['ip']
-          master_a[:q_puppetmaster_dnsaltnames]+=","+master['ip']
-        end
-
-        dashboard_user = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_user_email]}'"
-        smtp_host = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_host] || dashboard}'"
-        dashboard_password = options[:answers][:q_puppet_enterpriseconsole_auth_password]
-        smtp_port = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_port]}'"
-        smtp_username = options[:answers][:q_puppet_enterpriseconsole_smtp_username]
-        smtp_password = options[:answers][:q_puppet_enterpriseconsole_smtp_password]
-        smtp_use_tls = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_use_tls]}'"
-
-        console_a = {
-          :q_puppet_enterpriseconsole_install => 'y',
-          :q_puppet_enterpriseconsole_database_install => 'y',
-          :q_puppet_enterpriseconsole_auth_database_name => 'console_auth',
-          :q_puppet_enterpriseconsole_auth_database_user => 'mYu7hu3r',
-          :q_puppet_enterpriseconsole_auth_database_password => "'#{dashboard_password}'",
-          :q_puppet_enterpriseconsole_database_name => 'console',
-          :q_puppet_enterpriseconsole_database_user => 'mYc0nS03u3r',
-          :q_puppet_enterpriseconsole_database_root_password => "'#{dashboard_password}'",
-          :q_puppet_enterpriseconsole_database_password => "'#{dashboard_password}'",
-          :q_puppet_enterpriseconsole_inventory_hostname => host,
-          :q_puppet_enterpriseconsole_inventory_certname => host,
-          :q_puppet_enterpriseconsole_inventory_dnsaltnames => master,
-          :q_puppet_enterpriseconsole_inventory_port => 8140,
-          :q_puppet_enterpriseconsole_master_hostname => master,
-
-          :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
-          :q_puppet_enterpriseconsole_auth_password => "'#{dashboard_password}'",
-
-          :q_puppet_enterpriseconsole_httpd_port => 443,
-
-          :q_puppet_enterpriseconsole_smtp_host => smtp_host,
-          :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
-          :q_puppet_enterpriseconsole_smtp_port => smtp_port,
-        }
-
-        console_a[:q_puppet_enterpriseconsole_auth_user] = console_a[:q_puppet_enterpriseconsole_auth_user_email]
-
-        if smtp_password and smtp_username
-          console_a.merge!({
-                             :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
-                             :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
-                             :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
-                           })
-        end
-
-        answers = agent_a.dup
-        if host == master
-          answers.merge! master_a
-        end
-
-        if host == dashboard
-          answers.merge! console_a
-        end
-
-        return answers
+      if master['ip']
+        master_a[:q_puppetmaster_dnsaltnames]+=","+master['ip']
       end
 
-      # Return answer data for all hosts.
-      #
-      # @param [Array<Beaker::Host>] hosts An array of host objects.
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.answers(hosts, master_certname, options)
-        the_answers = {}
-        dashboard = only_host_with_role(hosts, 'dashboard')
-        master = only_host_with_role(hosts, 'master')
-        hosts.each do |h|
-          the_answers[h.name] = host_answers(h, master_certname, master, dashboard, options)
-          h[:answers] = the_answers[h.name]
-        end
-        return the_answers
+      dashboard_user = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_user_email)}'"
+      smtp_host = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_host, dashboard)}'"
+      dashboard_password = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_password)}'"
+      smtp_port = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_port)}'"
+      smtp_username = answer_for(options, :q_puppet_enterpriseconsole_smtp_username)
+      smtp_password = answer_for(options, :q_puppet_enterpriseconsole_smtp_password)
+      smtp_use_tls = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_use_tls)}'"
+      auth_database_name = answer_for(options, :q_puppet_enterpriseconsole_auth_database_name, 'console_auth')
+      auth_database_user = answer_for(options, :q_puppet_enterpriseconsole_auth_database_user, 'mYu7hu3r')
+      console_database_name = answer_for(options, :q_puppet_enterpriseconsole_database_name, 'console')
+      console_database_user = answer_for(options, :q_puppet_enterpriseconsole_database_user, 'mYc0nS03u3r')
+      console_inventory_port = answer_for(options, :q_puppet_enterpriseconsole_inventory_port, 8140)
+      console_httpd_port = answer_for(options, :q_puppet_enterpriseconsole_httpd_port, 443)
+
+      console_a = {
+        :q_puppet_enterpriseconsole_install => 'y',
+        :q_puppet_enterpriseconsole_database_install => 'y',
+        :q_puppet_enterpriseconsole_auth_database_name => auth_database_name,
+        :q_puppet_enterpriseconsole_auth_database_user => auth_database_user,
+        :q_puppet_enterpriseconsole_auth_database_password => dashboard_password,
+        :q_puppet_enterpriseconsole_database_name => console_database_name,
+        :q_puppet_enterpriseconsole_database_user => console_database_user,
+        :q_puppet_enterpriseconsole_database_root_password => dashboard_password,
+        :q_puppet_enterpriseconsole_database_password => dashboard_password,
+        :q_puppet_enterpriseconsole_inventory_hostname => host,
+        :q_puppet_enterpriseconsole_inventory_certname => host,
+        :q_puppet_enterpriseconsole_inventory_dnsaltnames => master,
+        :q_puppet_enterpriseconsole_inventory_port => console_inventory_port,
+        :q_puppet_enterpriseconsole_master_hostname => master,
+        :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
+        :q_puppet_enterpriseconsole_auth_password => dashboard_password,
+        :q_puppet_enterpriseconsole_httpd_port => console_httpd_port,
+        :q_puppet_enterpriseconsole_smtp_host => smtp_host,
+        :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
+        :q_puppet_enterpriseconsole_smtp_port => smtp_port,
+      }
+
+      console_a[:q_puppet_enterpriseconsole_auth_user] = console_a[:q_puppet_enterpriseconsole_auth_user_email]
+
+      if smtp_password and smtp_username
+        console_a.merge!({
+                           :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
+                           :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
+                           :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
+                         })
       end
+
+      answers = agent_a.dup
+      if host == master
+        answers.merge! master_a
+      end
+
+      if host == dashboard
+        answers.merge! console_a
+      end
+
+      return answers
+    end
+
+    # Return answer data for all hosts.
+    #
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def generate_answers
+      the_answers = {}
+      dashboard = only_host_with_role(@hosts, 'dashboard')
+      master = only_host_with_role(@hosts, 'master')
+      @hosts.each do |h|
+        the_answers[h.name] = host_answers(h, @master_certname, master, dashboard, @options)
+        if h[:custom_answers]
+          the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
+        end
+        h[:answers] = the_answers[h.name]
+      end
+      return the_answers
     end
   end
 end

--- a/lib/beaker/answers/version28.rb
+++ b/lib/beaker/answers/version28.rb
@@ -1,126 +1,126 @@
 module Beaker
-  module Answers
-    # This class provides answer file information for PE version 2.8
+  # This class provides answer file information for PE version 2.8
+  #
+  # @api private
+  class Version28 < Answers
+
+    # Return answer data for a host
     #
-    # @api private
-    module Version28
+    # @param [Beaker::Host] host Host to return data for
+    # @param [String] master_certname Hostname of the puppet master.
+    # @param [Beaker::Host] master Host object representing the master
+    # @param [Beaker::Host] dashboard Host object representing the dashboard
+    # @param [Hash] options options for answer files
+    # @option options [Symbol] :type Should be one of :upgrade or :install.
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def host_answers(host, master_certname, master, dashboard, options)
+      return nil if host['platform'] =~ /windows/
 
-      # Return answer data for a host
-      #
-      # @param [Beaker::Host] host Host to return data for
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Beaker::Host] master Host object representing the master
-      # @param [Beaker::Host] dashboard Host object representing the dashboard
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.host_answers(host, master_certname, master, dashboard, options)
-        return nil if host['platform'] =~ /windows/
+      agent_a = {
+        :q_install => 'y',
+        :q_puppetagent_install => 'y',
+        :q_puppet_cloud_install => 'y',
+        :q_puppet_symlinks_install => 'y',
+        :q_vendor_packages_install => 'y',
+        :q_puppetagent_certname => host,
+        :q_puppetagent_server => master,
 
-        agent_a = {
-          :q_install => 'y',
-          :q_puppetagent_install => 'y',
-          :q_puppet_cloud_install => 'y',
-          :q_puppet_symlinks_install => 'y',
-          :q_vendor_packages_install => 'y',
-          :q_puppetagent_certname => host,
-          :q_puppetagent_server => master,
+        # Disable console and master by default
+        # This will be overridden by other blocks being merged in
+        :q_puppetmaster_install => 'n',
+        :q_puppet_enterpriseconsole_install => 'n',
+      }
 
-          # Disable console and master by default
-          # This will be overridden by other blocks being merged in
-          :q_puppetmaster_install => 'n',
-          :q_puppet_enterpriseconsole_install => 'n',
-        }
+      master_a = {
+        :q_puppetmaster_install => 'y',
+        :q_puppetmaster_certname => master_certname,
+        :q_puppetmaster_install => 'y',
+        :q_puppetmaster_dnsaltnames => master_certname+",puppet",
+        :q_puppetmaster_enterpriseconsole_hostname => dashboard,
+        :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),
+        :q_puppetmaster_forward_facts => 'y',
+      }
 
-        master_a = {
-          :q_puppetmaster_install => 'y',
-          :q_puppetmaster_certname => master_certname,
-          :q_puppetmaster_install => 'y',
-          :q_puppetmaster_dnsaltnames => master_certname+",puppet",
-          :q_puppetmaster_enterpriseconsole_hostname => dashboard,
-          :q_puppetmaster_enterpriseconsole_port => 443,
-          :q_puppetmaster_forward_facts => 'y',
-        }
-
-        if master['ip']
-          master_a[:q_puppetmaster_dnsaltnames]+=","+master['ip']
-        end
-
-        dashboard_user = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_user_email]}'"
-        smtp_host = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_host] || dashboard}'"
-        dashboard_password = options[:answers][:q_puppet_enterpriseconsole_auth_password]
-        smtp_port = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_port]}'"
-        smtp_username = options[:answers][:q_puppet_enterpriseconsole_smtp_username]
-        smtp_password = options[:answers][:q_puppet_enterpriseconsole_smtp_password]
-        smtp_use_tls = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_use_tls]}'"
-
-        console_a = {
-          :q_puppet_enterpriseconsole_install => 'y',
-          :q_puppet_enterpriseconsole_database_install => 'y',
-          :q_puppet_enterpriseconsole_auth_database_name => 'console_auth',
-          :q_puppet_enterpriseconsole_auth_database_user => 'mYu7hu3r',
-          :q_puppet_enterpriseconsole_auth_database_password => "'#{dashboard_password}'",
-          :q_puppet_enterpriseconsole_database_name => 'console',
-          :q_puppet_enterpriseconsole_database_user => 'mYc0nS03u3r',
-          :q_puppet_enterpriseconsole_database_password => "'#{dashboard_password}'",
-          :q_puppet_enterpriseconsole_inventory_hostname => host,
-          :q_puppet_enterpriseconsole_inventory_certname => host,
-          :q_puppet_enterpriseconsole_inventory_dnsaltnames => master,
-          :q_puppet_enterpriseconsole_inventory_port => 8140,
-          :q_puppet_enterpriseconsole_master_hostname => master,
-
-          :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
-          :q_puppet_enterpriseconsole_auth_password => "'#{dashboard_password}'",
-
-          :q_puppet_enterpriseconsole_httpd_port => 443,
-
-          :q_puppet_enterpriseconsole_smtp_host => smtp_host,
-          :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
-          :q_puppet_enterpriseconsole_smtp_port => smtp_port,
-        }
-
-        console_a[:q_puppet_enterpriseconsole_auth_user] = console_a[:q_puppet_enterpriseconsole_auth_user_email]
-
-        if smtp_password and smtp_username
-          console_a.merge!({
-                             :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
-                             :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
-                             :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
-                           })
-        end
-
-        answers = agent_a.dup
-        if host == master
-          answers.merge! master_a
-        end
-
-        if host == dashboard
-          answers.merge! console_a
-        end
-
-        return answers
+      if master['ip']
+        master_a[:q_puppetmaster_dnsaltnames]+=","+master['ip']
       end
 
-      # Return answer data for all hosts.
-      #
-      # @param [Array<Beaker::Host>] hosts An array of host objects.
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.answers(hosts, master_certname, options)
-        the_answers = {}
-        dashboard = only_host_with_role(hosts, 'dashboard')
-        master = only_host_with_role(hosts, 'master')
-        hosts.each do |h|
-          the_answers[h.name] = host_answers(h, master_certname, master, dashboard, options)
-          h[:answers] = the_answers[h.name]
-        end
-        return the_answers
+      dashboard_user = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_user_email)}'"
+      smtp_host = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_host, dashboard)}'"
+      dashboard_password = "'#{answer_for(options, :q_puppet_enterpriseconsole_auth_password)}'"
+      smtp_port = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_port)}'"
+      smtp_username = answer_for(options, :q_puppet_enterpriseconsole_smtp_username)
+      smtp_password = answer_for(options, :q_puppet_enterpriseconsole_smtp_password)
+      smtp_use_tls = "'#{answer_for(options, :q_puppet_enterpriseconsole_smtp_use_tls)}'"
+      auth_database_name = answer_for(options, :q_puppet_enterpriseconsole_auth_database_name, 'console_auth')
+      auth_database_user = answer_for(options, :q_puppet_enterpriseconsole_auth_database_user, 'mYu7hu3r')
+      console_database_name = answer_for(options, :q_puppet_enterpriseconsole_database_name, 'console')
+      console_database_user = answer_for(options, :q_puppet_enterpriseconsole_database_user, 'mYc0nS03u3r')
+      console_inventory_port = answer_for(options, :q_puppet_enterpriseconsole_inventory_port, 8140)
+      console_httpd_port = answer_for(options, :q_puppet_enterpriseconsole_httpd_port, 443)
+
+      console_a = {
+        :q_puppet_enterpriseconsole_install => 'y',
+        :q_puppet_enterpriseconsole_database_install => 'y',
+        :q_puppet_enterpriseconsole_auth_database_name => auth_database_name,
+        :q_puppet_enterpriseconsole_auth_database_user => auth_database_user,
+        :q_puppet_enterpriseconsole_auth_database_password => dashboard_password,
+        :q_puppet_enterpriseconsole_database_name => console_database_name,
+        :q_puppet_enterpriseconsole_database_user => console_database_user,
+        :q_puppet_enterpriseconsole_database_password => dashboard_password,
+        :q_puppet_enterpriseconsole_inventory_hostname => host,
+        :q_puppet_enterpriseconsole_inventory_certname => host,
+        :q_puppet_enterpriseconsole_inventory_dnsaltnames => master,
+        :q_puppet_enterpriseconsole_inventory_port => console_inventory_port,
+        :q_puppet_enterpriseconsole_master_hostname => master,
+        :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
+        :q_puppet_enterpriseconsole_auth_password => dashboard_password,
+        :q_puppet_enterpriseconsole_httpd_port => console_httpd_port,
+        :q_puppet_enterpriseconsole_smtp_host => smtp_host,
+        :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
+        :q_puppet_enterpriseconsole_smtp_port => smtp_port,
+      }
+
+      console_a[:q_puppet_enterpriseconsole_auth_user] = console_a[:q_puppet_enterpriseconsole_auth_user_email]
+
+      if smtp_password and smtp_username
+        console_a.merge!({
+                           :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
+                           :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
+                           :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
+                         })
       end
 
+      answers = agent_a.dup
+      if host == master
+        answers.merge! master_a
+      end
+
+      if host == dashboard
+        answers.merge! console_a
+      end
+
+      return answers
     end
+
+    # Return answer data for all hosts.
+    #
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def generate_answers
+      the_answers = {}
+      dashboard = only_host_with_role(@hosts, 'dashboard')
+      master = only_host_with_role(@hosts, 'master')
+      @hosts.each do |h|
+        the_answers[h.name] = host_answers(h, @master_certname, master, dashboard, @options)
+        if h[:custom_answers]
+          the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
+        end
+        h[:answers] = the_answers[h.name]
+      end
+      return the_answers
+    end
+
   end
 end

--- a/lib/beaker/answers/version30.rb
+++ b/lib/beaker/answers/version30.rb
@@ -1,215 +1,221 @@
 module Beaker
-  module Answers
-    # This class provides answer file information for PE version 3.x
+  # This class provides answer file information for PE version 3.x
+  #
+  # @api private
+  class Version30 < Answers
+    # Return answer data for a host
     #
-    # @api private
-    module Version30
-      # Return answer data for a host
-      #
-      # @param [Beaker::Host] host Host to return data for
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Beaker::Host] master Host object representing the master
-      # @param [Beaker::Host] dashboard Host object representing the dashboard
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.host_answers(host, master_certname, master, database, dashboard, options)
-        # Windows hosts don't have normal answers...
-        return nil if host['platform'] =~ /windows/
+    # @param [Beaker::Host] host Host to return data for
+    # @param [String] master_certname Hostname of the puppet master.
+    # @param [Beaker::Host] master Host object representing the master
+    # @param [Beaker::Host] dashboard Host object representing the dashboard
+    # @param [Hash] options options for answer files
+    # @option options [Symbol] :type Should be one of :upgrade or :install.
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def host_answers(host, master_certname, master, database, dashboard, options)
+      # Windows hosts don't have normal answers...
+      return nil if host['platform'] =~ /windows/
 
-        # Everything's an agent
-        agent_a = {
-          :q_puppetagent_install => 'y',
-          :q_puppet_cloud_install => 'y',
-          :q_verify_packages => options[:answers][:q_verify_packages],
-          :q_puppet_symlinks_install => 'y',
-          :q_puppetagent_certname => host,
-          :q_puppetagent_server => master_certname,
+      # Everything's an agent
+      agent_a = {
+        :q_puppetagent_install => 'y',
+        :q_puppet_cloud_install => 'y',
+        :q_verify_packages => options[:answers][:q_verify_packages],
+        :q_puppet_symlinks_install => 'y',
+        :q_puppetagent_certname => host,
+        :q_puppetagent_server => master_certname,
 
-          # Disable database, console, and master by default
-          # This will be overridden by other blocks being merged in.
-          :q_puppetmaster_install => 'n',
-          :q_all_in_one_install => 'n',
-          :q_puppet_enterpriseconsole_install => 'n',
-          :q_puppetdb_install => 'n',
-          :q_database_install => 'n',
-        }
+        # Disable database, console, and master by default
+        # This will be overridden by other blocks being merged in.
+        :q_puppetmaster_install => 'n',
+        :q_all_in_one_install => 'n',
+        :q_puppet_enterpriseconsole_install => 'n',
+        :q_puppetdb_install => 'n',
+        :q_database_install => 'n',
+      }
 
-        # These base answers are needed by all
-        common_a = {
-          :q_install => 'y',
-          :q_vendor_packages_install => 'y',
-        }
+      # These base answers are needed by all
+      common_a = {
+        :q_install => 'y',
+        :q_vendor_packages_install => 'y',
+      }
 
-        # master/database answers
-        master_database_a = {
-          :q_puppetmaster_certname => master_certname
-        }
+      # master/database answers
+      master_database_a = {
+        :q_puppetmaster_certname => master_certname
+      }
 
-        # Master/dashboard answers
-        master_console_a = {
-          :q_puppetdb_hostname => database,
-          :q_puppetdb_port => 8081
-        }
+      # Master/dashboard answers
+      master_console_a = {
+        :q_puppetdb_hostname => database,
+        :q_puppetdb_port => answer_for(options, :q_puppetdb_port, 8081)
+      }
 
-        # Master only answers
-        master_a = {
-          :q_puppetmaster_install => 'y',
-          :q_puppetmaster_dnsaltnames => master_certname+",puppet",
-          :q_puppetmaster_enterpriseconsole_hostname => dashboard,
-          :q_puppetmaster_enterpriseconsole_port => 443,
-        }
+      # Master only answers
+      master_a = {
+        :q_puppetmaster_install => 'y',
+        :q_puppetmaster_dnsaltnames => master_certname+",puppet",
+        :q_puppetmaster_enterpriseconsole_hostname => dashboard,
+        :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),
+      }
 
-        if master['ip']
-          master_a[:q_puppetmaster_dnsaltnames]+= "," + master['ip']
-        end
+      if master['ip']
+        master_a[:q_puppetmaster_dnsaltnames]+= "," + master['ip']
+      end
 
-        # Common answers for console and database
-        dashboard_password = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_password]}'"
-        puppetdb_password = "'#{options[:answers][:q_puppetdb_password]}'"
+      # Common answers for console and database
+      database_name = answer_for(options, :q_puppetdb_database_name, 'pe-puppetdb')
+      database_user = answer_for(options, :q_puppetdb_database_user, 'mYpdBu3r')
+      dashboard_password = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_password]}'"
+      puppetdb_password = "'#{options[:answers][:q_puppetdb_password]}'"
+      auth_database_name = answer_for(options, :q_puppet_enterpriseconsole_auth_database_name, 'console_auth')
+      auth_database_user = answer_for(options, :q_puppet_enterpriseconsole_auth_database_user, 'mYu7hu3r')
+      console_database_name = answer_for(options, :q_puppet_enterpriseconsole_database_name, 'console')
+      console_database_user = answer_for(options, :q_puppet_enterpriseconsole_database_user, 'mYc0nS03u3r')
+      database_port = answer_for(options, :q_database_port, 5432)
 
-        console_database_a = {
-          :q_puppetdb_database_name => 'pe-puppetdb',
-          :q_puppetdb_database_user => 'mYpdBu3r',
-          :q_puppetdb_database_password => puppetdb_password,
-          :q_puppet_enterpriseconsole_auth_database_name => 'console_auth',
-          :q_puppet_enterpriseconsole_auth_database_user => 'mYu7hu3r',
-          :q_puppet_enterpriseconsole_auth_database_password => dashboard_password,
-          :q_puppet_enterpriseconsole_database_name => 'console',
-          :q_puppet_enterpriseconsole_database_user => 'mYc0nS03u3r',
-          :q_puppet_enterpriseconsole_database_password => dashboard_password,
+      console_database_a = {
+        :q_puppetdb_database_name => database_name,
+        :q_puppetdb_database_user => database_user,
+        :q_puppetdb_database_password => puppetdb_password,
+        :q_puppet_enterpriseconsole_auth_database_name => auth_database_name,
+        :q_puppet_enterpriseconsole_auth_database_user => auth_database_user,
+        :q_puppet_enterpriseconsole_auth_database_password => dashboard_password,
+        :q_puppet_enterpriseconsole_database_name => console_database_name,
+        :q_puppet_enterpriseconsole_database_user => console_database_user,
+        :q_puppet_enterpriseconsole_database_password => dashboard_password,
 
-          :q_database_host => database,
-          :q_database_port => 5432
-        }
+        :q_database_host => database,
+        :q_database_port => database_port,
+      }
 
-        # Console only answers
-        dashboard_user = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_user_email]}'"
+      # Console only answers
+      dashboard_user = "'#{options[:answers][:q_puppet_enterpriseconsole_auth_user_email]}'"
 
 
-        smtp_host = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_host] || dashboard}'"
-        smtp_port = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_port]}'"
-        smtp_username = options[:answers][:q_puppet_enterpriseconsole_smtp_username]
-        smtp_password = options[:answers][:q_puppet_enterpriseconsole_smtp_password]
-        smtp_use_tls = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_use_tls]}'"
+      smtp_host = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_host] || dashboard}'"
+      smtp_port = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_port]}'"
+      smtp_username = options[:answers][:q_puppet_enterpriseconsole_smtp_username]
+      smtp_password = options[:answers][:q_puppet_enterpriseconsole_smtp_password]
+      smtp_use_tls = "'#{options[:answers][:q_puppet_enterpriseconsole_smtp_use_tls]}'"
+      console_inventory_port = answer_for(options, :q_puppet_enterpriseconsole_inventory_port, 8140)
+      console_httpd_port = answer_for(options, :q_puppet_enterpriseconsole_httpd_port, 443)
 
-        console_a = {
-          :q_puppet_enterpriseconsole_install => 'y',
-          :q_puppet_enterpriseconsole_inventory_hostname => host,
-          :q_puppet_enterpriseconsole_inventory_certname => host,
-          :q_puppet_enterpriseconsole_inventory_dnsaltnames => dashboard,
-          :q_puppet_enterpriseconsole_inventory_port => 8140,
-          :q_puppet_enterpriseconsole_master_hostname => master,
+      console_a = {
+        :q_puppet_enterpriseconsole_install => 'y',
+        :q_puppet_enterpriseconsole_inventory_hostname => host,
+        :q_puppet_enterpriseconsole_inventory_certname => host,
+        :q_puppet_enterpriseconsole_inventory_dnsaltnames => dashboard,
+        :q_puppet_enterpriseconsole_inventory_port => console_inventory_port,
+        :q_puppet_enterpriseconsole_master_hostname => master,
 
-          :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
-          :q_puppet_enterpriseconsole_auth_password => dashboard_password,
+        :q_puppet_enterpriseconsole_auth_user_email => dashboard_user,
+        :q_puppet_enterpriseconsole_auth_password => dashboard_password,
 
-          :q_puppet_enterpriseconsole_httpd_port => 443,
+        :q_puppet_enterpriseconsole_httpd_port => console_httpd_port,
 
-          :q_puppet_enterpriseconsole_smtp_host => smtp_host,
-          :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
-          :q_puppet_enterpriseconsole_smtp_port => smtp_port,
-        }
+        :q_puppet_enterpriseconsole_smtp_host => smtp_host,
+        :q_puppet_enterpriseconsole_smtp_use_tls => smtp_use_tls,
+        :q_puppet_enterpriseconsole_smtp_port => smtp_port,
+      }
 
-        if smtp_password and smtp_username
-          console_a.merge!({
-                             :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
-                             :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
-                             :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
-                           })
-        end
+      if smtp_password and smtp_username
+        console_a.merge!({
+                           :q_puppet_enterpriseconsole_smtp_password => "'#{smtp_password}'",
+                           :q_puppet_enterpriseconsole_smtp_username => "'#{smtp_username}'",
+                           :q_puppet_enterpriseconsole_smtp_user_auth => 'y'
+                         })
+      end
 
-        # Database only answers
-        database_a = {
-          :q_puppetdb_install => 'y',
-          :q_database_install => 'y',
-          :q_database_root_password => "'=ZYdjiP3jCwV5eo9s1MBd'",
-          :q_database_root_user => 'pe-postgres',
-        }
+      # Database only answers
+      database_a = {
+        :q_puppetdb_install => 'y',
+        :q_database_install => 'y',
+        :q_database_root_password => "'#{answer_for(options, :q_database_root_password, '=ZYdjiP3jCwV5eo9s1MBd')}'",
+        :q_database_root_user => answer_for(options, :q_database_root_user, 'pe-postgres'),
+      }
 
-        # Special answers for special hosts
-        aix_a = {
-          :q_run_updtvpkg => 'y',
-        }
+      # Special answers for special hosts
+      aix_a = {
+        :q_run_updtvpkg => 'y',
+      }
 
-        answers = common_a.dup
+      answers = common_a.dup
 
+      unless options[:type] == :upgrade
+        answers.merge! agent_a
+      end
+
+      if host == master
+        answers.merge! master_console_a
         unless options[:type] == :upgrade
-          answers.merge! agent_a
+          answers.merge! master_a
+          answers.merge! master_database_a
         end
-
-        if host == master
-          answers.merge! master_console_a
-          unless options[:type] == :upgrade
-            answers.merge! master_a
-            answers.merge! master_database_a
-          end
-        end
-
-        if host == dashboard
-          answers.merge! master_console_a
-          answers.merge! console_database_a
-          answers[:q_pe_database] = 'y'
-          unless options[:type] == :upgrade
-            answers.merge! console_a
-          else
-            answers[:q_database_export_dir] = '/tmp'
-          end
-        end
-
-        if host == database
-          if database != master
-            if options[:type] == :upgrade
-              # This is kinda annoying - if we're upgrading to 3.0 and are
-              # puppetdb, we're actually doing a clean install. We thus
-              # need the core agent answers.
-              answers.merge! agent_a
-            end
-            answers.merge! master_database_a
-          end
-          answers.merge! database_a
-          answers.merge! console_database_a
-        end
-
-        if host == master and host == database and host == dashboard
-          answers[:q_all_in_one_install] = 'y'
-        end
-
-        if host['platform'].include? 'aix'
-          answers.merge! aix_a
-        end
-
-        return answers
       end
 
-      # Return answer data for all hosts.
-      #
-      # @param [Array<Beaker::Host>] hosts An array of host objects.
-      # @param [String] master_certname Hostname of the puppet master.
-      # @param [Hash] options options for answer files
-      # @option options [Symbol] :type Should be one of :upgrade or :install.
-      # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
-      #   data.
-      def self.answers(hosts, master_certname, options)
-        the_answers = {}
-        database = only_host_with_role(hosts, 'database')
-        dashboard = only_host_with_role(hosts, 'dashboard')
-        master = only_host_with_role(hosts, 'master')
-        hosts.each do |h|
-          if options[:type] == :upgrade and h[:pe_ver] =~ /\A3.0/
-            # 3.0.x to 3.0.x should require no answers
-            the_answers[h.name] = {
-              :q_install => 'y',
-              :q_install_vendor_packages => 'y',
-            }
-          else
-            the_answers[h.name] = host_answers(h, master_certname, master, database, dashboard, options)
-          end
-          h[:answers] = the_answers[h.name]
+      if host == dashboard
+        answers.merge! master_console_a
+        answers.merge! console_database_a
+        answers[:q_pe_database] = 'y'
+        unless options[:type] == :upgrade
+          answers.merge! console_a
+        else
+          answers[:q_database_export_dir] = answer_for(options, :q_database_export_dir, '/tmp')
         end
-        return the_answers
       end
+
+      if host == database
+        if database != master
+          if options[:type] == :upgrade
+            # This is kinda annoying - if we're upgrading to 3.0 and are
+            # puppetdb, we're actually doing a clean install. We thus
+            # need the core agent answers.
+            answers.merge! agent_a
+          end
+          answers.merge! master_database_a
+        end
+        answers.merge! database_a
+        answers.merge! console_database_a
+      end
+
+      if host == master and host == database and host == dashboard
+        answers[:q_all_in_one_install] = 'y'
+      end
+
+      if host['platform'].include? 'aix'
+        answers.merge! aix_a
+      end
+
+      return answers
+    end
+
+    # Return answer data for all hosts.
+    #
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def generate_answers
+      the_answers = {}
+      database = only_host_with_role(@hosts, 'database')
+      dashboard = only_host_with_role(@hosts, 'dashboard')
+      master = only_host_with_role(@hosts, 'master')
+      @hosts.each do |h|
+        if @options[:type] == :upgrade and h[:pe_ver] =~ /\A3.0/
+          # 3.0.x to 3.0.x should require no answers
+          the_answers[h.name] = {
+            :q_install => 'y',
+            :q_install_vendor_packages => 'y',
+          }
+        else
+          the_answers[h.name] = host_answers(h, @master_certname, master, database, dashboard, @options)
+        end
+        if h[:custom_answers]
+          the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
+        end
+        h[:answers] = the_answers[h.name]
+      end
+      return the_answers
     end
   end
 end

--- a/lib/beaker/answers/version32.rb
+++ b/lib/beaker/answers/version32.rb
@@ -1,31 +1,36 @@
 require 'beaker/answers/version30'
 
 module Beaker
-  module Answers
-    module Version32
-      def self.answers(hosts, master_certname, options)
-        dashboard = only_host_with_role(hosts, 'dashboard')
-        database = only_host_with_role(hosts, 'database')
-        master = only_host_with_role(hosts, 'master')
+  # This class provides answer file information for PE version 3.2
+  #
+  # @api private
+  class Version32 < Version30
+    # Return answer data for all hosts.
+    #
+    # @return [Hash] A hash (keyed from hosts) containing hashes of answer file
+    #   data.
+    def generate_answers
+      dashboard = only_host_with_role(@hosts, 'dashboard')
+      database = only_host_with_role(@hosts, 'database')
+      master = only_host_with_role(@hosts, 'master')
 
-        the_answers = Version30.answers(hosts, master_certname, options)
-        if dashboard != master
-          # in 3.2, dashboard needs the master certname
-          the_answers[dashboard.name][:q_puppetmaster_certname] = master_certname
-        end
-
-        if options[:type] == :upgrade && dashboard != database
-          # In a split configuration, there is no way for the upgrader
-          # to know how much disk space is available for the database
-          # migration. We tell it to continue on, because we're
-          # awesome.
-          the_answers[dashboard.name][:q_upgrade_with_unknown_disk_space] = 'y'
-        end
-        hosts.each do |h|
-          h[:answers] = the_answers[h.name]
-        end
-        return the_answers
+      the_answers = super
+      if dashboard != master
+        # in 3.2, dashboard needs the master certname
+        the_answers[dashboard.name][:q_puppetmaster_certname] = @master_certname
       end
+
+      if @options[:type] == :upgrade && dashboard != database
+        # In a split configuration, there is no way for the upgrader
+        # to know how much disk space is available for the database
+        # migration. We tell it to continue on, because we're
+        # awesome.
+        the_answers[dashboard.name][:q_upgrade_with_unknown_disk_space] = 'y'
+      end
+      @hosts.each do |h|
+        h[:answers] = the_answers[h.name]
+      end
+      return the_answers
     end
   end
 end

--- a/lib/beaker/answers/version34.rb
+++ b/lib/beaker/answers/version34.rb
@@ -1,12 +1,12 @@
 require 'beaker/answers/version32'
 
 module Beaker
-  module Answers
-    module Version34
-      def self.answers(hosts, master_certname, options)
-        the_answers = Version32.answers(hosts, master_certname, options)
-        return the_answers
-      end
+  # This class provides answer file information for PE version 3.4
+  #
+  # @api private
+  class Version34 < Version32
+    def generate_answers
+      super
     end
   end
 end

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -161,21 +161,25 @@ module Beaker
     #
     # @return nil
     def print_env_vars_affecting_beaker( log_level )
-      beaker_env_vars = Beaker::Options::Presets::ENVIRONMENT_SPEC.values
       non_beaker_env_vars =  [ 'BUNDLE_PATH', 'BUNDLE_BIN', 'GEM_HOME', 'GEM_PATH', 'RUBYLIB', 'PATH']
-      important_env_vars = beaker_env_vars + non_beaker_env_vars
-      env_var_map = important_env_vars.inject({}) do |memo, possibly_set_vars|
+      env_var_map = non_beaker_env_vars.inject({}) do |memo, possibly_set_vars|
         set_var = Array(possibly_set_vars).detect {|possible_var| ENV[possible_var] }
         memo[set_var] = ENV[set_var] if set_var
         memo
       end
 
-      puts ''
-      @logger.send( log_level, "Important ENV variables that may have affected your run:" )
+      env_var_map = env_var_map.merge(Beaker::Options::Presets.new.env_vars)
+
+      @logger.send( log_level, "\nImportant ENV variables that may have affected your run:" )
       env_var_map.each_pair do |var, value|
-        @logger.send( log_level, "    #{var}\t\t#{value}" )
+        if value.is_a?(Hash)
+          value.each_pair do | subvar, subvalue |
+            @logger.send( log_level, "    #{subvar}\t\t#{subvalue}" )
+          end
+        else
+          @logger.send( log_level, "    #{var}\t\t#{value}" )
+        end
       end
-      puts ''
     end
 
     # Prints the command line that can be called to reproduce this run
@@ -186,10 +190,8 @@ module Beaker
     #
     # @return nil
     def print_command_line( log_level = :debug )
-      puts ''
-      @logger.send(log_level, "You can reproduce this run with:\n")
+      @logger.send(log_level, "\nYou can reproduce this run with:\n")
       @logger.send(log_level, @options[:command_line])
-      puts ''
     end
   end
 end

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -476,8 +476,8 @@ module Beaker
             # We only need answers if we're using the classic installer
             version = host['pe_ver'] || opts[:pe_ver]
             if (! host['roles'].include? 'frictionless') || version_is_less(version, '3.2.0')
-              answers = Beaker::Answers.answers(opts[:pe_ver] || host['pe_ver'], hosts, master_certname, opts)
-              create_remote_file host, "#{host['working_dir']}/answers", Beaker::Answers.answer_string(host, answers)
+              answers = Beaker::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, master_certname, opts)
+              create_remote_file host, "#{host['working_dir']}/answers", answers.answer_string(host)
             else
               # If We're *not* running the classic installer, we want
               # to make sure the master has packages for us.

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -161,6 +161,7 @@ module Beaker
       #
       def initialize
          @command_line_parser = Beaker::Options::CommandLineParser.new
+         @presets = Beaker::Options::Presets.new
       end
 
       # Parses ARGV or provided arguments array, file options, hosts options and combines with environment variables and
@@ -181,7 +182,7 @@ module Beaker
         # Will use env, then hosts/config file, then command line, then file options
 
 
-        @options = Beaker::Options::Presets.presets
+        @options = @presets.presets
         cmd_line_options = @command_line_parser.parse(args)
         file_options = Beaker::Options::OptionsFileParser.parse_options_file(cmd_line_options[:options_file])
 
@@ -204,7 +205,7 @@ module Beaker
 
           # merge in env vars
           #   overwrite options (default, file options, command line, hosts file) with env
-          env_vars = Beaker::Options::Presets.env_vars
+          env_vars = @presets.env_vars
 
           @options = @options.merge(env_vars)
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -1,12 +1,12 @@
 module Beaker
   module Options
-    #A set of functions representing the environment variables and preset argument values to be incorporated
+    #A class representing the environment variables and preset argument values to be incorporated
     #into the Beaker options Object.
-    module Presets
+    class Presets
 
       # This is a constant that describes the variables we want to collect
       # from the environment. The keys correspond to the keys in
-      # `self.presets` (flattened) The values are an optional array of
+      # `presets` (flattened) The values are an optional array of
       # environment variable names to look for. The array structure allows
       # us to define multiple environment variables for the same
       # configuration value. They are checked in the order they are arrayed
@@ -26,24 +26,27 @@ module Beaker
         :release_apt_repo_url => ['BEAKER_RELEASE_APT_REPO', 'RELEASE_APT_REPO'],
         :release_yum_repo_url => ['BEAKER_RELEASE_YUM_REPO', 'RELEASE_YUM_REPO'],
         :dev_builds_url       => ['BEAKER_DEV_BUILDS_URL', 'DEV_BUILDS_URL'],
-        :q_puppet_enterpriseconsole_auth_user_email => 'q_puppet_enterpriseconsole_auth_user_email',
-        :q_puppet_enterpriseconsole_auth_password   => 'q_puppet_enterpriseconsole_auth_password',
-        :q_puppet_enterpriseconsole_smtp_host       => 'q_puppet_enterpriseconsole_smtp_host',
-        :q_puppet_enterpriseconsole_smtp_port       => 'q_puppet_enterpriseconsole_smtp_port',
-        :q_puppet_enterpriseconsole_smtp_username   => 'q_puppet_enterpriseconsole_smtp_username',
-        :q_puppet_enterpriseconsole_smtp_password   => 'q_puppet_enterpriseconsole_smtp_password',
-        :q_puppet_enterpriseconsole_smtp_use_tls    => 'q_puppet_enterpriseconsole_smtp_use_tls',
-        :q_verify_packages                          => 'q_verify_packages',
-        :q_puppetdb_password                        => 'q_puppetdb_password',
       }
+
+      # Select all environment variables whose name matches provided regex
+      # @return [Hash] Hash of environment variables
+      def select_env_by_regex regex
+        envs = Beaker::Options::OptionsHash.new
+        ENV.each_pair do | k, v |
+          if k.to_s =~ /#{regex}/
+            envs[k] = v
+          end
+        end
+        envs
+      end
 
       # Takes an environment_spec and searches the processes environment variables accordingly
       #
       # @param [Hash{Symbol=>Array,String}] env_var_spec  the spec of what env vars to search for
       #
       # @return [Hash] Found environment values
-      def self.collect_env_vars( env_var_spec )
-        env_var_spec.inject({:answers => {}}) do |memo, key_value|
+      def collect_env_vars( env_var_spec )
+        env_var_spec.inject({}) do |memo, key_value|
           key, value = key_value[0], key_value[1]
 
           set_env_var = Array(value).detect {|possible_variable| ENV[possible_variable] }
@@ -54,40 +57,43 @@ module Beaker
       end
 
       # Takes a hash where the values are found environment configuration values
-      # and munges them to appropriate Beaker configuration values
+      # and formats them to appropriate Beaker configuration values
       #
       # @param [Hash{Symbol=>String}] found_env_vars  Environment variables to munge
       #
-      # @return [Hash] Environment config values munged appropriately
-      def self.munge_found_env_vars( found_env_vars )
-        found_env_vars[:answers] ||= {}
-        found_env_vars.each_pair do |key,value|
-          found_env_vars[:answers][key] = value if key.to_s =~ /q_/
-        end
+      # @return [Hash] Environment config values formatted appropriately
+      def format_found_env_vars( found_env_vars )
         found_env_vars[:consoleport] &&= found_env_vars[:consoleport].to_i
         found_env_vars[:type] = found_env_vars[:is_pe] == 'true' || found_env_vars[:is_pe] == 'yes' ? 'pe' : nil
         found_env_vars[:pe_version_file_win] = found_env_vars[:pe_version_file]
-        found_env_vars[:answers].delete_if {|key, value| value.nil? or value.empty? }
-        found_env_vars.delete_if {|key, value| value.nil? or value.empty? }
+        found_env_vars
       end
-
 
       # Generates an OptionsHash of the environment variables of interest to Beaker
       #
       # @return [OptionsHash] The supported environment variables in an OptionsHash,
       #                       empty or nil environment variables are removed from the OptionsHash
-      def self.env_vars
-        h = Beaker::Options::OptionsHash.new
+      def calculate_env_vars
+        found = Beaker::Options::OptionsHash.new
+        found = found.merge(format_found_env_vars( collect_env_vars( ENVIRONMENT_SPEC )))
+        found[:answers] = select_env_by_regex('\\Aq_')
 
-        found = munge_found_env_vars( collect_env_vars( ENVIRONMENT_SPEC ))
+        found.delete_if {|key, value| value.nil? or value.empty? }
+        found
+      end
 
-        return h.merge( found )
+      # Return an OptionsHash of environment variables used in this run of Beaker
+      #
+      # @return [OptionsHash] The supported environment variables in an OptionsHash,
+      #                       empty or nil environment variables are removed from the OptionsHash
+      def env_vars
+        @env ||= calculate_env_vars
       end
 
       # Generates an OptionsHash of preset values for arguments supported by Beaker
       #
       # @return [OptionsHash] The supported arguments in an OptionsHash
-      def self.presets
+      def presets
         h = Beaker::Options::OptionsHash.new
         h.merge({
           :project              => 'Beaker',
@@ -125,12 +131,24 @@ module Beaker
           :pe_version_file      => 'LATEST',
           :pe_version_file_win  => 'LATEST-win',
           :answers              => {
-                                     :q_puppet_enterpriseconsole_auth_user_email => 'admin@example.com',
-                                     :q_puppet_enterpriseconsole_auth_password   => '~!@#$%^*-/ aZ',
-                                     :q_puppet_enterpriseconsole_smtp_port       => 25,
-                                     :q_puppet_enterpriseconsole_smtp_use_tls    => 'n',
-                                     :q_verify_packages                          => 'y',
-                                     :q_puppetdb_password                        => '~!@#$%^*-/ aZ'
+                                     :q_puppet_enterpriseconsole_auth_user_email    => 'admin@example.com',
+                                     :q_puppet_enterpriseconsole_auth_password      => '~!@#$%^*-/ aZ',
+                                     :q_puppet_enterpriseconsole_smtp_port          => 25,
+                                     :q_puppet_enterpriseconsole_smtp_use_tls       => 'n',
+                                     :q_verify_packages                             => 'y',
+                                     :q_puppetdb_password                           => '~!@#$%^*-/ aZ',
+                                     :q_puppetmaster_enterpriseconsole_port         => 443,
+                                     :q_puppet_enterpriseconsole_auth_database_name => 'console_auth',
+                                     :q_puppet_enterpriseconsole_auth_database_user => 'mYu7hu3r',
+                                     :q_puppet_enterpriseconsole_database_name      => 'console',
+                                     :q_puppet_enterpriseconsole_database_user      => 'mYc0nS03u3r',
+                                     :q_database_root_password                      => '=ZYdjiP3jCwV5eo9s1MBd',
+                                     :q_database_root_user                          => 'pe-postgres',
+                                     :q_database_export_dir                         => '/tmp',
+                                     :q_puppetdb_database_name                      => 'pe-puppetdb',
+                                     :q_puppetdb_database_user                      => 'mYpdBu3r',
+                                     :q_database_port                               => 5432,
+                                     :q_puppetdb_port                               => 8081,
           },
           :dot_fog              => File.join(ENV['HOME'], '.fog'),
           :ec2_yaml             => 'config/image_templates/ec2.yaml',

--- a/spec/beaker/answers_spec.rb
+++ b/spec/beaker/answers_spec.rb
@@ -3,205 +3,231 @@ require 'spec_helper'
 module Beaker
   describe Answers do
     let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
-    let( :options )     { Beaker::Options::Presets.presets }
+    let( :options )     { Beaker::Options::Presets.new.presets }
     let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
                           basic_hosts[1]['platform'] = 'windows'
                           basic_hosts }
     let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
 
     it 'generates 3.4 answers for 3.4 hosts' do
       @ver = '3.4'
-      Beaker::Answers::Version34.should_receive( :answers ).with( hosts, master_certname, {}).once
-      subject.answers( @ver, hosts, master_certname, {} )
+      expect( answers ).to be_a_kind_of Version34
     end
 
     it 'generates 3.2 answers for 3.3 hosts' do
       @ver = '3.3'
-      Beaker::Answers::Version32.should_receive( :answers ).with( hosts, master_certname, {}).once
-      subject.answers( @ver, hosts, master_certname, {} )
+      expect( answers ).to be_a_kind_of Version32
     end
 
     it 'generates 3.2 answers for 3.2 hosts' do
       @ver = '3.2'
-      Beaker::Answers::Version32.should_receive( :answers ).with( hosts, master_certname, options ).once
-      subject.answers( @ver, hosts, master_certname, options )
+      expect( answers ).to be_a_kind_of Version32
     end
 
     it 'generates 3.0 answers for 3.1 hosts' do
       @ver = '3.1'
-      Beaker::Answers::Version30.should_receive( :answers ).with( hosts, master_certname, options ).once
-      subject.answers( @ver, hosts, master_certname, options )
+      expect( answers ).to be_a_kind_of Version30
     end
 
     it 'generates 3.0 answers for 3.0 hosts' do
       @ver = '3.0'
-      Beaker::Answers::Version30.should_receive( :answers ).with( hosts, master_certname, options ).once
-      subject.answers( @ver, hosts, master_certname, options )
+      expect( answers ).to be_a_kind_of Version30
     end
 
     it 'generates 2.8 answers for 2.8 hosts' do
       @ver = '2.8'
-      Beaker::Answers::Version28.should_receive( :answers ).with( hosts, master_certname, options ).once
-      subject.answers( @ver, hosts, master_certname, options )
+      expect( answers ).to be_a_kind_of Version28
     end
 
     it 'generates 2.0 answers for 2.0 hosts' do
       @ver = '2.0'
-      Beaker::Answers::Version20.should_receive( :answers ).with( hosts, master_certname, options ).once
-      subject.answers( @ver, hosts, master_certname, options )
+      expect( answers ).to be_a_kind_of Version20
     end
 
     it 'raises an error for an unknown version' do
       @ver = 'x.x'
-      expect{ subject.answers( @ver, hosts, master_certname, options ) }.to raise_error( NotImplementedError )
+      expect{ answers }.to raise_error( NotImplementedError )
     end
   end
 
-  module Answers
-    describe Version34 do
-      let( :options )     { Beaker::Options::Presets.presets }
-      let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
-      let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
-                      basic_hosts[1]['roles'] = ['dashboard', 'agent']
-                      basic_hosts[2]['roles'] = ['database', 'agent']
-                      basic_hosts }
-      let( :master_certname ) { 'master_certname' }
-      it 'should add answers to the host objects' do
-        @ver = '3.4'
-        answers = subject.answers( hosts, master_certname, options )
-        hosts.each do |host|
-          expect( host[:answers] ).to be === answers[host.name]
-        end
+  describe Version34 do
+    let( :options )     { Beaker::Options::Presets.new.presets }
+    let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+    let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                    basic_hosts[0][:custom_answers] = { :q_custom => 'LOOKYHERE' }
+                    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                    basic_hosts[2]['roles'] = ['database', 'agent']
+                    basic_hosts }
+    let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+
+    before :each do
+      @ver = '3.4'
+      @answers = answers.answers
+    end
+
+    it 'should add answers to the host objects' do
+      hosts.each do |host|
+        expect( host[:answers] ).to be === @answers[host.name]
       end
     end
 
-    describe Version32 do
-      let( :options )     { Beaker::Options::Presets.presets }
-      let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
-      let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
-                      basic_hosts[1]['roles'] = ['dashboard', 'agent']
-                      basic_hosts[2]['roles'] = ['database', 'agent']
-                      basic_hosts }
-      let( :master_certname ) { 'master_certname' }
+    it 'appends custom answers to generated answers' do
+      expect( hosts[0][:custom_answers] ).to be == { :q_custom => 'LOOKYHERE' }
+      expect( @answers['vm1'] ).to include :q_custom
+      expect( hosts[0][:answers] ).to include :q_custom
+    end
 
-      # The only difference between 3.2 and 3.0 is the addition of the
-      # master certname to the dashboard answers
-      it 'should add q_puppetmaster_certname to the dashboard answers' do
-        @ver = '3.2'
-        expect( subject.answers( hosts, master_certname, options )['vm2']).to include :q_puppetmaster_certname
+  end
+
+  describe Version32 do
+    let( :options )     { Beaker::Options::Presets.new.presets }
+    let( :basic_hosts ) { make_hosts( {'pe_ver' => @ver } ) }
+    let( :hosts ) { basic_hosts[0]['roles'] = ['master', 'agent']
+                    basic_hosts[1]['roles'] = ['dashboard', 'agent']
+                    basic_hosts[2]['roles'] = ['database', 'agent']
+                    basic_hosts }
+    let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options.merge( {:type => :upgrade}) ) }
+
+    before :each do
+      @ver = '3.2'
+      @answers = answers.answers
+    end
+
+    # The only difference between 3.2 and 3.0 is the addition of the
+    # master certname to the dashboard answers
+    it 'should add q_puppetmaster_certname to the dashboard answers' do
+      expect( @answers['vm2']).to include :q_puppetmaster_certname
+    end
+
+    it 'should add q_upgrade_with_unknown_disk_space to the dashboard on upgrade' do
+      @upgrade_answers = upgrade_answers.answers
+      expect( @upgrade_answers['vm2']).to include :q_upgrade_with_unknown_disk_space
+    end
+
+    it 'should add answers to the host objects' do
+      hosts.each do |host|
+        expect( host[:answers] ).to be === @answers[host.name]
       end
+    end
+  end
 
-      it 'should add q_upgrade_with_unknown_disk_space to the dashboard on upgrade' do
-        @ver = '3.2'
-        expect( subject.answers( hosts, master_certname, options.merge( {:type => :upgrade} ) )['vm2']).to include :q_upgrade_with_unknown_disk_space
-      end
+  describe Version30 do
+    let( :options )     { Beaker::Options::Presets.new.presets }
+    let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
+    let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
+                          basic_hosts[1]['platform'] = 'windows'
+                          basic_hosts[2][:custom_answers] = { :q_custom => 'LOOKLOOKLOOK' }
+                          basic_hosts }
+    let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
+    let( :upgrade_answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options.merge( {:type => :upgrade}) ) }
 
-      it 'should add answers to the host objects' do
-        @ver = '3.2'
-        answers = subject.answers( hosts, master_certname, options )
-        hosts.each do |host|
-          expect( host[:answers] ).to be === answers[host.name]
-        end
+    before :each do
+      @ver = '3.0'
+      @answers = answers.answers
+    end
+
+    it 'uses simple answers for upgrade from 3.0.x to 3.0.x' do
+      @upgrade_answers = upgrade_answers.answers
+      expect( @upgrade_answers ).to be === { "vm2"=>{ :q_install=>"y", :q_install_vendor_packages=>"y" }, "vm1"=>{ :q_install=>"y", :q_install_vendor_packages=>"y" }, "vm3"=>{ :q_install=>"y", :q_install_vendor_packages=>"y", :q_custom=>"LOOKLOOKLOOK" } }
+    end
+
+    it 'sets correct answers for an agent' do
+      @ver = '3.0'
+      expect( @answers['vm3'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"n", :q_all_in_one_install=>"n", :q_puppet_enterpriseconsole_install=>"n", :q_puppetdb_install=>"n", :q_database_install=>"n", :q_custom=>"LOOKLOOKLOOK" }
+    end
+
+    it 'sets correct answers for a master' do
+      @ver = '3.0'
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"y", :q_all_in_one_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetdb_install=>"y", :q_database_install=>"y", :q_puppetdb_hostname=>hosts[0], :q_puppetdb_port=>8081, :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_certname=>"master_certname", :q_puppetdb_database_name=>"pe-puppetdb", :q_puppetdb_database_user=>"mYpdBu3r", :q_puppetdb_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_database_host=>hosts[0], :q_database_port=>5432, :q_pe_database=>"y", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_database_root_password=>"'=ZYdjiP3jCwV5eo9s1MBd'", :q_database_root_user=>"pe-postgres" }
+    end
+
+    it 'generates nil answers for a windows host' do
+      @ver = '3.0'
+      expect( @answers['vm2'] ).to be === nil
+    end
+
+    it 'should add answers to the host objects' do
+      @ver = '3.0'
+      a = answers.answers
+      hosts.each do |host|
+        expect( host[:answers] ).to be === @answers[host.name]
       end
     end
 
-    describe Version30 do
-      let( :options )     { Beaker::Options::Presets.presets }
-      let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
-      let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
-                            basic_hosts[1]['platform'] = 'windows'
-                            basic_hosts }
-      let( :master_certname ) { 'master_certname' }
+    it 'appends custom answers to generated answers' do
+      expect( hosts[2][:custom_answers] ).to be == { :q_custom => 'LOOKLOOKLOOK' }
+      expect( @answers['vm3'] ).to include :q_custom
+      expect( hosts[2][:answers] ).to include :q_custom
+    end
+  end
 
-      it 'uses simple answers for upgrade from 3.0.x to 3.0.x' do
-        @ver = '3.0'
-        expect( subject.answers( hosts, master_certname, options.merge({ :type => :upgrade }) )).to be === { "vm2"=>{ :q_install=>"y", :q_install_vendor_packages=>"y" }, "vm1"=>{ :q_install=>"y", :q_install_vendor_packages=>"y" }, "vm3"=>{ :q_install=>"y", :q_install_vendor_packages=>"y" } }
-      end
+  describe Version28 do
+    let( :options )     { Beaker::Options::Presets.new.presets }
+    let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
+    let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
+                          basic_hosts[1]['platform'] = 'windows'
+                          basic_hosts }
+    let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
 
-      it 'sets correct answers for an agent' do
-        expect( subject.answers( hosts, master_certname, options )['vm3'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"n", :q_all_in_one_install=>"n", :q_puppet_enterpriseconsole_install=>"n", :q_puppetdb_install=>"n", :q_database_install=>"n" }
-      end
+    before :each do
+      @ver = '2.8'
+      @answers = answers.answers
+    end
 
-      it 'sets correct answers for a master' do
-        @ver = '3.0'
-        expect( subject.answers( hosts, master_certname, options )['vm1'] ).to be === { :q_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_verify_packages=>"y", :q_puppet_symlinks_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>master_certname, :q_puppetmaster_install=>"y", :q_all_in_one_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetdb_install=>"y", :q_database_install=>"y", :q_puppetdb_hostname=>hosts[0], :q_puppetdb_port=>8081, :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_certname=>"master_certname", :q_puppetdb_database_name=>"pe-puppetdb", :q_puppetdb_database_user=>"mYpdBu3r", :q_puppetdb_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_database_host=>hosts[0], :q_database_port=>5432, :q_pe_database=>"y", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_database_root_password=>"'=ZYdjiP3jCwV5eo9s1MBd'", :q_database_root_user=>"pe-postgres" }
-      end
+    it 'sets correct answers for an agent' do
+      expect( @answers['vm3'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"n", :q_puppet_enterpriseconsole_install=>"n" }
+    end
 
-      it 'generates nil answers for a windows host' do
-        @ver = '3.0'
-        expect( subject.answers( hosts, master_certname, options )['vm2'] ).to be === nil
-      end
+    it 'sets correct answers for a master' do
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
+    end
 
-      it 'should add answers to the host objects' do
-        @ver = '3.0'
-        answers = subject.answers( hosts, master_certname, options )
-        hosts.each do |host|
-          expect( host[:answers] ).to be === answers[host.name]
-        end
+    it 'generates nil answers for a windows host' do
+      expect( @answers['vm2'] ).to be === nil
+    end
+
+    it 'should add answers to the host objects' do
+      hosts.each do |host|
+        expect( host[:answers] ).to be === @answers[host.name]
       end
     end
 
-    describe Version28 do
-      let( :options )     { Beaker::Options::Presets.presets }
-      let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
-      let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
-                            basic_hosts[1]['platform'] = 'windows'
-                            basic_hosts }
-      let( :master_certname ) { 'master_certname' }
+  end
+  describe Version20 do
+    let( :options )     { Beaker::Options::Presets.new.presets }
+    let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
+    let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
+                          basic_hosts[1]['platform'] = 'windows'
+                          basic_hosts }
+    let( :master_certname ) { 'master_certname' }
+    let( :answers )     { Beaker::Answers.create(@ver, hosts, master_certname, options) }
 
-      it 'sets correct answers for an agent' do
-        @ver = '2.8'
-        expect( subject.answers( hosts, master_certname, options )['vm3'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"n", :q_puppet_enterpriseconsole_install=>"n" }
-      end
-
-      it 'sets correct answers for a master' do
-        @ver = '2.8'
-        expect( subject.answers( hosts, master_certname, options )['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
-      end
-
-      it 'generates nil answers for a windows host' do
-        @ver = '2.8'
-        expect( subject.answers( hosts, master_certname, options )['vm2'] ).to be === nil
-      end
-
-      it 'should add answers to the host objects' do
-        @ver = '2.8'
-        answers = subject.answers( hosts, master_certname, options )
-        hosts.each do |host|
-          expect( host[:answers] ).to be === answers[host.name]
-        end
-      end
-
+    before :each do
+      @ver = '2.0'
+      @answers = answers.answers
     end
-    describe Version20 do
-      let( :options )     { Beaker::Options::Presets.presets }
-      let( :basic_hosts ) { make_hosts( { 'pe_ver' => @ver } ) }
-      let( :hosts )       { basic_hosts[0]['roles'] = ['master', 'database', 'dashboard']
-                            basic_hosts[1]['platform'] = 'windows'
-                            basic_hosts }
-      let( :master_certname ) { 'master_certname' }
 
-      it 'sets correct answers for an agent' do
-        @ver = '2.0'
-        expect( subject.answers( hosts, master_certname, options )['vm3'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"n", :q_puppet_enterpriseconsole_install=>"n" }
-      end
+    it 'sets correct answers for an agent' do
+      expect( @answers['vm3'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[2], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"n", :q_puppet_enterpriseconsole_install=>"n" }
+    end
 
-      it 'sets correct answers for a master' do
-        @ver = '2.0'
-        expect( subject.answers( hosts, master_certname, options )['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_root_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
-      end
+    it 'sets correct answers for a master' do
+      expect( @answers['vm1'] ).to be === { :q_install=>"y", :q_puppetagent_install=>"y", :q_puppet_cloud_install=>"y", :q_puppet_symlinks_install=>"y", :q_vendor_packages_install=>"y", :q_puppetagent_certname=>hosts[0], :q_puppetagent_server=>hosts[0], :q_puppetmaster_install=>"y", :q_puppet_enterpriseconsole_install=>"y", :q_puppetmaster_certname=>"master_certname", :q_puppetmaster_dnsaltnames=>"master_certname,puppet,#{hosts[0][:ip]}", :q_puppetmaster_enterpriseconsole_hostname=>hosts[0], :q_puppetmaster_enterpriseconsole_port=>443, :q_puppetmaster_forward_facts=>"y", :q_puppet_enterpriseconsole_database_install=>"y", :q_puppet_enterpriseconsole_auth_database_name=>"console_auth", :q_puppet_enterpriseconsole_auth_database_user=>"mYu7hu3r", :q_puppet_enterpriseconsole_auth_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_name=>"console", :q_puppet_enterpriseconsole_database_user=>"mYc0nS03u3r", :q_puppet_enterpriseconsole_database_root_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_database_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_inventory_hostname=>hosts[0], :q_puppet_enterpriseconsole_inventory_certname=>hosts[0], :q_puppet_enterpriseconsole_inventory_dnsaltnames=>hosts[0], :q_puppet_enterpriseconsole_inventory_port=>8140, :q_puppet_enterpriseconsole_master_hostname=>hosts[0], :q_puppet_enterpriseconsole_auth_user_email=>"'admin@example.com'", :q_puppet_enterpriseconsole_auth_password=>"'~!@\#$%^*-/ aZ'", :q_puppet_enterpriseconsole_httpd_port=>443, :q_puppet_enterpriseconsole_smtp_host=>"'vm1'", :q_puppet_enterpriseconsole_smtp_use_tls=>"'n'", :q_puppet_enterpriseconsole_smtp_port=>"'25'", :q_puppet_enterpriseconsole_auth_user=>"'admin@example.com'" }
+    end
 
-      it 'generates nil answers for a windows host' do
-        @ver = '2.0'
-        expect( subject.answers( hosts, master_certname, options )['vm2'] ).to be === nil
-      end
+    it 'generates nil answers for a windows host' do
+      expect( @answers['vm2'] ).to be === nil
+    end
 
-      it 'should add answers to the host objects' do
-        @ver = '2.0'
-        answers = subject.answers( hosts, master_certname, options )
-        hosts.each do |host|
-          expect( host[:answers] ).to be === answers[host.name]
-        end
+    it 'should add answers to the host objects' do
+      hosts.each do |host|
+        expect( host[:answers] ).to be === @answers[host.name]
       end
     end
   end

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -19,7 +19,7 @@ module Beaker
         cli.stub(:validate).and_return(true)
         cli.stub(:provision).and_return(true)
       end
-     
+
       describe "test fail mode" do
         it 'continues testing after failed test if using slow fail_mode' do
           cli.stub(:run_suite).with(:pre_suite, :fast).and_return(true)
@@ -47,7 +47,7 @@ module Beaker
 
         end
       end
- 
+
       describe "SUT preserve mode" do
         it 'cleans up SUTs post testing if tests fail and preserve_hosts = never' do
           cli.stub(:run_suite).with(:pre_suite, :fast).and_return(true)

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -8,7 +8,8 @@ class ClassMixedWithDSLInstallUtils
 end
 
 describe ClassMixedWithDSLInstallUtils do
-  let(:opts)          { Beaker::Options::Presets.presets.merge(Beaker::Options::Presets.env_vars) }
+  let(:presets)       { Beaker::Options::Presets.new }
+  let(:opts)          { presets.presets.merge(presets.env_vars) }
   let(:basic_hosts)   { make_hosts( { :pe_ver => '3.0',
                                        :platform => 'linux',
                                        :roles => [ 'agent' ] } ) }

--- a/spec/beaker/options/presets_spec.rb
+++ b/spec/beaker/options/presets_spec.rb
@@ -4,7 +4,7 @@ module Beaker
   module Options
 
     describe Presets do
-      let(:presets)    { Presets }
+      let(:presets)    { Presets.new }
 
       it "returns an env_vars OptionsHash" do
         expect(presets.env_vars).to be_instance_of(Beaker::Options::OptionsHash)
@@ -22,16 +22,16 @@ module Beaker
       describe 'when setting the type as pe from the environment' do
         describe 'sets type to pe if...' do
           it 'env var is set to "true"' do
-            munged = presets.munge_found_env_vars :is_pe => 'true'
+            munged = presets.format_found_env_vars( {:is_pe => 'true'} )
             expect( munged[:type] ).to be == 'pe'
           end
           it 'env var is set to "yes"' do
-            munged = presets.munge_found_env_vars :is_pe => 'yes'
+            munged = presets.format_found_env_vars( {:is_pe => 'yes'} )
             expect( munged[:type] ).to be == 'pe'
           end
         end
         it 'does not set type otherwise' do
-          munged = presets.munge_found_env_vars :is_pe => 'false'
+          munged = presets.format_found_env_vars( {:is_pe => 'false'} )
           expect( munged[:type] ).to be == nil
         end
       end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -47,7 +47,8 @@ module HostHelpers
   end
 
   def make_opts
-     Beaker::Options::Presets.presets.merge( Beaker::Options::Presets.env_vars ).merge( { :logger => logger,
+    opts = Beaker::Options::Presets.new
+    opts.presets.merge( opts.env_vars ).merge( { :logger => logger,
                                                :host_config => 'sample.config',
                                                :type => :foss,
                                                :pooling_api => 'http://vcloud.delivery.puppetlabs.net/',


### PR DESCRIPTION
...file before install
- add ability to add custom_answers to individual hosts to be appended
  to answer file
- rework answer file code so that answers are an object that can be
  queried for an answer string
- instead of querying env for individual answers just pull in anything
  that matches q_*
- pull the default answer values into the presets so that it is more
  easily tracked
