### PR TITLE
Add vco provisioning

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'fog', '~> 1.25'
+  s.add_runtime_dependency 'rest-client', '~> 1.7'
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -54,6 +54,8 @@ module Beaker
           Beaker::Docker
         when /^openstack$/
           Beaker::OpenStack
+        when /^vcenter_orchestrator$/
+          Beaker::VcenterOrchestrator
         when /^none$/
           Beaker::Hypervisor
         else
@@ -129,6 +131,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack', 'vcenter_orchestrator', 'vcenter_orchestrator_helper' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/lib/beaker/hypervisor/vcenter_orchestrator.rb
+++ b/lib/beaker/hypervisor/vcenter_orchestrator.rb
@@ -1,0 +1,57 @@
+require 'yaml' unless defined?(YAML)
+
+module Beaker
+  class VcenterOrchestrator < Beaker::Hypervisor
+    def initialize(vco_hosts, options)
+      @options = options
+      @logger = options[:logger]
+      @hosts = vco_hosts
+    end
+
+    def provision
+      vco_vms = {}
+      @hosts.each do |h|
+        name = h["vmname"] || h.name
+        vco_vms[name] = h["provision_workflow"]
+      end
+
+      self.execute_workflow(vco_vms)
+
+    end
+
+    def cleanup
+      vco_vms = {}
+      @hosts.each do |h|
+        name = h["vmname"] || h.name
+        vco_vms[name] = h["cleanup_workflow"]
+      end
+
+      self.execute_workflow(vco_vms)
+    end
+
+    def execute_workflow vco_vms
+      vco_credentials = VcenterOrchestratorHelper.load_config(@options[:dot_fog])
+
+      @options[:verify_ssl] = true if @options[:verify_ssl].nil?
+
+      vco_helper = VcenterOrchestratorHelper.new( vco_credentials, @options[:verify_ssl] )
+
+      vco_vms.each_pair do |name, wf|
+        workflow = vco_helper.find_workflow(wf["name"], wf["id"])
+
+        @logger.notify "Executing vCenter Orchestrator workflow"
+
+        start = Time.now
+        # This will block for each workflow run
+        wf_return = vco_helper.run_workflow(workflow, vco_vms[name]["parameters"])
+
+        time = Time.now - start
+        @logger.notify "Spent %.2f seconds running workflow" % time
+
+        if wf_return != "COMPLETED"
+          raise "Vcenter Orchestrator Workflow run returned #{wf_return}, we expected it to return COMPLETED"
+        end
+      end
+    end
+  end
+end

