### PR TITLE
Fix #519 Unable to ssh to docker container based on Ubuntu Trusty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ doc
 .idea/
 # rbenv file
 .ruby-version
+.ruby-gemset
 # Vagrant folder
 .vagrant/
 .vagrant_files/

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -111,6 +111,7 @@ module Beaker
       # add platform-specific actions
       case host['platform']
       when /ubuntu/, /debian/
+        sshd_options = '-o "PermitRootLogin yes" -o "PasswordAuthentication yes"'
         dockerfile += <<-EOF
           RUN apt-get update
           RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES.join(' ')}


### PR DESCRIPTION
Fixes issue 519 - Docker unable to ssh with root user in Ubuntu Trusty

https://github.com/puppetlabs/beaker/issues/519
