### PR TITLE
fix bug with sed conditional check during permit root login

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -324,8 +324,9 @@ module Beaker
       logger = opts[:logger]
       block_on host do |host|
         logger.debug "Update /etc/ssh/sshd_config to allow root login"
-        host.exec(Command.new("sudo su -c \"sed -i 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config\""), {:pty => true}
-  )
+        # note: this sed command only works on gnu sed
+        host.exec(Command.new("sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""), {:pty => true}
+        )
         #restart sshd
         if host['platform'] =~ /debian|ubuntu/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})


### PR DESCRIPTION
If the sshd_config line has a '#" character the original code would fail to enable root logins and fail the whole test.  This fixes that by making the '#' character optional.

This fix will ensure any of the following permutations will be set to allow root logins.

``` shell
 #PermitRootLogin no
 #PermitRootLogin yes
 PermitRootLogin no
 PermitRootLogin yes


```
