### PR TITLE
QENG-1074 Add options for mac and win download from alternative sources for install_puppet

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -185,7 +185,7 @@ module Beaker
         end
       end
 
-      #Create the Higgs install command string based upon the host and options settings.  Installation command will be run as a 
+      #Create the Higgs install command string based upon the host and options settings.  Installation command will be run as a
       #background process.  The output of the command will be stored in the provided host['higgs_file'].
       # @param [Host] host The host that Higgs is to be installed on
       #                    The host object must have the 'working_dir', 'dist' and 'pe_installer' field set correctly.
@@ -532,7 +532,7 @@ module Beaker
       # @param  [Hash{Symbol=>Symbol, String}] opts The options
       # @option opts [String] :pe_dir Default directory or URL to pull PE package from
       #                  (Otherwise uses individual hosts pe_dir)
-      # @option opts [String] :pe_ver Default PE version to install 
+      # @option opts [String] :pe_ver Default PE version to install
       #                  (Otherwise uses individual hosts pe_ver)
       # @raise [StandardError] When installation times out
       #
@@ -598,10 +598,13 @@ module Beaker
       #Install FOSS based upon host configuration and options
       # @example will install puppet 3.6.1 from native puppetlabs provided packages wherever possible and will fail over to gem installation when impossible
       #  install_puppet({
-      #    :version        => '3.6.1',
-      #    :facter_version => '2.0.1',
-      #    :hiera_version  => '1.3.3',
-      #    :default_action => 'gem_install'
+      #    :version          => '3.6.1',
+      #    :facter_version   => '2.0.1',
+      #    :hiera_version    => '1.3.3',
+      #    :default_action   => 'gem_install',
+      #
+      #   })
+      #
       #
       # @example Will install latest packages on Enterprise Linux and Debian based distros and fail hard on all othere platforms.
       #  install_puppet()
@@ -609,12 +612,19 @@ module Beaker
       # @note This will attempt to add a repository for apt.puppetlabs.com on
       #       Debian or Ubuntu machines, or yum.puppetlabs.com on EL or Fedora
       #       machines, then install the package 'puppet'.
+      # @param [Hash{Symbol=>String}] opts
+      # @option opts [String] :version Version of puppet to download
+      # @option opts [String] :mac_download_url Url to download msi pattern of %url%/puppet-%version%.msi
+      # @option opts [String] :win_download_url Url to download dmg  pattern of %url%/(puppet|hiera|facter)-%version%.msi
       #
       # @api dsl
       # @return nil
       # @raise [StandardError] When encountering an unsupported platform by default, or if gem cannot be found when default_action => 'gem_install'
       # @raise [FailTest] When error occurs during the actual installation process
       def install_puppet(opts = {})
+        default_download_url = 'http://downloads.puppetlabs.com'
+        opts = {:win_download_url => "#{default_download_url}/windows",
+                :mac_download_url => "#{default_download_url}/mac"}.merge(opts)
         hosts.each do |host|
           if host['platform'] =~ /el-(5|6|7)/
             relver = $1
@@ -721,9 +731,7 @@ module Beaker
       # @param [Host] host The host to install packages on
       # @param [Hash{Symbol=>String}] opts An options hash
       # @option opts [String] :version The version of Puppet to install, required
-      #
-      # @return nil
-      # @api private
+      # @option opts [String] :win_download_url The url to download puppet from
       def install_puppet_from_msi( host, opts )
         #only install 64bit builds if
         # - we are on puppet version 3.7+
@@ -735,7 +743,7 @@ module Beaker
         else
           host['dist'] = "puppet-#{version}"
         end
-        link = "http://downloads.puppetlabs.com/windows/#{host['dist']}.msi"
+        link = "#{opts[:win_download_url]}/#{host['dist']}.msi"
         if not link_exists?( link )
           raise "Puppet #{version} at #{link} does not exist!"
         end
@@ -756,6 +764,7 @@ module Beaker
       # @option opts [String] :version The version of Puppet to install, required
       # @option opts [String] :facter_version The version of Facter to install, required
       # @option opts [String] :hiera_version The version of Hiera to install, required
+      # @option opts [String] :mac_download_url Url to download msi pattern of %url%/puppet-%version%.msi
       #
       # @return nil
       # @api private
@@ -764,9 +773,9 @@ module Beaker
         facter_ver = opts[:facter_version]
         hiera_ver = opts[:hiera_version]
 
-        on host, "curl -O http://downloads.puppetlabs.com/mac/puppet-#{puppet_ver}.dmg"
-        on host, "curl -O http://downloads.puppetlabs.com/mac/facter-#{facter_ver}.dmg"
-        on host, "curl -O http://downloads.puppetlabs.com/mac/hiera-#{hiera_ver}.dmg"
+        on host, "curl -O #{opts[:mac_download_url]}/puppet-#{puppet_ver}.dmg"
+        on host, "curl -O #{opts[:mac_download_url]}/facter-#{facter_ver}.dmg"
+        on host, "curl -O #{opts[:mac_download_url]}/hiera-#{hiera_ver}.dmg"
 
         on host, "hdiutil attach puppet-#{puppet_ver}.dmg"
         on host, "hdiutil attach facter-#{facter_ver}.dmg"

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -475,6 +475,21 @@ describe ClassMixedWithDSLInstallUtils do
         subject.install_puppet( :version => '3000', :facter_version => '1999', :hiera_version => '2001' )
       end
     end
+    context 'on windows' do
+      let(:platform) { "windows-2008r2-i386" }
+      it 'installs specific version of puppet when passed :version' do
+        subject.stub(:link_exists?).and_return( true )
+        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://downloads.puppetlabs.com/windows/puppet-3000.msi')
+        expect(subject).to receive(:on).with(hosts[0], 'msiexec /qn /i puppet-3000.msi')
+        subject.install_puppet(:version => '3000')
+      end
+      it 'installs from custom url when passed :win_download_url' do
+        subject.stub(:link_exists?).and_return( true )
+        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://nightlies.puppetlabs.com/puppet-latest/repos/windows/puppet-3000.msi')
+        expect(subject).to receive(:on).with(hosts[0], 'msiexec /qn /i puppet-3000.msi')
+        subject.install_puppet( :version => '3000', :win_download_url => 'http://nightlies.puppetlabs.com/puppet-latest/repos/windows' )
+      end
+    end
     describe 'on unsupported platforms' do
       let(:platform) { 'solaris-11-x86_64' }
       let(:host) { make_host('henry', :platform => 'solaris-11-x86_64') }


### PR DESCRIPTION
I've compressed the origin commits (which were: implement feature, nit, add tests, fix tests) into one.
