### PR TITLE
(MAINT) also ignore the 'bundle' directory

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -26,7 +26,7 @@ module Beaker
       GitHubSig   = 'github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
 
       # The directories in the module directory that will not be scp-ed to the test system when using `copy_module_to`
-      PUPPET_MODULE_INSTALL_IGNORE = ['.bundle', '.git', '.idea', '.vagrant', '.vendor', 'vendor', 'acceptance', 'spec', 'tests', 'log']
+      PUPPET_MODULE_INSTALL_IGNORE = ['.bundle', '.git', '.idea', '.vagrant', '.vendor', 'vendor', 'acceptance', 'bundle', 'spec', 'tests', 'log']
 
       # @param [String] uri A uri in the format of <git uri>#<revision>
       #                     the `git://`, `http://`, `https://`, and ssh


### PR DESCRIPTION
If the 'bundle' directory is present, ignore it during setup/scp. Often has self-referential symlinks which do NOT play will with the scp which does a dereference of all symlinks. This results in infinite copy during setup. There's a similar PR which was merged in Sept for the '.bundle' directory but I've never seen bundler create a dir by that name so that ignore may be unnecessary. 