### PR TITLE
(gh-503) (QENG-1485) Fix recursive copying in do_scp_to

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -358,9 +358,9 @@ module Beaker
         dir_source.each do |s|
           s_path = Pathname.new(s)
           if s_path.absolute?
-            file_path = File.join(target, s.gsub(source,''))
+            file_path = File.join(target, File.dirname(s).gsub(source,''))
           else
-            file_path = File.join(target, s)
+            file_path = File.join(target, File.dirname(s))
           end
           result = connection.scp_to(s, file_path, options, $dry_run)
           @logger.trace result.stdout

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -384,11 +384,11 @@ module Beaker
 
           (@fileset1 + @fileset2).each do |file|
             if file !~ /#{exclude_file}/
-              file_args = [ file, File.join(target_path, file.gsub(source_path,'')), {:ignore => [exclude_file]} ]
+              file_args = [ file, File.join(target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file]} ]
               conn_args = file_args + [ nil ]
               expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
             else
-              file_args = [ file, File.join(target_path, file.gsub(source_path,'')), {:ignore => [exclude_file]} ]
+              file_args = [ file, File.join(target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file]} ]
               conn_args = file_args + [ nil ]
               expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
@@ -445,7 +445,7 @@ module Beaker
           expect( host ).to receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset1 + @fileset2).each do |file|
             if file !~ /#{exclude_file}/
-              file_args = [ file, File.join('target', file), {:ignore => [exclude_file]} ]
+              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
               conn_args = file_args + [ nil ]
               expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
             end
@@ -467,7 +467,7 @@ module Beaker
           expect( logger ).to receive(:trace)
           expect( host ).to receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset2).each do |file|
-            file_args = [ file, File.join('target', file), {:ignore => [exclude_file]} ]
+            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
             conn_args = file_args + [ nil ]
             expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
           end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -448,6 +448,10 @@ module Beaker
               file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
               conn_args = file_args + [ nil ]
               expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
+            else
+              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
+              conn_args = file_args + [ nil ]
+              expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
           end
 
@@ -465,7 +469,13 @@ module Beaker
           allow( Dir ).to receive( :glob ).and_return( @fileset1 + @fileset2 )
 
           expect( logger ).to receive(:trace)
+          expect( host ).to_not receive( :mkdir_p ).with('target/tmp/tests')
           expect( host ).to receive( :mkdir_p ).with('target/tmp/tests2')
+          (@fileset1).each do |file|
+            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
+            conn_args = file_args + [ nil ]
+            expect( conn ).to_not receive(:scp_to).with( *conn_args )
+          end
           (@fileset2).each do |file|
             file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
             conn_args = file_args + [ nil ]


### PR DESCRIPTION
Because of the functionality within do_scp_to which allows certain files and directories to be ignored when copying, each specific file/directory is copied individually. In the existing code the source and target paths are effectively the same, causing directories to be copied as subdirectories of themselves. This PR ensures that all files and directories are copied to their parent directories.

This PR also includes some additional expectations for the spec tests for do_scp_to. Some tests which are supposed to test whether files and directories are excluded from copies were only testing that non-excluded files *were* copied, and didn't test that excluded files *weren't* copied. The relevant commit explicitly tests that excluded files are not copied. Although not directly related to the original issue, it seemed sensible to roll this commit in with the others.