### PR TITLE
(QENG-1430) Added fail_on_error option to host.exec

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -249,7 +249,13 @@ module Beaker
           # exit codes at the host level and then raising...
           # is it necessary to break execution??
           unless result.exit_code_in?(Array(options[:acceptable_exit_codes] || 0))
-            raise CommandFailure, "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{@options[:trace_limit]} lines of output were:\n#{result.formatted_output(@options[:trace_limit])}"
+            msg = "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{@options[:trace_limit]} lines of output were:\n#{result.formatted_output(@options[:trace_limit])}"
+            if options[:fail_on_error] then
+              require 'beaker/dsl/outcomes'
+              fail_test msg
+            else
+              raise CommandFailure, msg
+            end
           end
         end
         # Danger, so we have to return this result?

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -119,6 +119,7 @@ module Beaker
           :dry_run              => false,
           :timeout              => 300,
           :fail_mode            => 'slow',
+          :fail_on_error        => false,
           :timesync             => false,
           :disable_iptables     => false,
           :repo_proxy           => false,

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -200,6 +200,24 @@ module Beaker
         host.exec(command,{})
       end
 
+      it 'raises a CommandFailure when an unacceptable exit code is returned' do
+        result.exit_code = 7
+        opts = { :acceptable_exit_codes => [0, 1] }
+
+        expect { host.exec(command, opts) }.to raise_error(Beaker::Host::CommandFailure)
+      end
+
+      it 'fails when an unacceptable exit code is returned and the fail_on_error option is set' do
+        result.exit_code = 7
+        opts = {
+          :acceptable_exit_codes  => [0, 1],
+          :fail_on_error          => true
+        }
+
+        host.should_receive( :fail_test ).once
+        host.exec(command, opts)
+      end
+
       context "controls the result objects logging" do
         it "and passes a test if the exit_code doesn't match the default :acceptable_exit_codes of 0" do
           result.exit_code = 0


### PR DESCRIPTION
Before, if an unacceptable exit code was returned, there was only one result: the
test would error out.  QA wants to be able to specify that as a failure in their
tests.  I've added this functionality in that if the fail_on_error option is set,
we fail rather than error out.
