### PR TITLE
(gh-456) Can't ssh root@127.0.0.1 via vagrant if root...

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -128,7 +128,10 @@ module Beaker
 
         set_ssh_config host, 'vagrant'
 
+        #copy vagrant's keys to roots home dir, to allow for login as root
         copy_ssh_to_root host, @options
+        #ensure that root login is enabled for this host
+        enable_root_login host, @options
         #shut down connection, will reconnect on next exec
         host.close
 

--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -17,7 +17,6 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
       provider_section << "      vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium','#{host['disk_path']}']\n"
       provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
       provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
-      provider_section << "    end\n"
     end
     provider_section << "    end\n"
 


### PR DESCRIPTION
... login disabled in /etc/ssh/sshd_config
- add enable_root_login step by default
- clean up spurious 'end' when generating/using an extra disk on
  virtualbox instances
- tested clean locally
