### PR TITLE
beaker restarts sshd incorrectly on centos 6 

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -331,7 +331,7 @@ module Beaker
         if host['platform'] =~ /debian|ubuntu/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /centos|el-|redhat|fedora/
-          host.exec(Command.new("sudo su -c \"service sshd restart\""), {:pty => true})
+          host.exec(Command.new("sudo -E service sshd restart"))
         else
           @logger.warn("Attempting to update ssh on non-supported platform: #{host.name}: #{host['platform']}")
         end


### PR DESCRIPTION
I am not exactly sure how this was working before, but there seems to be an issue when running a combination of sudo,  su with -c and a pty session.  I removed some of this complexity since we don't need su - c to execute a command.  Additionally, I could not get my command to work without removing the pty session.  I only updated the redhat based line so further testing would need to be performed on debian but it nobody is complaining that it must work and therefore there is no reason to change it.

I have included the fix for #546 since its related but if you want to merge them separately I can just rebase against the master and push again.
