### PR TITLE
(QENG-1000) Ensure that add-el-extras works on all rhel platforms

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -143,9 +143,8 @@ module Beaker
     # @option opts [String] :epel_6_pkg Package to download from provided link for el-6
     # @option opts [String] :epel_5_pkg Package to download from provided link for el-5
     # @raise [Exception] Raises an error if the host provided's platform != /el-(5|6)/
-
     def epel_info_for host, opts
-      if !['centos','scientific','redhat','el'].include?(host['platform'].variant)
+      if !el_based?(host)
         raise "epel_info_for! not available for #{host.name} on platform #{host['platform']}"
       end
 
@@ -236,7 +235,7 @@ module Beaker
       debug_opt = opts[:debug] ? 'vh' : ''
       block_on host do |host|
         case
-        when ['centos','redhat','scientific','el'].include?(host['platform'].variant) && ['5','6'].include?(host['platform'].version)
+        when el_based?(host) && ['5','6'].include?(host['platform'].version)
           result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
           if result.exit_code == 1
             url, arch, pkg = epel_info_for host, opts
@@ -503,6 +502,16 @@ module Beaker
         #close the host to re-establish the connection with the new sshd settings
         host.close
       end
+    end
+
+    private
+
+    # A helper to tell whether a host is el-based
+    # @param [Host] host the host to act upon
+    #
+    # @return [Boolean] if the host is el_based
+    def el_based? host
+      ['centos','redhat','scientific','el','oracle'].include?(host['platform'].variant)
     end
 
   end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -238,19 +238,20 @@ describe Beaker do
 
     it "add extras for el-5/6 hosts" do
 
-      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 5 )
+      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 6 )
       hosts[0][:platform] = Beaker::Platform.new('el-6-arch')
       hosts[1][:platform] = Beaker::Platform.new('centos-6-arch')
       hosts[2][:platform] = Beaker::Platform.new('scientific-6-arch')
       hosts[3][:platform] = Beaker::Platform.new('redhat-6-arch')
+      hosts[4][:platform] = Beaker::Platform.new('oracle-5-arch')
 
-      Beaker::Command.should_receive( :new ).with("rpm -qa | grep epel-release").exactly( 5 ).times
+      Beaker::Command.should_receive( :new ).with("rpm -qa | grep epel-release").exactly( 6 ).times
       Beaker::Command.should_receive( :new ).with("rpm -i http://mirrors.kernel.org/fedora-epel/6/i386/epel-release-6-8.noarch.rpm").exactly( 4 ).times
-      Beaker::Command.should_receive( :new ).with("rpm -i http://mirrors.kernel.org/fedora-epel/5/i386/epel-release-5-4.noarch.rpm").exactly( 1 ).times
+      Beaker::Command.should_receive( :new ).with("rpm -i http://mirrors.kernel.org/fedora-epel/5/i386/epel-release-5-4.noarch.rpm").exactly( 2 ).times
       Beaker::Command.should_receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://mirrors\\.kernel\\.org/fedora\\-epel/6/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 4 ).times
-      Beaker::Command.should_receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://mirrors\\.kernel\\.org/fedora\\-epel/5/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 1 ).times
-      Beaker::Command.should_receive( :new ).with("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo").exactly( 5 ).times
-      Beaker::Command.should_receive( :new ).with("yum clean all && yum makecache").exactly( 5 ).times
+      Beaker::Command.should_receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://mirrors\\.kernel\\.org/fedora\\-epel/5/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 2 ).times
+      Beaker::Command.should_receive( :new ).with("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo").exactly( 6 ).times
+      Beaker::Command.should_receive( :new ).with("yum clean all && yum makecache").exactly( 6 ).times
 
       subject.add_el_extras( hosts, options )
 


### PR DESCRIPTION
The --add-el-extras options was only working for platform strings of the form
el-(5,6), which meant that you couldn't have beaker add the el repo on a
'centos' platform for instance.

Change makes more use of the Beaker::Platform attributes and checks
other rhel variants (centos, scientific, and the 'redhat' variant is
another platform label used for rhel I believe).
