### PR TITLE
Allow overriding Docker api gem options

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -8,7 +8,7 @@ module Beaker
       @hosts = hosts
 
       # increase the http timeouts as provisioning images can be slow
-      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }
+      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(::Docker.options || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch
       ::Docker.validate_version!


### PR DESCRIPTION
Do not clean the Docker.options, as they may be already set

Specifically to allow the workaround from https://github.com/swipely/docker-api/issues/202 for
Excon::Errors::SocketError: end of file reached (EOFError) 
