### PR TITLE
(QENG-1677) Adds Fog Hypervisor

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -129,6 +129,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack', 'fog' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/lib/beaker/hypervisor/fog.rb
+++ b/lib/beaker/hypervisor/fog.rb
@@ -1,0 +1,105 @@
+require 'fog'
+
+module Beaker
+  #Beaker support for Fog
+  class Fog < Beaker::Hypervisor
+
+    SLEEPWAIT = 5
+
+    #Create a new instance of the Fog hypervisor object
+    #@param [<Host>] hosts The array of Fog hosts to provision
+    #@param [Hash{Symbol=>String}] options The options hash containing configuration values
+    def initialize(hosts, options)
+      @options = options
+      @logger = options[:logger]
+      @hosts = hosts
+      @vms = []
+
+      host = hosts.first
+
+      fog_auth = get_cloud_auth_method(hosts)
+
+      fog_compute_options = { :provider => host[:cloud_provider]}.merge( fog_auth )
+
+      @compute_client ||= ::Fog::Compute.new( fog_compute_options )
+
+      if not @compute_client
+        raise "Unable to create #{host[:cloud_provider]} Compute instance"
+      end
+    end
+
+    #Create new instances in digitalocean
+    def provision
+      @hosts.each do |host|
+        @logger.notify "Provisioning #{host[:cloud_provider]} using Fog"
+        host[:vmhostname] = generate_host_name
+        @logger.debug "Provisioning #{host.name} (#{host[:vmhostname]})"
+
+        extras = provider_specific_fields(host)
+
+        default_server_options = {
+          :name => host[:vmhostname],
+          :image_id => host[:image_id],
+          :public_key_path => host[:public_key_path] || File.expand_path('~/.ssh/id_rsa.pub'),
+          :private_key_path => host[:private_key_path] || File.expand_path('~/.ssh/id_rsa'),
+        }
+
+        server_options = default_server_options.merge(extras)
+
+        vm = @compute_client.servers.bootstrap(server_options)
+
+        @logger.debug "Waiting for #{host.name} (#{host[:vmhostname]}) to respond"
+        vm.wait_for {
+          ready?
+        }
+
+        host[:ip] = vm.public_ip_address
+
+        @vms << vm
+
+      end
+    end
+
+    #Destroy any digitalocean instances
+    def cleanup
+      @logger.notify "Cleaning up Fog Created Servers"
+      @vms.each do |vm|
+        @logger.debug "Destroying host: #{vm.name}"
+        vm.destroy
+      end
+    end
+
+    def get_cloud_auth_method(hosts)
+      host = hosts.first
+
+      provider = host[:cloud_provider]
+
+      case provider
+      when /DigitalOcean/
+        fog_auth = {
+          :digitalocean_api_key => host[:digitalocean_api_key],
+          :digitalocean_client_id => host[:digitalocean_client_id],
+        }
+      else
+        raise NotImplementedError, "Don't know the cloud auth for #{provider}"
+      end
+    end
+
+    def provider_specific_fields(host)
+      provider = host[:cloud_provider]
+
+      case provider
+      when /DigitalOcean/
+        specific_fields = {
+          :flavor_id => host[:flavor_id],
+          :region_id => host[:region_id],
+          :size_id   => host[:size_id],
+        }
+      else
+        raise NotImplementedError, "Cant find the server specific fields for #{provider}"
+      end
+
+    end
+
+  end
+end

--- a/lib/beaker/hypervisor/fog.rb
+++ b/lib/beaker/hypervisor/fog.rb
@@ -34,7 +34,7 @@ module Beaker
     def provision
       @hosts.each do |host|
         @logger.notify "Provisioning #{host[:cloud_provider]} using Fog"
-        host[:vmhostname] = generate_host_name
+        host[:vmhostname] = "beaker-#{generate_host_name}"
         @logger.debug "Provisioning #{host.name} (#{host[:vmhostname]})"
 
         extras = provider_specific_fields(host)

--- a/lib/beaker/hypervisor/fog.rb
+++ b/lib/beaker/hypervisor/fog.rb
@@ -28,7 +28,9 @@ module Beaker
       end
     end
 
-    #Create new instances in digitalocean
+    # Provision all hosts in cloud using the Fog API
+    #
+    # @return [void]
     def provision
       @hosts.each do |host|
         @logger.notify "Provisioning #{host[:cloud_provider]} using Fog"
@@ -60,7 +62,11 @@ module Beaker
       end
     end
 
