### PR TITLE
(QENG-1594) Prefix carriage returns during sshd_config append

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -479,28 +479,28 @@ module Beaker
         logger.debug("setting local environment on #{host.name}")
         case host['platform']
         when /windows/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/sshd_config"))
           host.exec(Command.new("cygrunsrv -E sshd"))
           host.exec(Command.new("cygrunsrv -S sshd"))
           env['CYGWIN'] = 'nodosfilewarning'
         when /osx/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/sshd_config"))
           host.exec(Command.new("launchctl unload /System/Library/LaunchDaemons/ssh.plist"))
           host.exec(Command.new("launchctl load /System/Library/LaunchDaemons/ssh.plist"))
         when /debian|ubuntu|cumulus/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("service ssh restart"))
         when /el-|centos|fedora|redhat|oracle|scientific|eos/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("/sbin/service sshd restart"))
         when /sles/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("rcsshd restart"))
         when /solaris/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("svcadm restart svc:/network/ssh:default"))
         when /aix/
-          host.exec(Command.new("echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config"))
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("stopsrc -g ssh"))
           host.exec(Command.new("startsrc -g ssh"))
         end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -449,7 +449,7 @@ describe Beaker do
 
     it "can set the environment on a windows host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/sshd_config",
         "cygrunsrv -E sshd",
         "cygrunsrv -S sshd"
       ]
@@ -458,7 +458,7 @@ describe Beaker do
 
     it "can set the environment on an OS X host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/sshd_config",
         "launchctl unload /System/Library/LaunchDaemons/ssh.plist",
         "launchctl load /System/Library/LaunchDaemons/ssh.plist"
       ]
@@ -467,7 +467,7 @@ describe Beaker do
 
     it "can set the environment on an ssh-based linux host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config",
         "service ssh restart"
       ]
       set_env_helper('ubuntu', commands)
@@ -475,7 +475,7 @@ describe Beaker do
 
     it "can set the environment on an sshd-based linux host" do
       commands = [
-          "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
+          "echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config",
           "/sbin/service sshd restart"
       ]
       set_env_helper('eos', commands)
@@ -483,7 +483,7 @@ describe Beaker do
 
     it "can set the environment on an sles host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config",
         "rcsshd restart"
       ]
       set_env_helper('sles', commands)
@@ -491,7 +491,7 @@ describe Beaker do
 
     it "can set the environment on a solaris host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config",
         "svcadm restart svc:/network/ssh:default"
       ]
       set_env_helper('solaris', commands)
@@ -499,7 +499,7 @@ describe Beaker do
 
     it "can set the environment on an aix host" do
       commands = [
-        "echo 'PermitUserEnvironment yes\n' >> /etc/ssh/sshd_config",
+        "echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config",
         "stopsrc -g ssh",
         "startsrc -g ssh"
       ]


### PR DESCRIPTION
The original fix: f2c1b1efd4d36575032294d504b15c56e3cda4e7 was appending
carriage returns instead of prefixing them. This patch corrects the order,
so QENG-1594 can be closed again.

Signed-off-by: Ken Barber <ken@bob.sh>