### PR TITLE
(gh-585) Add support for vagrant 1.7.x

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -65,7 +65,7 @@ module Beaker
           stdout.read
         end
         #replace hostname with ip
-        ssh_config = ssh_config.gsub(/#{host.name}/, host['ip']) unless not host['ip']
+        ssh_config = ssh_config.gsub(/Host #{host.name}/, "Host #{host['ip']}") unless not host['ip']
         if host['platform'] =~ /windows/
           ssh_config = ssh_config.gsub(/127\.0\.0\.1/, host['ip']) unless not host['ip']
         end


### PR DESCRIPTION
As of version 1.7.x, vagrant will replace the default insecure keypair with a
randomly generated keypair on first 'vagrant up'. As a result the generated
ssh configs have changed and contain per-host private keys. Beaker was
breaking the path to these new private key files due to a substitution which
wasn't sufficiently constrained (the path to the private key now contains the
hostname, which was being replaced with the host's IP). This commit adds the
necessary constraint.
