### PR TITLE
(MAINT) Improve error message when docker not found

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -11,7 +11,12 @@ module Beaker
       ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(::Docker.options || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch
-      ::Docker.validate_version!
+      begin
+        ::Docker.validate_version!
+      rescue Excon::Errors::SocketError => e
+        raise "Docker instance not found.\nif you are on OSX, you might not have Boot2Docker setup correctly\nCheck your DOCKER_HOST variable has been set"
+      end
+
       # Pass on all the logging from docker-api to the beaker logger instance
       ::Docker.logger = @logger
     end


### PR DESCRIPTION
Right now when docker not found, you get:

```
Hypervisor for debian-7 is docker
Beaker::Hypervisor, found some docker boxes to create
/opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/gems/excon-0.43.0/lib/excon/unix_socket.rb:14:in `connect_nonblock': No such file or directory - connect(2) (Errno::ENOENT) (Excon::Errors::SocketError)
	from /opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/gems/excon-0.43.0/lib/excon/unix_socket.rb:14:in `connect'
	from /opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/gems/excon-0.43.0/lib/excon/socket.rb:28:in `initialize'
```

This improves the message and gives a little guidance