--- a/lib/beaker/hypervisor/vcenter_orchestrator_helper.rb
+++ b/lib/beaker/hypervisor/vcenter_orchestrator_helper.rb
@@ -1,0 +1,153 @@
+require 'yaml' unless defined?(YAML)
+require 'beaker/logger'
+require 'rest-client'
+require 'nokogiri'
+require 'base64'
+require 'json'
+
+class VcenterOrchestratorHelper
+  def initialize vInfo, verify_ssl = true
+    @logger = vInfo[:logger] || Beaker::Logger.new
+
+    @base_url = "https://#{vInfo[:server]}/api"
+    @auth = 'Basic ' + Base64.encode64( "#{vInfo[:user]}:#{vInfo[:pass]}" ).chomp
+
+    @verify_ssl = verify_ssl
+  end
+
+  def self.load_config(dot_fog = '.fog')
+    # support Fog/Cloud Provisioner layout
+    # (ie, someplace besides my made up conf)
+    vco_credentials = nil
+    if File.exists?( dot_fog )
+      vco_credentials = load_fog_credentials(dot_fog)
+    else
+      raise ArgumentError, ".fog file '#{dot_fog}' does not exist"
+    end
+
+    return vco_credentials
+  end
+
+  def self.load_fog_credentials(dot_fog = '.fog')
+    vInfo = YAML.load_file( dot_fog )
+
+    vco_credentials = {}
+    vco_credentials[:server] = vInfo[:default][:vco_server]
+    vco_credentials[:user]   = vInfo[:default][:vco_username]
+    vco_credentials[:pass]   = vInfo[:default][:vco_password]
+
+    return vco_credentials
+  end
+
+  def find_workflow(wf, id)
+    if id
+      url = "#{@base_url}/workflows/#{id}"
+    else
+      wf.gsub!(/ /, '%20')
+      wfs = JSON.parse(RestClient::Request.new( :method => :get, 
+                                                :url => "#{@base_url}/workflows?conditions=name=#{wf}", 
+                                                :headers => {:Authorization => @auth, :accept => :json}, 
+                                                :verify_ssl => @verify_ssl).execute.body)
+      case wfs["count"]
+      when 1
+        id = nil
+        wfs["links"][0]["attributes"].each { |a| id = a["value"] if a["name"] == "id" }
+        raise "Could not find the ID for the workflow #{wf}" if id.nil?
+        url = "#{@base_url}/workflows/#{id}"
+      when 0
+        raise "No workflow found with the name #{wf}"
+      else
+        raise "More than one workflow found with the name: #{wf}\nTry specifying the workflow id instead"
+      end
+    end
+
+    url
+  end
+
+  # vCO 5.1 has a bug where it won't accept JSON in, but XML is painful to parse. So send requests in XML and receive responses in JSON
+  def run_workflow(url, parameters)
+    params = self.params_to_xml(parameters)
+
+    unless self.validate_wf(url, params)
+      raise "The parameters supplied are not valid for this workflow"
+    end
+
+    # Execute the workflow
+    response = RestClient::Request.new( :method => :post,
+                                        :url => "#{url}/executions",
+                                        :payload => params.to_xml,
+                                        :headers => {:Authorization => @auth, :accept => :json, :content_type => :xml},
+                                        :verify_ssl => @verify_ssl).execute
+
+    # Wait until something happens
+    wf_status = "RUNNING"
+    while wf_status == "RUNNING"
+      wf_status = self.get_wf_status(response.headers[:location])
+      sleep 5
+    end
+
+    wf_status
+  end
+
+  def params_to_xml parameters
+    Nokogiri::XML::Builder.new do |xml|
+      xml.send("execution-context", 'xmlns' => "http://www.vmware.com/vco") {
+        xml.parameters {
+          parameters.each_pair do |key, value|
+            type = self.javascript_class_type(value)
+            xml.send("parameter", :name => key, :type => type) {
+              if value.instance_of? Array
+                value.each do |arr_val|
+                  type = self.javascript_class_type(arr_val)
+                  xml.send("#{type}", arr_val)
+                end
+              else
+                xml.send("#{type}", value)
+              end
+            }
+          end
+        }
+      }
+    end
+  end
+
+  def validate_wf url, params
+    response = JSON.parse(RestClient::Request.new(  :method => :post,
+                                                    :url => "#{url}/presentation/instances",
+                                                    :payload => params.to_xml,
+                                                    :headers => {:Authorization => @auth, :accept => :json, :content_type => :xml}, 
+                                                    :verify_ssl => @verify_ssl).execute.body)
+
+    if response["valid"]
+      true
+    else
+      @logger.notify "Vcenter Orchestrator parameter validation failed:\n #{response['validationErrors']}"
+      false
+    end
+  end
+
+  def get_wf_status url
+    response = JSON.parse(RestClient::Request.new(:method => :get, 
+                                                  :url => url, 
+                                                  :headers => {:Authorization => @auth, :accept => :json, :content_type => :xml},
+                                                  :verify_ssl => @verify_ssl).execute.body)
+
+    response["state"]
+  end
+
+  def javascript_class_type value
+    class_of = lambda { |object, klass| object.kind_of?(klass) }
+    case
+      when class_of.curry[value][String]
+        return "string"
+      when class_of.curry[value][Fixnum], class_of.curry[value][Float]
+        return "number"
+      when class_of.curry[value][FalseClass], class_of.curry[value][TrueClass]
+        return "boolean"
+      when class_of.curry[value][Array]
+        return "Array/#{self.javascript_class_type(value[0])}"
+      else
+        raise "Unsupported parameter type #{value.class}"
+    end
+  end
+end

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -302,7 +302,7 @@ module Beaker
           if ['blimpy'].include?(visor)
             check_yaml_file(@options[:ec2_yaml], "required by #{visor}")
           end
