### PR TITLE
(QENG-1548) vcloud hypervisor improvements

### DIFF
--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -98,8 +98,11 @@ module Beaker
         start = Time.now
         tasks = []
         @hosts.each_with_index do |h, i|
-          # Generate a randomized hostname
-          h['vmhostname'] = generate_host_name
+          if h['name']
+            h['vmhostname'] = h['name']
+          else
+            h['vmhostname'] = generate_host_name
+          end
 
           if h['template'] =~ /\//
             templatefolders = h['template'].split('/')


### PR DESCRIPTION
This PR has two changed to the 'vcloud' hypervisor:
- 'resourcepool' is not a required parameter, as non-DRS-enabled clusters do not have resource pools
- if 'name' is a specified host parameter, a randomized hostname is not generated
