### PR TITLE
Allow overriding Docker image entrypoint

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -146,6 +146,11 @@ module Beaker
         "RUN #{command}\n"
       }.join('')
 
+      # Override image entrypoint
+      if host['docker_image_entrypoint']
+        dockerfile += "ENTRYPOINT #{host['docker_image_entrypoint']}\n"
+      end
+
       # How to start a sshd on port 22.  May be an init for more supervision
       cmd = host['docker_cmd'] || "/usr/sbin/sshd -D #{sshd_options}"
       dockerfile += <<-EOF

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -238,6 +238,15 @@ module Beaker
         dockerfile.should =~ /RUN special one\nRUN special two\nRUN special three/
       end
 
+      it 'should add docker_image_entrypoint' do
+        dockerfile = docker.send(:dockerfile_for, {
+          'platform' => 'el-',
+          'docker_image_entrypoint' => '/bin/bash'
+        })
+
+        dockerfile.should =~ %r{ENTRYPOINT /bin/bash}
+      end
+
       it 'should use zypper on sles' do
         dockerfile = docker.send(:dockerfile_for, {
           'platform' => 'sles',


### PR DESCRIPTION
Using docker_image_entrypoint

May be useful for images that have an entrypoint so you can run sshd before that
