### PR TITLE
(QENG-270) Added ntp_server as an option for host config

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -27,6 +27,7 @@ module Beaker
     # @option opts [Beaker::Logger] :logger A {Beaker::Logger} object
     def timesync host, opts
       logger = opts[:logger]
+      ntp_server = opts[:ntp_server] ? opts[:ntp_server] : NTPSERVER
       block_on host do |host|
         logger.notify "Update system time sync for '#{host.name}'"
         if host['platform'].include? 'windows'
@@ -34,15 +35,15 @@ module Beaker
           # is not actually necessary.
           host.exec(Command.new("w32tm /register"), :acceptable_exit_codes => [0,5])
           host.exec(Command.new("net start w32time"), :acceptable_exit_codes => [0,2])
-          host.exec(Command.new("w32tm /config /manualpeerlist:#{NTPSERVER} /syncfromflags:manual /update"))
+          host.exec(Command.new("w32tm /config /manualpeerlist:#{ntp_server} /syncfromflags:manual /update"))
           host.exec(Command.new("w32tm /resync"))
           logger.notify "NTP date succeeded on #{host}"
         else
           case
             when host['platform'] =~ /sles-/
-              ntp_command = "sntp #{NTPSERVER}"
+              ntp_command = "sntp #{ntp_server}"
             else
-              ntp_command = "ntpdate -t 20 #{NTPSERVER}"
+              ntp_command = "ntpdate -t 20 #{ntp_server}"
           end
           success=false
           try = 0


### PR DESCRIPTION
Before this, you couldn't specify an ntp server, so if you used the timesync option, it would only use the hard-coded value 'pool.ntp.org'.
This was a problem because occasionally that service couldn't be reached.  In order to fix this, we've allowed people to specify a server, so that they can get more reliable ntp services, and not see failures based on being able to reach one.
