### PR TITLE
[docker] No need to restart sshd

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -108,7 +108,9 @@ module Beaker
       if @options[:disable_iptables]
         disable_iptables @hosts, @options
       end
-      set_env(@hosts, @options)
+      if @options[:set_env]
+        set_env(@hosts, @options)
+      end
     end
 
     #Default validation steps to be run for a given hypervisor.  Ensures that SUTs meet requirements to be

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -112,15 +112,15 @@ module Beaker
       sshd_options = ''
 
       # add platform-specific actions
+      service_name = "sshd"
       case host['platform']
       when /ubuntu/, /debian/
-        sshd_options = '-o "PermitRootLogin yes" -o "PasswordAuthentication yes"'
+        service_name = "ssh"
         dockerfile += <<-EOF
           RUN apt-get update
           RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES.join(' ')}
         EOF
         when  /cumulus/
-          sshd_options = '-o "PermitRootLogin yes" -o "PasswordAuthentication yes"'
           dockerfile += <<-EOF
           RUN apt-get update
           RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES.join(' ')}
@@ -133,11 +133,11 @@ module Beaker
           RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
         EOF
       when /opensuse/, /sles/
-        sshd_options = '-o "PermitRootLogin yes" -o "PasswordAuthentication yes" -o "UsePAM no"'
         dockerfile += <<-EOF
           RUN zypper -n in openssh #{Beaker::HostPrebuiltSteps::SLES_PACKAGES.join(' ')}
           RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
           RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
+          RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
         EOF
       else
         # TODO add more platform steps here
@@ -150,6 +150,13 @@ module Beaker
         RUN echo root:#{root_password} | chpasswd
       EOF
 
+      # Configure sshd service to allowroot login using password
+      dockerfile += <<-EOF
+        RUN sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        RUN sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+      EOF
+
+
       # Any extra commands specified for the host
       dockerfile += (host['docker_image_commands'] || []).map { |command|
         "RUN #{command}\n"
@@ -161,7 +168,8 @@ module Beaker
       end
 
       # How to start a sshd on port 22.  May be an init for more supervision
-      cmd = host['docker_cmd'] || "/usr/sbin/sshd -D #{sshd_options}"
+      # Ensure that the ssh server can be restarted (done from set_env) and container keeps running
+      cmd = host['docker_cmd'] || ["sh","-c","service #{service_name} start ; tail -f /dev/null"]
       dockerfile += <<-EOF
         EXPOSE 22
         CMD #{cmd}

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -138,6 +138,7 @@ module Beaker
           :accept_all_exit_codes  => false,
           :timesync               => false,
           :disable_iptables       => false,
+          :set_env                => true,
           :repo_proxy             => false,
           :package_proxy          => false,
           :add_el_extras          => false,


### PR DESCRIPTION
Do not restart the sshd service when using Docker as it causes the container to stop.
Fix #611