### PR TITLE
Fix copying module files to guest

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -311,7 +311,7 @@ module Beaker
       ignore_re = nil
       if has_ignore
         ignore_arr = Array(options[:ignore]).map do |entry|
-          "((\/|\\A)#{entry}(\/|\\z))".sub(/\./, "\.")
+          "((\/|\\A)#{entry}(\/|\\z))".gsub(/\./, '\.')
         end
         ignore_re = Regexp.new(ignore_arr.join('|'))
       end


### PR DESCRIPTION
In certain scenarios, no module files are copied to the guest. I have found this issue with modules residing under `/vagrant/module_path` and `/home/ci/.../module_path`.

The regexp generated was `/(?-mix:((\/|\A).bundle(\/|\z))|((\/|\A).git(\/|\z))|((\/|\A).idea(\/|\z))|((\/|\A).vagrant(\/|\z))|((\/|\A).vendor(\/|\z))|((\/|\A)acceptance(\/|\z))|((\/|\A)spec(\/|\z))|((\/|\A)tests(\/|\z))|((\/|\A)log(\/|\z))|((\/|\A).(\/|\z))|((\/|\A)..(\/|\z)))/`. I tested this pattern in http://rubular.com/ and found that indeed it matches all files under those directories.

The string substitution was not doing anything at all (`"\."` gets expanded to `.` instead of `\.`).

It was also only trying to replace the first `.` of each entry as it was using `String#sub` instead of `String#gsub`.

Once that was fixed, beaker worked.
