### PR TITLE
(QENG-1454) Allow user to specify ports to open on ec2

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -236,7 +236,7 @@ module Beaker
           :image_id => image_id,
           :monitoring_enabled => true,
           :key_pair => ensure_key_pair(region),
-          :security_groups => [ensure_group(vpc || region, Beaker::EC2Helper.amiports(host['roles']))],
+          :security_groups => [ensure_group(vpc || region, Beaker::EC2Helper.amiports(host))],
           :instance_type => amisize,
           :disable_api_termination => false,
           :instance_initiated_shutdown_behavior => "terminate",

--- a/lib/beaker/hypervisor/ec2_helper.rb
+++ b/lib/beaker/hypervisor/ec2_helper.rb
@@ -3,11 +3,13 @@ module Beaker
     # Return a list of open ports for testing based on a hosts role
     #
     # @todo horribly hard-coded
-    # @param [Array<String>] roles An array of roles
+    # @param [Host] host to find ports for
     # @return [Array<Number>] array of port numbers
     # @api private
-    def self.amiports(roles)
+    def self.amiports(host)
       ports = [22, 61613, 8139]
+
+      roles = host['roles']
 
       if roles.include? 'database'
         ports << 5432
@@ -25,7 +27,15 @@ module Beaker
         ports << 4435
       end
 
-      ports
+      # If they only specified one port in the host config file, YAML will have converted it
+      # into a string, but if it was more than one, an array.
+      user_ports = []
+      if host.has_key?('additional_ports')
+        user_ports = host['additional_ports'].is_a?(Array) ? host['additional_ports'] : [host['additional_ports']]
+      end
+
+      additional_ports = ports + user_ports
+      additional_ports.uniq
     end
   end
 end

--- a/spec/beaker/hypervisor/ec2_helper_spec.rb
+++ b/spec/beaker/hypervisor/ec2_helper_spec.rb
@@ -4,20 +4,41 @@ require 'beaker/hypervisor/ec2_helper'
 describe Beaker::EC2Helper do
   context ".amiports" do
     let(:ec2) { Beaker::EC2Helper }
+
+    let(:master_host)  do
+      opts = { :snapshot => :pe, :roles => ['master'], :additional_ports => 9999 }
+      make_host('master', opts)
+    end
+
+    let(:database_host)  do
+      opts = { :snapshot => :pe, :roles => ['database'], :additional_ports => [1111, 5432] }
+      make_host('database', opts)
+    end
+
+    let(:dashboard_host)  do
+      opts = { :snapshot => :pe, :roles => ['dashboard'], :additional_ports => 2003 }
+      make_host('dashboard', opts)
+    end
+
+    let(:all_in_one_host)  do
+      opts = { :snapshot => :pe, :roles => ['master', 'database', 'dashboard']}
+      make_host('all_in_one', opts)
+    end
+
     it "can set ports for database host" do
-      expect(ec2.amiports(["database"])).to be === [22, 61613, 8139, 5432, 8080, 8081]
+      expect(ec2.amiports(database_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 1111]
     end
 
     it "can set ports for master host" do
-      expect(ec2.amiports(["master"])).to be === [22, 61613, 8139, 8140]
+      expect(ec2.amiports(master_host)).to be === [22, 61613, 8139, 8140, 9999]
     end
 
     it "can set ports for dashboard host" do
-      expect(ec2.amiports(["dashboard"])).to be === [22, 61613, 8139, 443, 4433, 4435]
+      expect(ec2.amiports(dashboard_host)).to be === [22, 61613, 8139, 443, 4433, 4435, 2003]
     end
 
     it "can set ports for combined master/database/dashboard host" do
-      expect(ec2.amiports(["dashboard", "master", "database"])).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 443, 4433, 4435]
+      expect(ec2.amiports(all_in_one_host)).to be === [22, 61613, 8139, 5432, 8080, 8081, 8140, 443, 4433, 4435]
     end
   end
 end


### PR DESCRIPTION
Previous to this commit, the list of ports that beaker should open for
ec2 was hard coded and incomplete. For example it was missing port
'5432' for the database node, which is the port postgresql uses.
This commit adds the ability for a user to specify additional ports to open
in their `hosts.cfg` file. By allowing this, it should provide some
flexibility to the hard coded nature of the ports, and allow beaker to
just provide the defaults that are currently known.
