### PR TITLE
(QENG-1126) Allow setting IS_PE to the negative

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -64,7 +64,19 @@ module Beaker
       # @return [Hash] Environment config values formatted appropriately
       def format_found_env_vars( found_env_vars )
         found_env_vars[:consoleport] &&= found_env_vars[:consoleport].to_i
-        found_env_vars[:type] = found_env_vars[:is_pe] == 'true' || found_env_vars[:is_pe] == 'yes' ? 'pe' : nil
+
+        if found_env_vars[:is_pe]
+          is_pe_val = found_env_vars[:is_pe]
+          type = case is_pe_val
+                 when /yes|true/ then 'pe'
+                 when /no|false/ then 'foss'
+                 else
+                   raise "Invalid value for one of #{ENVIRONMENT_SPEC[:is_pe].join(' ,')}: #{is_pe_val}"
+                 end
+
+          found_env_vars[:type] = type
+        end
+
         found_env_vars[:pe_version_file_win] = found_env_vars[:pe_version_file]
         found_env_vars
       end

--- a/spec/beaker/options/presets_spec.rb
+++ b/spec/beaker/options/presets_spec.rb
@@ -30,8 +30,18 @@ module Beaker
             expect( munged[:type] ).to be == 'pe'
           end
         end
+        describe 'sets type to foss if...' do
+          it 'env var is set to "false"' do
+            munged = presets.format_found_env_vars( {:is_pe => 'true'} )
+            expect( munged[:type] ).to be == 'pe'
+          end
+          it 'env var is set to "no"' do
+            munged = presets.format_found_env_vars( {:is_pe => 'yes'} )
+            expect( munged[:type] ).to be == 'pe'
+          end
+        end
         it 'does not set type otherwise' do
-          munged = presets.format_found_env_vars( {:is_pe => 'false'} )
+          munged = presets.format_found_env_vars( {:is_pe => nil} )
           expect( munged[:type] ).to be == nil
         end
       end


### PR DESCRIPTION
Previously we had an environment variable "IS_PE" or "BEAKER_IS_PE" to
set whether or not we were using PE. Since then PE has become the
default. Module authors would like a similarly simple way via the ENV
to override the default and set the installation type as "FOSS".
The convention that has arisen is to use the negative in the IS_PE
environment variable (e.g. "IS_PE=no"). This brings that convention
into Beaker proper.

Original work done by @cyberious (Travis Fields).