-    #Destroy any digitalocean instances
+    # Cleanup all earlier provisioned machines on cloud of choice using Fog
+    #
+    # #cleanup does nothing without a #provision call first.
+    #
+    # @return [void]
     def cleanup
       @logger.notify "Cleaning up Fog Created Servers"
       @vms.each do |vm|
@@ -69,6 +75,13 @@ module Beaker
       end
     end
 
+    # Return a hash containing the auth credentials for the VPS of choice
+    #
+    # Every provider has different auth methods, so we have to specify the keys
+    #
+    # @param [Array<Beaker::Host>] hosts Array of Beaker::Host objects
+    # @return [Hash<Symbol, String>] fog_auth Auth keys for given provider
+    # @api private
     def get_cloud_auth_method(hosts)
       host = hosts.first
 
@@ -85,6 +98,13 @@ module Beaker
       end
     end
 
+    # Return a hash containing the provider specific fields for the VPS of choice
+    #
+    # Not everyone has region ids, some you have to specify networks and such
+    #
+    # @param [Array<Beaker::Host>] hosts Array of Beaker::Host objects
+    # @return [Hash<Symbol, String>] specific_fields Provider specific fields
+    # @api private
     def provider_specific_fields(host)
       provider = host[:cloud_provider]
 

--- a/lib/beaker/hypervisor/fog.rb
+++ b/lib/beaker/hypervisor/fog.rb
@@ -42,8 +42,8 @@ module Beaker
         default_server_options = {
           :name => host[:vmhostname],
           :image_id => host[:image_id],
-          :public_key_path => host[:public_key_path] || File.expand_path('~/.ssh/id_rsa.pub'),
-          :private_key_path => host[:private_key_path] || File.expand_path('~/.ssh/id_rsa'),
+          :public_key_path => host[:public_key_path] || @options[:fog_private_key],
+          :private_key_path => host[:private_key_path] || @options[:fog_public_key],
         }
 
         server_options = default_server_options.merge(extras)

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -191,6 +191,8 @@ module Beaker
           :ec2_yaml               => 'config/image_templates/ec2.yaml',
           :help                   => false,
           :collect_perf_data      => false,
+          :fog_private_key        => "#{ENV['HOME']}/.ssh/id_rsa",
+          :fog_public_key         => "#{ENV['HOME']}/.ssh/id_rsa.pub",
           :ssh                    => {
                                      :config                => false,
                                      :paranoid              => false,

--- a/spec/beaker/hypervisor/fog_spec.rb
+++ b/spec/beaker/hypervisor/fog_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Beaker
+  describe Fog do
+    let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
+    let( :fog ) { Beaker::Fog.new( @hosts, options ) }
+
+    before :each do
+      @hosts = make_hosts( {
+                              :cloud_provider => 'DigitalOcean',
+                              :digitalocean_api_key => 'Foo',
+                              :digitalocean_client_id => 'Bar',
+                            }
+                          )
+    end
+
+    it "can provision a set of hosts" do
+      ::Fog.mock!
+      allow(File).to receive(:read).with(File.expand_path('~/.ssh/id_rsa')).and_return('Key')
+      allow(File).to receive(:read).with(File.expand_path('~/.ssh/id_rsa.pub')).and_return('Pub Key')
+      fog.provision
+    end
+
+  end
+end

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -68,6 +68,13 @@ module Beaker
       expect( hypervisor.create( 'vagrant_virtualbox', [], make_opts() ) ).to be === vagrant
     end
 
+    it "creates a fog hypervisor for fog hosts" do
+      fog = double( 'fog' )
+      allow( fog ).to receive( :provision ).and_return( true )
+      expect( Fog ).to receive( :new ).once.and_return( fog )
+      expect( hypervisor.create( 'fog', [], make_opts() ) ).to be === fog
+    end
+
     context "#configure" do
       let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
       let( :hosts ) { make_hosts( { :platform => 'el-5' } ) }


### PR DESCRIPTION
This adds a new generic fog hypervisor, which you can then specify to the cloud provider you pick. Right now it does some regex to check the cloud provider name to check the auth method and any special fields you need to add (not every provider has regions, not every provider has flavors etc.)

This means that instead of having to write out an entire new provider if someone asks for it for some of the other popular cloud services out there (Brightbox are pretty big in the UK, Linode are starting to get popular etc.) we can just extend how the fog provider works and use that.

It also means if someone prefers the fog way of doing things rather than the beaker implementation for some reason, they can use fog to run GCE, AWS, Openstack etc.