-          if ['aix', 'solaris', 'vcloud'].include?(visor)
+          if ['aix', 'solaris', 'vcloud', 'vco'].include?(visor)
             check_yaml_file(@options[:dot_fog], "required by #{visor}")
           end
         end

--- a/spec/beaker/hypervisor/vcenter_orchestrator_helper_spec.rb
+++ b/spec/beaker/hypervisor/vcenter_orchestrator_helper_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+module Beaker
+  describe VcenterOrchestratorHelper do
+    let( :logger )         { double('logger').as_null_object }
+    let( :vInfo )          { { :server => "vsphere.labs.net", :user => "vco@labs.com", :pass => "supersekritpassword" } }
+    let( :vcenter_orchestrator_helper ) { VcenterOrchestratorHelper.new ( vInfo.merge( { :logger => logger } ) ) }
+    let( :url )            { "https://vsphere.labs.net:8280/workflows/12345678910"}
+    let( :params )         { {"vm_name" => "vm01"} }
+    let( :params_xml )         { '<?xml version="1.0"?>
+<execution-context xmlns="http://www.vmware.com/vco">
+  <parameters>
+    <parameter name="vm_name" type="string">
+      <string>vm01</string>
+    </parameter>
+  </parameters>
+</execution-context>
+' }
+
+    before :each do
+     stub_const( "RestClient", MockRestClient )
+     @parameters_obj = vcenter_orchestrator_helper.params_to_xml(params)
+    end
+
+    describe "#load_config" do 
+
+      it 'can load a .fog file' do
+        allow( File ).to receive( :exists? ).and_return( true )
+        allow( YAML ).to receive( :load_file ).and_return( fog_file_contents )
+
+        expect( VcenterOrchestratorHelper.load_config ).to be === vInfo
+
+      end
+
+      it 'raises an error when the .fog file is missing' do
+        allow( File ).to receive( :exists? ).and_return( false )
+
+        expect{ VcenterOrchestratorHelper.load_config }.to raise_error( ArgumentError )
+
+      end
+
+    end
+
+    describe '#params_to_xml' do
+
+      it 'returns parameters in xml' do
+        expect( vcenter_orchestrator_helper.params_to_xml(params).to_xml ).to be === params_xml
+      end
+
+    end
+
+    describe '#validate_wf' do
+
+      it 'returns true when parameters are correct' do
+        mockrequest = MockRestClient::Request.new
+        mockrequest.set_response(true)
+        
+        expect( vcenter_orchestrator_helper.validate_wf(url, @parameters_obj) ).to be === true
+      end
+
+      it 'returns false when parameters are incorrect' do
+        mockrequest = MockRestClient::Request.new
+        mockrequest.set_response(false)
+
+        expect( vcenter_orchestrator_helper.validate_wf(url, @parameters_obj) ).to be === false
+      end
+
+    end
+
+    describe '#javascript_class_type' do
+
+      it 'returns string when a String is passed to it' do
+        expect( vcenter_orchestrator_helper.javascript_class_type("a string") ).to be === "string"
+      end
+
+      it 'returns number when a Fixnum is passed to it' do
+        expect( vcenter_orchestrator_helper.javascript_class_type(1) ).to be === "number"
+      end
+
+      it 'returns boolean when true is passed to it' do
+        expect( vcenter_orchestrator_helper.javascript_class_type(true) ).to be === "boolean"
+      end
+
+      it 'returns Array/number when an array of Fixnum is passed to it' do
+        expect( vcenter_orchestrator_helper.javascript_class_type([1]) ).to be === "Array/number"
+      end
+
+    end
+
+    describe '#run_workflow' do
+
+      it 'returns the COMPLETED workflow status' do
+        allow( vcenter_orchestrator_helper ).to receive( :sleep ).and_return( true )
+        allow( vcenter_orchestrator_helper ).to receive( :params_to_xml ).and_return( @parameters_obj )
+        allow( vcenter_orchestrator_helper ).to receive( :validate_wf ).and_return( true )
+        mockrequest = MockRestClient::Request.new
+        mockrequest.set_response("COMPLETED")
+
+        expect( vcenter_orchestrator_helper.run_workflow(url, params) ).to be === "COMPLETED"
+      end
+
+      it 'Gets the workflow status until it returns completed' do    
+        allow( vcenter_orchestrator_helper ).to receive( :sleep ).and_return( true )
+        allow( vcenter_orchestrator_helper ).to receive( :params_to_xml ).and_return( @parameters_obj )
+        allow( vcenter_orchestrator_helper ).to receive( :validate_wf ).and_return( true )
+
+        @times_run = 0
+        allow( vcenter_orchestrator_helper ).to receive( :get_wf_status ) do |url|
+          if @times_run < 2
+            @times_run += 1
+            "RUNNING"
+          else
+            "COMPLETED"
+          end
+        end
+        
+        expect( vcenter_orchestrator_helper ).to receive(:get_wf_status).exactly(3).times
+        vcenter_orchestrator_helper.run_workflow(url, params)
+      end
+
+    end
+
+  end
+
+end

--- a/spec/beaker/hypervisor/vcenter_orchestrator_spec.rb
+++ b/spec/beaker/hypervisor/vcenter_orchestrator_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Beaker
+  describe VcenterOrchestrator do
+
+    before :each do
+      MockVcenterOrchestratorHelper.set_config( fog_file_contents )
+      MockVcenterOrchestratorHelper.set_wfs ( make_hosts() )
+      stub_const( "VcenterOrchestratorHelper", MockVcenterOrchestratorHelper )
+    end
+
+    describe '#provision' do
+      it 'runs provision workflow' do
+        vco = Beaker::VcenterOrchestrator.new( make_hosts(), make_opts )
+
+        vco.provision
+      end
+
+      it 'raises an error if a wf is missing' do
+        hosts = make_hosts()
+        hosts[0][:provision_workflow][:name] = "Unknown workflow"
+        vco = Beaker::VcenterOrchestrator.new( hosts, make_opts )
+
+        expect{ vco.provision }.to raise_error
+      end
+
+      it 'raises an error when the wf fails' do
+        hosts = make_hosts()
+        hosts[0][:provision_workflow][:parameters][:result] = "FAILED"
+        vco = Beaker::VcenterOrchestrator.new( hosts, make_opts )
+
+        expect{ vco.provision }.to raise_error
+      end
+    end
+
+    describe '#cleanup' do
+      it 'runs cleanup workflow' do
+        vco = Beaker::VcenterOrchestrator.new( make_hosts(), make_opts )
+
+        vco.cleanup
+      end
+    end
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -19,7 +19,10 @@ module TestFileHelpers
                     :solaris_hypervisor_snappaths => ["rpoooool/USER/z0"],
                     :vsphere_server => "vsphere.labs.net",
                     :vsphere_username => "vsphere@labs.com",
-                    :vsphere_password => "supersekritpassword"} }
+                    :vsphere_password => "supersekritpassword",
+                    :vco_server => "vsphere.labs.net",
+                    :vco_username => "vco@labs.com",
+                    :vco_password => "supersekritpassword",}, }
   end
 
 end
