### PR TITLE
(MAINT) pinned Yard version

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.9.12.6'
 
   # Documentation dependencies
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'yard', '0.8.7.4'
   s.add_development_dependency 'markdown' unless RUBY_VERSION < '1.9'
   s.add_development_dependency 'thin'
   s.add_development_dependency 'gitlab-grit'


### PR DESCRIPTION
Yard moved to 0.8.7.6 over the weekend, which broke our tests. This is an
issue because it takes time to figure out what happened when this upgrades
from under us when we're not aware, and they end up failing.  Pinning this
makes the problem explicit when we take the explicit action of upgrading
the library.  Pinned to 0.8.7.4.
