### PR TITLE
Fix const_get for custom hypervisors

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -59,7 +59,7 @@ module Beaker
           rescue LoadError
             raise "Invalid hypervisor: #{type}"
           end
-          const_get("Beaker::#{type.capitalize}")
+          Beaker.const_get(type.capitalize)
         end
 
       hypervisor = hyper_class.new(hosts_to_provision, options)


### PR DESCRIPTION
This code must not have ever been used before, as const_get() has to be
run for each section of a namespace (and thus can't contain ::)

I don't have time to write tests right now, but this is required for custom hypervisors to work.