@@ -94,7 +97,20 @@ module HostHelpers
                :ip => HOST_IP % name,
                :template => HOST_TEMPLATE % name,
                :box => HOST_BOX % name,
-               :box_url => HOST_BOX_URL % name }.merge( preset_opts )
+               :box_url => HOST_BOX_URL % name,
+               :provision_workflow => {  :name => "Provision Workflow",
+                 :parameters => {
+                   :name => "vm_name",
+                   :result => "COMPLETED",
+                 }
+               },
+               :cleanup_workflow => {  :name => "Cleanup Workflow",
+                 :parameters => {
+                   :name => "vm_name",
+                   :result => "COMPLETED",
+                 }
+               }
+            }.merge( preset_opts )
       hosts << make_host(name, opts)
     end
     hosts

--- a/spec/mock_vcenter_orchestrator.rb
+++ b/spec/mock_vcenter_orchestrator.rb
@@ -1,0 +1,60 @@
+require 'json'
+
+class MockRestClient
+  class Response
+    attr_accessor :headers
+
+    def body
+      @body
+    end
+
+    def body=(value)
+      @body = value.to_json
+    end
+  end
+
+  class Request
+    def initialize opts = {}
+      @method = opts[:method]
+      @url = opts[:url]
+      @headers = opts[:headers]
+      @verify_ssl = opts[:verify_ssl]
+    end
+
+    def set_response response
+      @@response = response
+    end
+
+    def execute
+      execute_response = MockRestClient::Response.new
+      if @method == :get
+        if @url =~ /workflows?conditions=name=/
+          execute_response.body = {
+            "count" => 1, 
+            "links" => [
+              "attributes" => {
+                "value" => "12345678910",
+                "name" => "id",
+              },
+            ],
+          }
+        end
+        if @url =~ /workflows\/[0-9]*\/executions/
+          execute_response.body = { "state" => @@response }
+        end
+      end
+
+      if @method == :post
+        if @url =~ /presentation\/instances/
+          execute_response.body = { "valid" => @@response }
+        end
+
+        if @url =~ /executions/
+          execute_response.headers = { :location => "#{@url}/workflows/12345678910/executions/1" }
+        end
+      end
+
+      return execute_response
+    end
+  end
+end

