### PR TITLE
Prevent Docker.options from being overwritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ doc
 .idea/
 # rbenv file
 .ruby-version
+.ruby-gemset
 # Vagrant folder
 .vagrant/
 .vagrant_files/

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -8,7 +8,11 @@ module Beaker
       @hosts = hosts
 
       # increase the http timeouts as provisioning images can be slow
-      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }
+      timeout_opts = { :write_timeout => 300, :read_timeout => 300 }
+
+      # avoid over writing Docker options
+      ::Docker.options =  ( ::Docker.respond_to?(:options) ? ::Docker.options.merge(timeout_opts) : timeout_opts)
+
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch
       ::Docker.validate_version!


### PR DESCRIPTION
When running beaker specs under MacOs X the following exception occurs.

Excon::Errors::SocketError: end of file reached (EOFError) (swipely/docker-api#202)

Trying to apply a fix by passing the path of cert files is over written by:

https://github.com/puppetlabs/beaker/blob/master/lib/beaker/hypervisor/docker.rb#L11

``` ruby
cert_path = File.expand_path ENV['DOCKER_CERT_PATH']

Docker.options = {
  client_cert: File.join(cert_path, 'cert.pem'),
  client_key: File.join(cert_path, 'key.pem'),
  ssl_ca_file: File.join(cert_path, 'ca.pem'),
  scheme: 'https' # This is important when the URL starts with tcp://
}
```
