### PR TITLE
(QENG-104) Remove gems that were pinned for Ruby 1.8

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'fakefs', '0.4'
   s.add_development_dependency 'rake', '~> 10.1.0'
-  s.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.9.12.6'
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
+  s.add_development_dependency 'markdown'
   s.add_development_dependency 'thin'
   s.add_development_dependency 'gitlab-grit'
 
@@ -44,13 +44,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fission', '~> 0.4'
   s.add_runtime_dependency 'google-api-client', '~> 0.7.1'
   s.add_runtime_dependency 'aws-sdk', '1.42.0'
-  s.add_runtime_dependency 'docker-api' unless RUBY_VERSION < '1.9'
+  s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'fog', '~> 1.22.1'
 
-  # These are transitive dependencies that we include or pin to because...
-  # Ruby 1.8 compatibility
-  s.add_runtime_dependency 'nokogiri', '~> 1.5.10'
-  s.add_runtime_dependency 'mime-types', '~> 1.25' # 2.0 won't install on 1.8
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'
 end


### PR DESCRIPTION
We no longer use ruby 1.8 internally. There is no reason to keep it
around any longer.

![nuke the entire site from orbit](http://iruntheinternet.com/lulzdump/images/gifs/alien-sigourneyweaver-nuke-riley-orbit-1348491814r.gif)
