### PR TITLE
Add stderr output to stacktrace

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -162,12 +162,12 @@ module Beaker
             @logger.info(line)
           end
           if not wait_thr.value.success?
-            raise "Failed to exec 'vagrant #{args}'"
+            raise "Failed to exec 'vagrant #{args}'. Error was #{stderr.read}"
           end
           exit_status = wait_thr.value
         }
         if exit_status != 0
-          raise "Failed to execute vagrant_cmd ( #{args} )"
+          raise "Failed to execute vagrant_cmd ( #{args} ). Error was #{stderr.read}"
         end
       end
     end


### PR DESCRIPTION
In some cases an underlying issue causes the vagrant hypervisor to fail but gives no usable output.
By adding the stderr output to the raise gives the user more info on why it failed.