### PR TITLE
(GH-552) Hypervisor: Add support for vagrant_libvirt

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -38,6 +38,8 @@ module Beaker
           end
         when /^vagrant$/
           Beaker::Vagrant
+        when /^vagrant_libvirt$/
+          Beaker::VagrantLibvirt
         when /^vagrant_virtualbox$/
           Beaker::VagrantVirtualbox
         when /^vagrant_fusion$/
@@ -124,6 +126,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -1,0 +1,11 @@
+require 'beaker/hypervisor/vagrant'
+
+class Beaker::VagrantLibvirt < Beaker::Vagrant
+  def provision(provider = 'libvirt')
+    super
+  end
+
+  def self.provider_vfile_section(host, options)
+    "    v.vm.provider :libvirt"
+  end
+end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Beaker::VagrantLibvirt do
+  let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
+  let( :vagrant ) { Beaker::VagrantLibvirt.new( @hosts, options ) }
+
+  before :each do
+    @hosts = make_hosts()
+  end
+
+  it "uses the vagrant_libvirt provider for provisioning" do
+    @hosts.each do |host|
+      host_prev_name = host['user']
+      vagrant.should_receive( :set_ssh_config ).with( host, 'vagrant' ).once
+      vagrant.should_receive( :copy_ssh_to_root ).with( host, options ).once
+      vagrant.should_receive( :set_ssh_config ).with( host, host_prev_name ).once
+    end
+    vagrant.should_receive( :hack_etc_hosts ).with( @hosts, options ).once
+    FakeFS.activate!
+    vagrant.should_receive( :vagrant_cmd ).with( "up --provider libvirt" ).once
+    vagrant.provision
+  end
+
+  it "can make a Vagranfile for a set of hosts" do
+    FakeFS.activate!
+    path = vagrant.instance_variable_get( :@vagrant_path )
+    vagrant.stub( :randmac ).and_return( "0123456789" )
+
+    vagrant.make_vfile( @hosts )
+
+    vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+    expect( vagrantfile ).to include( %Q{    v.vm.provider :libvirt})
+  end
+end


### PR DESCRIPTION
Currently vagrand backend support is limited to virtualbox,
vmware_workstation and fusion. Vagrant offers a non-official
libvirt backend through the vagrant-libvirt[1] plugin.
This commit aims to add support for vagrant_libvirt.

[1] https://github.com/pradels/vagrant-libvirt

Closes #552 
