### PR TITLE
(QENG-1211) Added documentation & tests for retry_on

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -1130,9 +1130,9 @@ module Beaker
 
       def curl_with_retries(desc, host, url, desired_exit_codes, max_retries = 60, retry_interval = 1)
         opts = {
-            :desired_exit_codes => desired_exit_codes,
-            :max_retries => max_retries,
-            :retry_interval => retry_interval
+          :desired_exit_codes => desired_exit_codes,
+          :max_retries => max_retries,
+          :retry_interval => retry_interval
         }
         retry_on(host, "curl -m 1 #{url}", opts)
       end

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -185,8 +185,8 @@ describe ClassMixedWithDSLHelpers do
       result.exit_code = 0
 
       opts = {
-          :max_retries    => 5,
-          :retry_interval => 0.0001,
+        :max_retries    => 5,
+        :retry_interval => 0.0001,
       }
 
       subject.stub(:on).and_return(result)
@@ -201,8 +201,8 @@ describe ClassMixedWithDSLHelpers do
       result.stderr = 'stderr'
 
       opts = {
-          :max_retries    => 10,
-          :retry_interval => 0.1,
+        :max_retries    => 10,
+        :retry_interval => 0.1,
       }
 
       reps_num = 4


### PR DESCRIPTION
Before, the retry_command method was private by convention, because it didn't have
tests or any documentation.  Some of the QA team wanted to use this functionality,
so now we've added those supporting items to gain confidence in its regular use.
