### PR TITLE
Added link to installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Puppet Labs cloud enabled acceptance testing tool.
 
+# Installation
+
+See [Beaker Installation](https://github.com/puppetlabs/beaker/wiki/Beaker-Installation) wiki page.
+
 #Documentation
 
 Documentation for Beaker can be found online at the


### PR DESCRIPTION
I thought there were no installation instructions for `beaker` until I accidentaly clicked on `How to Beaker` in the Wiki.

Hence I propose to add these lines to the ReadMe to make life easier for Ruby newbies like me.
