### PR TITLE
(GH-320) Allow disabling of vbguest plugin auto-update

### DIFF
--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -9,6 +9,7 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
     provider_section  = ""
     provider_section << "    v.vm.provider :virtualbox do |vb|\n"
     provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{options['vagrant_memsize'] ||= '1024'}']\n"
+    provider_section << "      vb.vbguest.auto_update = false" if options[:vbguest_plugin] == 'disable'
     if host['disk_path']
       unless File.exist?(host['disk_path'])
         host['disk_path'] = File.join(host['disk_path'], "#{host.name}.vmdk")

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -26,6 +26,7 @@ module Beaker
         :release_apt_repo_url => ['BEAKER_RELEASE_APT_REPO', 'RELEASE_APT_REPO'],
         :release_yum_repo_url => ['BEAKER_RELEASE_YUM_REPO', 'RELEASE_YUM_REPO'],
         :dev_builds_url       => ['BEAKER_DEV_BUILDS_URL', 'DEV_BUILDS_URL'],
+        :vbguest_plugin       => ['BEAKER_VB_GUEST_PLUGIN', 'BEAKER_vb_guest_plugin'],
       }
 
       # Select all environment variables whose name matches provided regex

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -18,7 +18,7 @@ module Beaker
 
     end
 
-    it "can make a Vagranfile for a set of hosts" do
+    it "can make a Vagrantfile for a set of hosts" do
       FakeFS.activate!
       path = vagrant.instance_variable_get( :@vagrant_path )
       vagrant.stub( :randmac ).and_return( "0123456789" )

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -31,4 +31,16 @@ describe Beaker::VagrantVirtualbox do
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
     expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024']\n    end})
   end
+
+  it "can disable the vb guest plugin" do
+    options.merge!({ :vbguest_plugin => 'disable' })
+
+    vfile_section = vagrant.class.provider_vfile_section( @hosts.first, options )
+
+    match = vfile_section.match(/vb.vbguest.auto_update = false/)
+
+    expect( match ).to_not be nil
+
+  end
+
 end


### PR DESCRIPTION
A common Vagrant plugin can cause considerably lengthier test runs
unless disabled in the Vagrantfile.

This patch allows disabling the "vb auto update plugin" via an
environment variable