--- a/spec/mock_vcenter_orchestrator_helper.rb
+++ b/spec/mock_vcenter_orchestrator_helper.rb
@@ -1,0 +1,53 @@
+class MockVcenterOrchestratorWorkflow
+  attr_accessor :name, :id, :parameters
+end
+
+class MockVcenterOrchestratorHelper
+
+  @@fog_file = {}
+
+  def initialize vInfo, verify_ssl
+
+  end
+
+  def self.set_config conf
+    @@fog_file = conf
+  end
+
+  def self.load_config file
+    @@fog_file
+  end
+
+  def find_workflow wf, id
+    url = nil
+    @@wfs.each_key do |workflow|
+      if workflow == wf
+        url = wf
+      end
+    end
+
+    if url
+      return url
+    else
+      raise "Workflow not found"
+    end
+  end
+
+  def self.set_wfs hosts
+    @@wfs = {}
+    hosts.each do |host|
+      wf = MockVcenterOrchestratorWorkflow.new
+      wf.name = host[:provision_workflow][:name]
+      wf.parameters = host[:provision_workflow][:parameters]
+      @@wfs[wf.name] = wf
+      wf = MockVcenterOrchestratorWorkflow.new
+      wf.name = host[:cleanup_workflow][:name]
+      wf.parameters = host[:cleanup_workflow][:parameters]
+      @@wfs[wf.name] = wf
+    end
+  end
+
+  def run_workflow url, parameters
+    parameters[:result]
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'matchers'
 require 'mock_fission'
 require 'mock_vsphere'
 require 'mock_vsphere_helper'
+require 'mock_vcenter_orchestrator'
+require 'mock_vcenter_orchestrator_helper'
 
 require 'rspec/its'
 


### PR DESCRIPTION
(gh-590) Add vCenter Orchestrator (vCO) support to Beaker

Without this patch beaker cannot use vCO to provision/cleanup virtual machines, which allows for the workflow that creates/destroys a vm to be customised to include various other steps that beaker will likely never support such as adding DNS, bootstrapping the guest OS, setting up password-less ssh login and creating appropriate hiera data.

This patch uses rest-client to issue REST API calls to a vCO host to execute a "provisioning" workflow and "cleanup" workflow where required. It uses the existing fog file to store vco credentials and allows for the workflow name and parameters to be set in the nodeset file.