### PR TITLE
(QENG-1538) fixes EOS hack

### DIFF
--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -270,21 +270,10 @@ describe Beaker do
   context "sync_root_keys" do
     subject { dummy_class.new }
 
-    it "can sync keys on a solaris host" do
+    it "can sync keys on a solaris/eos host" do
       @platform = 'solaris'
 
-      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "| bash" ).exactly( 3 ).times
-
-      subject.sync_root_keys( hosts, options )
-
-    end
-
-    it "can sync keys on an eos host" do
-      @platform = 'eos'
-
-      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "> manage_root_authorized_keys" ).exactly( 3 ).times
-      expect( Beaker::Command ).to receive( :new ).with( "sed -i 's|mv -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys|cp -f $SSH_HOME/authorized_keys.tmp $SSH_HOME/authorized_keys|' manage_root_authorized_keys" ).exactly( 3 ).times
-      expect( Beaker::Command ).to receive( :new ).with( "bash manage_root_authorized_keys" ).exactly( 3 ).times
+      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "bash" ).exactly( 3 ).times
 
       subject.sync_root_keys( hosts, options )
 
@@ -292,7 +281,7 @@ describe Beaker do
 
     it "can sync keys on a non-solaris host" do
 
-      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "| env PATH=/usr/gnu/bin:$PATH bash" ).exactly( 3 ).times
+      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "env PATH=/usr/gnu/bin:$PATH bash" ).exactly( 3 ).times
 
       subject.sync_root_keys( hosts, options )
 


### PR DESCRIPTION
In QENG-299, a hack was required to get around an issue w/EOS
for root ssh key setup.  A change was submitted to the
sshkeys repo to fix this.  This fix removes the hack, and
sets up the correct root ssh key procedure in Beaker for EOS

Conflicts:
	spec/beaker/host_prebuilt_steps_spec.rb