### PR TITLE
(QENG-846) Centralized dated log path generation, and added options for ...

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -43,6 +43,9 @@ module Beaker
       @options[:helper].each do |helper|
         require File.expand_path(helper)
       end
+
+      @options[:log_dated_dir] = Beaker::Logger.generate_dated_log_folder(@options[:log_dir], @timestamp)
+      @options[:xml_dated_dir] = Beaker::Logger.generate_dated_log_folder(@options[:xml_dir], @timestamp)
     end
 
     #Provision, validate and configure all hosts as defined in the hosts file

--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -306,6 +306,18 @@ module Beaker
       @sublog.read
     end
 
+    # Utility method to centralize dated log folder generation
+    #
+    # @param [String] base_dir path of the directory for the dated log folder to live in
+    # @param [Time] timestamp the timestamp that should be used to generate the dated log folder
+    #
+    # @return [String] the path of the dated log folder generated
+    def Logger.generate_dated_log_folder(base_dir, timestamp)
+      log_dir = File.join(base_dir, timestamp.strftime("%F_%H_%M_%S"))
+      FileUtils.mkdir_p(log_dir) unless File.directory?(log_dir)
+      log_dir
+    end
+
     private
     # Expand each symlink found to its full path
     # Lines are assumed to be in the format "String : Integer"

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 
 module Beaker
   describe Logger, :use_fakefs => true do
-    let(:my_io)  { MockIO.new                         }
-    let(:logger) { Logger.new(my_io, :quiet => true)  }
+    let(:my_io)     { MockIO.new                         }
+    let(:logger)    { Logger.new(my_io, :quiet => true)  }
+    let(:test_dir)  { 'tmp/tests' }
 
 
     context '#convert' do
@@ -22,6 +23,20 @@ module Beaker
           pending "not supported in ruby 1.8 (using #{RUBY_VERSION})"
         end
       end
+    end
+
+    context '#generate_dated_log_folder' do
+
+      it 'generates path for a given timestamp' do
+        input_time = Time.new(2014, 6, 2, 16, 31, 22, '-07:00')
+        expect( Logger.generate_dated_log_folder(test_dir, input_time) ).to be === File.join(test_dir, '2014-06-02_16_31_22')
+      end
+
+      it 'generates directory for a given timestamp' do
+        input_time = Time.new(2011, 6, 10, 13, 7, 55, '-09:00')
+        expect( File.directory? Logger.generate_dated_log_folder(test_dir, input_time) ).to be_true
+      end
+
     end
 
     context 'new' do

--- a/spec/beaker/test_suite_spec.rb
+++ b/spec/beaker/test_suite_spec.rb
@@ -28,7 +28,7 @@ module Beaker
 
     context 'run', :use_fakefs => true do
 
-      let( :options )     { make_opts.merge({ :logger => double().as_null_object, 'name' => create_files(@files), :log_dir => '.' }) }
+      let( :options )     { make_opts.merge({ :logger => double().as_null_object, 'name' => create_files(@files), :log_dated_dir => '.', :xml_dated_dir => '.'}) }
       let(:broken_script) { "raise RuntimeError" }
       let(:fail_script)   { "raise Beaker::DSL::Outcomes::FailTest" }
       let(:okay_script)   { "true" }


### PR DESCRIPTION
...specific log paths

Before, the latest link was hard to use since it jumped around, and you couldn't really get at
the timestamped log path itself because it was hidden in the log_path function.  This work
separates out the timestamped path generation into a static method so that it can be used
anywhere, and adds the current usages of it to the global options, so that they can be used
for other purposes, such as the use case for this issue: copying other files to this location
