### PR TITLE
(QENG-1264) Allow users to specify recursive option for scp_{from,to}

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -166,12 +166,15 @@ module Beaker
     def scp_to source, target, options = {}, dry_run = false
       return if dry_run
 
-      options[:recursive]  = File.directory?(source)
-      options[:chunk_size] = options[:chunk_size] || 16384
+      local_opts = options.dup
+      if local_opts[:recursive].nil?
+        local_opts[:recursive] = File.directory?(source)
+      end
+      local_opts[:chunk_size] ||= 16384
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
-      @ssh.scp.upload! source, target, options do |ch, name, sent, total|
+      @ssh.scp.upload! source, target, local_opts do |ch, name, sent, total|
         result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
       end
 
@@ -188,12 +191,15 @@ module Beaker
     def scp_from source, target, options = {}, dry_run = false
       return if dry_run
 
-      options[:recursive] = true
-      options[:chunk_size] = options[:chunk_size] || 16384
+      local_opts = options.dup
+      if local_opts[:recursive].nil?
+        local_opts[:recursive] = true
+      end
+      local_opts[:chunk_size] ||= 16384
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
-      @ssh.scp.download! source, target, options do |ch, name, sent, total|
+      @ssh.scp.download! source, target, local_opts do |ch, name, sent, total|
         result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
       end
 


### PR DESCRIPTION
The fix for QENG-1128 caused scp_from and scp_to to ignore the
recursive flag. This caused all scp_from operations to be recursive,
which will cause a failure if trying to copy only a single file.

The fix to this, without regressing on QENG-1128, is to actually copy
the options hash locally so that we can modify it as needed for
defaults without updating any global data.
