### PR TITLE
Make restarting sshd more robust on Redhat systems

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -344,7 +344,7 @@ module Beaker
         if host['platform'] =~ /debian|ubuntu|cumulus/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
-          host.exec(Command.new("sudo -E service sshd restart"))
+          host.exec(Command.new("sudo -E /sbin/service sshd restart"))
         else
           @logger.warn("Attempting to update ssh on non-supported platform: #{host.name}: #{host['platform']}")
         end
@@ -492,7 +492,7 @@ module Beaker
           host.exec(Command.new("service ssh restart"))
         when /el-|centos|fedora|redhat|oracle|scientific|eos/
           host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
-          host.exec(Command.new("service sshd restart"))
+          host.exec(Command.new("/sbin/service sshd restart"))
         when /sles/
           host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("rcsshd restart"))

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -476,7 +476,7 @@ describe Beaker do
     it "can set the environment on an sshd-based linux host" do
       commands = [
           "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
-          "service sshd restart"
+          "/sbin/service sshd restart"
       ]
       set_env_helper('eos', commands)
     end


### PR DESCRIPTION
Without the exact path to the service command, it fails unless the path is correct. Specifying the path, makes beaker less dependent on path settings in the vagrant boxes
