### PR TITLE
WIP: (PDB-1034) Ezbake changes to get PDB source based builds working

### DIFF
--- a/lib/beaker/dsl/ezbake_utils.rb
+++ b/lib/beaker/dsl/ezbake_utils.rb
@@ -1,80 +1,158 @@
 require 'beaker/dsl/install_utils'
+require 'fileutils'
 
 module Beaker
   module DSL
-    #
     # This module contains methods to assist in installing projects from source
     # that use ezbake for packaging.
     #
     # @api dsl
     module EZBakeUtils
 
-      REMOTE_PACKAGES_REQUIRED = ['make']
+      # @!group Public DSL Methods
+
+      # Installs leiningen project with given name and version on remote host.
+      #
+      # @param [Host] host A single remote host on which to install the
+      #   specified leiningen project.
+      # @api dsl
+      def install_from_ezbake host
+        ezbake_validate_support host
+        ezbake_tools_available?
+        install_ezbake_tarball_on_host host
+        ezbake_installsh host, "service"
+      end
+
+      # Installs termini with given name and version on remote host.
+      #
+      # @param [Host] host A single remote host on which to install the
+      #   specified leiningen project.
+      # @api dsl
+      def install_termini_from_ezbake host
+        ezbake_validate_support host
+        ezbake_tools_available?
+        install_ezbake_tarball_on_host host
+        ezbake_installsh host, "termini"
+      end
+
+      # @!endgroup
+
+      class << self
+        attr_accessor :config
+      end
+
+      # @!group Private helpers
+
+      # Test for support in one place
+      #
+      # @param [Host] host host to check for support
+      # @raise [RuntimeError] if OS is not supported
+      # @api private
+      def ezbake_validate_support host
+        variant, version, _, _ = host['platform'].to_array
+        unless variant =~ /^(fedora|el|centos|debian|ubuntu)$/
+          raise RuntimeError,
+                "No support for #{variant} within ezbake_utils ..."
+        end
+      end
+
+      # Build, copy & unpack tarball on remote host
+      #
+      # @param [Host] host installation destination
+      # @api private
+      def install_ezbake_tarball_on_host host
+        if not ezbake_config
+          ezbake_stage
+        end
+
+        # Skip installation if the remote directory exists
+        result = on host, "test -d #{ezbake_install_dir}", :acceptable_exit_codes => [0, 1]
+        return if result.exit_code == 0
+
+        ezbake_staging_dir = File.join('target', 'staging')
+        Dir.chdir(ezbake_staging_dir) do
+          ezbake_local_cmd 'rake package:tar'
+        end
+
+        local_tarball = ezbake_staging_dir + "/pkg/" + ezbake_install_name + ".tar.gz"
+        remote_tarball = ezbake_install_dir + ".tar.gz"
+        scp_to host, local_tarball, remote_tarball
+
+        # untar tarball on host
+        on host, "tar -xzf " + remote_tarball
+
+        # Check to ensure directory exists
+        on host, "test -d #{ezbake_install_dir}"
+      end
+
       LOCAL_COMMANDS_REQUIRED = [
         ['leiningen', 'lein --version', nil],
-        ['lein-pprint', 'lein with-profile ci pprint :version', 
+        ['lein-pprint', 'lein with-profile ci pprint :version',
           'Must have lein-pprint installed under the :ci profile.'],
         ['java', 'java -version', nil],
         ['git', 'git --version', nil],
         ['rake', 'rake --version', nil],
       ]
-      class << self
-        attr_accessor :config
+
+      # Checks given host for the tools necessary to perform
+      # install_from_ezbake.
+      #
+      # @raise [RuntimeError] if tool is not found
+      # @api private
+      def ezbake_tools_available?
+        LOCAL_COMMANDS_REQUIRED.each do |software_name, command, additional_error_message|
+          if not system command
+            error_message = "Must have #{software_name} installed on development system.\n"
+            if additional_error_message
+              error_message += additional_error_message
+            end
+            raise RuntimeError, error_message
+          end
+        end
       end
 
       # Return the ezbake config.
       #
+      # @return [Hash] configuration for ezbake, usually from ezbake.rb
+      # @api private
       def ezbake_config
         EZBakeUtils.config
       end
 
-      # Checks given host for the tools necessary to perform
-      # install_from_ezbake. If no host is given then check the local machine
-      # for necessary available tools. If a tool is not found, then raise
-      # RuntimeError.
-      #
-      def ezbake_tools_available? host = nil
-        if host
-          REMOTE_PACKAGES_REQUIRED.each do |package_name|
-            if not check_for_package host, package_name
-              raise "Required package, #{package_name}, not installed on #{host}" 
-            end
-          end
-        else
-          LOCAL_COMMANDS_REQUIRED.each do |software_name, command, additional_error_message|
-            if not system command
-              error_message = "Must have #{software_name} installed on development system.\n"
-              if additional_error_message
-                error_message += additional_error_message
-              end
-              raise error_message
-            end
-          end
-        end
-      end
-
       # Prepares a staging directory for the specified project.
       #
-      # @param [String] project_name The name of the ezbake project being worked
-      #                              on.
-      # @param [String] project_param_string Parameters to be passed to ezbake
-      #                                      on the command line.
-      # @param [String] ezbake_dir The local directory where the ezbake project
-      #                            resides or should reside if it doesn't exist
-      #                            already.
-      #
-      def ezbake_stage project_name, project_param_string, ezbake_dir="tmp/ezbake"
-        ezbake_tools_available?
-        conditionally_clone "gitmirror@github.delivery.puppetlabs.net:puppetlabs-ezbake.git", ezbake_dir
+      # @api private
+      def ezbake_stage
+        # TODO: will need removal before merging, since we'll want to
+        # work against a shipped version of ezbake.
+        ezbake_dir = 'tmp/ezbake'
+        conditionally_clone "git@github.com:kbarber/ezbake.git",
+                            ezbake_dir, "pdb-1034-ezbake-pr-testing"
 
-        package_version = ''
+        # Get the absolute path to the local repo
+        m2_repo = File.join(Dir.pwd, 'tmp', 'm2-local')
+
+        lein_prefix = 'lein update-in : assoc :local-repo "\"' +
+                      m2_repo + '\"" --'
+
+        # Install the PuppetDB jar into the local repository
+        ezbake_local_cmd "#{lein_prefix} install",
+                         :throw_on_failure => true
+
         Dir.chdir(ezbake_dir) do
-          `lein run -- stage #{project_name} #{project_param_string}`
+          # TODO: here we compile a development version of the ezbake plugin,
+          # but for prod we'll need to work something else out
+          ezbake_local_cmd "#{lein_prefix} install",
+                            :throw_on_failure => true
         end
 
-        staging_dir = File.join(ezbake_dir, 'target/staging')
+        ezbake_local_cmd "#{lein_prefix} with-profile ezbake ezbake stage",
+                         :throw_on_failure => true
+
+        staging_dir = File.join('target','staging')
         Dir.chdir(staging_dir) do
-          output = `rake package:bootstrap`
+          ezbake_local_cmd 'rake package:bootstrap'
+
           load 'ezbake.rb'
           ezbake = EZBake::Config
           ezbake[:package_version] = `echo -n $(rake pl:print_build_param[ref] | tail -n 1)`
@@ -82,137 +160,79 @@ module Beaker
         end
       end
 
-      # Installs ezbake dependencies on given host.
+      # Executes a local command using system, logging the prepared command
       #
-      # @param [Host] host A single remote host on which to install the
-      # packaging dependencies of the ezbake project configuration currently in
-      # Beaker::DSL::EZBakeUtils.config
-      #
-      def install_ezbake_deps host
-        ezbake_tools_available? host
+      # @param [String] cmd command to execute
+      # @param [Hash] opts options
+      # @option opts [bool] :throw_on_failure If true, throws an
+      #   exception if the exit code is non-zero. Defaults to false.
+      # @return [bool] true if exit == 0 false if otherwise
+      # @raise [RuntimeError] if :throw_on_failure is true and
+      #   command fails
+      # @api private
+      def ezbake_local_cmd cmd, opts={}
+        opts = {
+          :throw_on_failure => false,
+        }.merge(opts)
 
-        if not ezbake_config
-          ezbake_stage project_name, project_param_string
+        logger.notify "localhost $ #{cmd}"
+        result = system cmd
+        if opts[:throw_on_failure] && result == false
+          raise RuntimeError, "Command failure #{cmd}"
         end
-
-        variant, version, arch, codename = host['platform'].to_array
-        ezbake = ezbake_config
-
-        case variant
-        when /^(fedora|el|centos)$/
-          dependency_list = ezbake[:redhat][:additional_dependencies]
-          dependency_list.each do |dependency|
-            package_name, _, package_version = dependency.split
-            install_package host, package_name, package_version
-          end
-
-        when /^(debian|ubuntu|cumulus)$/
-          dependency_list = ezbake[:debian][:additional_dependencies]
-          dependency_list.each do |dependency|
-            package_name, _, package_version = dependency.split
-            if package_version
-              package_version = package_version.chop
-            end
-            install_package host, package_name, package_version
-          end
-
-        else
-          raise "No repository installation step for #{variant} yet..."
-        end
-
+        result
       end
 
-      # Installs leiningen project with given name and version on remote host.
+      # Retrieve the tarball installation name. This is the name of
+      # the tarball without the .tar.gz extension, and the name of the
+      # path where it will unpack to.
       #
-      # @param [Host] host A single remote host on which to install the
-      # specified leiningen project.
-      # @param [String] project_name The name of the project. In ezbake context
-      # this is the name of both a subdirectory of the ezbake_dir/configs dir
-      # and the name of the .clj file in that directory which contains the
-      # project map used by ezbake to create the staging directory.
-      # @param [String] project_param_string The version of the project specified by
-      # project_name which is to be built and installed on the remote host.
-      # @param [String] ezbake_dir The directory to which ezbake should be
-      # cloned; alternatively, if ezbake is already at that directory, it will
-      # be updated from its github master before any ezbake operations are
-      # performed.
-      #
-      def install_from_ezbake host, project_name, project_param_string, env_args={}, ezbake_dir='tmp/ezbake'
-        ezbake_tools_available? host
-
-        if not ezbake_config
-          ezbake_stage project_name, project_param_string
-        end
-
-        variant, _, _, _ = host['platform'].to_array
-
-        case variant
-        when /^(osx|windows|solaris|aix)$/
-          raise "Beaker::DSL::EZBakeUtils unsupported platform: #{variant}"
-        end
-
+      # @return [String] name of the tarball and directory
+      # @api private
+      def ezbake_install_name
         ezbake = ezbake_config
         project_package_version = ezbake[:package_version]
         project_name = ezbake[:project]
+        "%s-%s" % [ project_name, project_package_version ]
+      end
 
-        ezbake_staging_dir = File.join(ezbake_dir, "target/staging")
+      # Returns the full path to the installed software on the remote host.
+      #
+      # This only returns the path, it doesn't work out if its installed or
+      # not.
+      #
+      # @return [String] path to the installation dir
+      # @api private
+      def ezbake_install_dir
+        "/root/#{ezbake_install_name}"
+      end
 
-        remote_tarball = ""
-        local_tarball = ""
-        dir_name = ""
-
-        Dir.chdir(ezbake_staging_dir) do
-          output = `rake package:tar`
-
-          pattern = "%s-%s"
-          dir_name = pattern % [
-            project_name,
-            project_package_version
-          ]
-          local_tarball = "./pkg/" + dir_name + ".tar.gz"
-          remote_tarball = "/root/" +  dir_name + ".tar.gz"
-
-          scp_to host, local_tarball, remote_tarball
-        end
-
-        # untar tarball on host
-        on host, "tar -xzf " + remote_tarball
-
-        # "make" on target
-        cd_to_package_dir = "cd /root/" + dir_name + "; "
-        env = ""
-        if not env_args.empty?
-          env = "env " + env_args.map {|k, v| "#{k}=#{v} "}.join(' ')
-        end
-        on host, cd_to_package_dir + env + "make -e install-" + project_name
-
-        # install init scripts and default settings, perform additional preinst
-        # TODO: figure out a better way to install init scripts and defaults
-        case variant
-          when /^(fedora|el|centos)$/
-            env += "defaultsdir=/etc/sysconfig "
-            on host, cd_to_package_dir + env + "make -e install-rpm-sysv-init"
-          when /^(debian|ubuntu|cumulus)$/
-            env += "defaultsdir=/etc/default "
-            on host, cd_to_package_dir + env + "make -e install-deb-sysv-init"
-          else
-            raise "No ezbake installation step for #{variant} yet..."
-        end
+      # A helper that wraps the execution of install.sh in the proper
+      # ezbake installation directory.
+      #
+      # @param [Host] host Host to run install.sh on
+      # @param [String] task Task to execute with install.sh
+      # @api private
+      def ezbake_installsh host, task=""
+        on host, "cd #{ezbake_install_dir}; bash install.sh #{task}"
       end
 
       # Only clone from given git URI if there is no existing git clone at the
       # given local_path location.
       #
-      # @!visibility private
-      def conditionally_clone(upstream_uri, local_path)
-        ezbake_tools_available?
-        if system "git --work-tree=#{local_path} --git-dir=#{local_path}/.git status"
-          system "git --work-tree=#{local_path} --git-dir=#{local_path}/.git fetch origin"
-          system "git --work-tree=#{local_path} --git-dir=#{local_path}/.git checkout origin/HEAD"
+      # @param [String] upstream_uri git URI
+      # @param [String] local_path path to conditionally install to
+      # @param [String] branch to checkout
+      # @api private
+      def conditionally_clone upstream_uri, local_path, branch="origin/HEAD"
+        if ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git status"
+          ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git fetch origin"
+          ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git checkout #{branch}"
         else
           parent_dir = File.dirname(local_path)
           FileUtils.mkdir_p(parent_dir)
-          system "git clone #{upstream_uri} #{local_path}"
+          ezbake_local_cmd "git clone #{upstream_uri} #{local_path}"
+          ezbake_local_cmd "git --work-tree=#{local_path} --git-dir=#{local_path}/.git checkout #{branch}"
         end
       end
 

--- a/spec/beaker/dsl/ezbake_utils_spec.rb
+++ b/spec/beaker/dsl/ezbake_utils_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-EZBAKE_CONFIG_EXAMPLE= { 
+EZBAKE_CONFIG_EXAMPLE= {
   :project => 'puppetserver',
   :real_name => 'puppetserver',
   :user => 'puppet',
@@ -10,7 +10,7 @@ EZBAKE_CONFIG_EXAMPLE= {
   :terminus_info => {},
   :debian => { :additional_dependencies => ["puppet (= 3.6.1-puppetlabs1)"], },
   :redhat => { :additional_dependencies => ["puppet = 3.6.1"], },
-  :java_args => '-Xmx192m', 
+  :java_args => '-Xmx192m',
 }
 
 class ClassMixedWithEZBakeUtils
@@ -37,46 +37,117 @@ describe ClassMixedWithEZBakeUtils do
   let( :opts ) { Beaker::Options::Presets.env_vars }
   let( :host ) { double.as_null_object }
   let( :local_commands ) { Beaker::DSL::EZBakeUtils::LOCAL_COMMANDS_REQUIRED }
-  let( :remote_packages ) { Beaker::DSL::EZBakeUtils::REMOTE_PACKAGES_REQUIRED }
 
-  describe '#ezbake_config' do
-    it "returns a map with ezbake configuration parameters" do
+  describe '#install_from_ezbake' do
+    let(:platform) { Beaker::Platform.new('el-7-i386') }
+    let(:host) do
+      FakeHost.create('fakevm', platform.to_s)
+    end
+
+    before do
+      allow(subject).to receive(:ezbake_tools_available?) { true }
+    end
+
+    it "when ran with an el-7 machine runs correct installsh command" do
+      expect(subject).to receive(:install_ezbake_tarball_on_host).
+                          ordered
+      expect(subject).
+        to receive(:ezbake_installsh).with(host, "service")
+      subject.install_from_ezbake host
+    end
+  end
+
+  describe '#install_termini_from_ezbake' do
+    let(:platform) { Beaker::Platform.new('el-7-i386') }
+    let(:host) do
+      FakeHost.create('fakevm', platform.to_s)
+    end
+
+    before do
+      allow(subject).to receive(:ezbake_tools_available?) { true }
+    end
+
+    it "when ran with an el-7 machine runs correct installsh command" do
+      expect(subject).to receive(:ezbake_validate_support).with(host).ordered
+      expect(subject).to receive(:install_ezbake_tarball_on_host).
+                          with(host).ordered
+      expect(subject).
+        to receive(:ezbake_installsh).with(host, "termini")
+      subject.install_termini_from_ezbake host
+    end
+  end
+
+  describe '#ezbake_validate_support' do
+    context 'when OS supported' do
+      let(:platform) { Beaker::Platform.new('el-7-i386') }
+      let(:host) do
+        FakeHost.create('fakevm', platform.to_s)
+      end
+
+      it 'should do nothing' do
+        subject.ezbake_validate_support host
+      end
+    end
+
+    context 'when OS not supported' do
+      let(:platform) { Beaker::Platform.new('aix-12-ppc') }
+      let(:host) do
+        FakeHost.create('fakevm', platform.to_s)
+      end
+
+      it 'should throw exception' do
+        expect {
+          subject.ezbake_validate_support host
+        }.to raise_error(RuntimeError,
+                         "No support for aix within ezbake_utils ...")
+      end
+    end
+  end
+
+  def install_ezbake_tarball_on_host_common_expects
+    result = object_double(Beaker::Result.new(host, "foo"), :exit_code => 1)
+    expect(subject).to receive(:on).
+                        with(kind_of(Beaker::Host), /test -d/,
+                             anything()).ordered { result }
+    expect(Dir).to receive(:chdir).and_yield()
+    expect(subject).to receive(:ezbake_local_cmd).with(/rake package:tar/).ordered
+    expect(subject).to receive(:scp_to).
+                        with(kind_of(Beaker::Host), anything(), anything()).ordered
+    expect(subject).to receive(:on).
+                        with(kind_of(Beaker::Host), /tar -xzf/).ordered
+    expect(subject).to receive(:on).
+                        with(kind_of(Beaker::Host), /test -d/).ordered
+  end
+
+  describe '#install_ezbake_tarball_on_host' do
+    let(:platform) { Beaker::Platform.new('el-7-i386') }
+    let(:host) do
+      FakeHost.create('fakevm', platform.to_s)
+    end
+
+    it 'when invoked with configuration should run expected tasks' do
       subject.initialize_ezbake_config
-      config = subject.ezbake_config
-      expect(config).to include(EZBAKE_CONFIG_EXAMPLE)
+      install_ezbake_tarball_on_host_common_expects
+      subject.install_ezbake_tarball_on_host host
+    end
+
+    it 'when invoked with nil configuration runs ezbake_stage' do
+      subject.wipe_out_ezbake_config
+      expect(subject).to receive(:ezbake_stage) {
+        Beaker::DSL::EZBakeUtils.config = EZBAKE_CONFIG_EXAMPLE
+      }.ordered
+      install_ezbake_tarball_on_host_common_expects
+      subject.install_ezbake_tarball_on_host host
     end
   end
 
   describe '#ezbake_tools_available?' do
-
     before do
       allow(subject).to receive(:check_for_package) { true }
       allow(subject).to receive(:system) { true }
     end
 
-    describe "checks for remote packages when given a host" do
-
-      it "and succeeds if all packages are found" do
-        remote_packages.each do |package|
-          expect(subject).to receive(:check_for_package).with(host, package)
-        end
-        subject.ezbake_tools_available? host
-      end
-
-      it "and raises an exception if a package is missing" do
-        allow(subject).to receive(:check_for_package) { false }
-        remote_packages.each do |package|
-          expect(subject).to receive(:check_for_package).with(host, package)
-          break # just need first element
-        end
-      expect{
-        subject.ezbake_tools_available? host
-      }.to raise_error(RuntimeError, /Required package, .*, not installed on/)
-      end
-
-    end
-
-    describe "checks for local successful local commands when no host given" do
+    describe "checks for local successful commands" do
 
       it "and succeeds if all commands return successfully" do
         local_commands.each do |software_name, command, additional_error_messages|
@@ -100,6 +171,14 @@ describe ClassMixedWithEZBakeUtils do
 
   end
 
+  describe '#ezbake_config' do
+    it "returns a map with ezbake configuration parameters" do
+      subject.initialize_ezbake_config
+      config = subject.ezbake_config
+      expect(config).to include(EZBAKE_CONFIG_EXAMPLE)
+    end
+  end
+
   describe '#ezbake_stage' do
     before do
       allow(subject).to receive(:ezbake_tools_available?) { true }
@@ -107,132 +186,99 @@ describe ClassMixedWithEZBakeUtils do
     end
 
     it "initializes EZBakeUtils.config" do
-      allow( Dir ).to receive( :chdir ).and_yield()
+      allow(Dir).to receive(:chdir).and_yield()
       allow(subject).to receive(:conditionally_clone) { true }
 
-      expect(subject).to receive(:`).with(/^lein.*/).ordered
-      expect(subject).to receive(:`).with("rake package:bootstrap").ordered
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/^lein.*install/, :throw_on_failure =>
+                                                 true).ordered
+      expect(Dir).to receive(:chdir).and_yield().ordered
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/^lein.*install/, :throw_on_failure =>
+                                                 true).ordered
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/^lein.*with-profile ezbake ezbake stage/, :throw_on_failure =>
+                                                 true).ordered
+      expect(subject).to receive(:ezbake_local_cmd).with("rake package:bootstrap").ordered
       expect(subject).to receive(:load) { }.ordered
-      expect(subject).to receive(:`).with(anything()).ordered
+      expect(subject).to receive(:`).ordered
 
       config = subject.ezbake_config
       expect(config).to eq(nil)
 
-      subject.ezbake_stage "ruby", "is", "junky"
+      subject.ezbake_stage
 
       config = subject.ezbake_config
       expect(config).to include(EZBAKE_CONFIG_EXAMPLE)
     end
   end
 
-  RSpec.shared_examples "installs-ezbake-dependencies" do
-    it "installs ezbake dependencies" do
-      expect(subject).to receive(:install_package).
-        with( kind_of(Beaker::Host), anything(), anything())
-      subject.install_ezbake_deps host
+  describe '#ezbake_local_cmd' do
+    it 'should execute system on the command specified' do
+      expect(subject).to receive(:system).with("my command") { true }
+      subject.ezbake_local_cmd("my command")
+    end
+
+    it 'with :throw_on_failure should throw exeception when failed' do
+      expect(subject).to receive(:system).with("my failure") { false }
+      expect {
+        subject.ezbake_local_cmd("my failure", :throw_on_failure => true)
+      }.to raise_error(RuntimeError, "Command failure my failure")
+    end
+
+    it 'without :throw_on_failure should just fail and return false' do
+      expect(subject).to receive(:system).with("my failure") { false }
+      expect(subject.ezbake_local_cmd("my failure")).to eq(false)
     end
   end
 
-  describe '#install_ezbake_deps' do
-    let( :platform ) { Beaker::Platform.new('redhat-7-i386') }
-    let(:host) do
-      FakeHost.create('fakevm', platform.to_s)
-    end
-
-    before do
-      allow(subject).to receive(:ezbake_tools_available?) { true }
-      subject.initialize_ezbake_config
-    end
-
-    it "Raises an exception for unsupported platforms." do
-      expect{ 
-        subject.install_ezbake_deps host
-      }.to raise_error(RuntimeError, /No repository installation step for/)
-    end
-
-    context "When host is a debian-like platform" do
-      let( :platform ) { Beaker::Platform.new('debian-7-i386') }
-      include_examples "installs-ezbake-dependencies"
-    end
-
-    context "When host is a redhat-like platform" do
-      let( :platform ) { Beaker::Platform.new('centos-7-i386') }
-      include_examples "installs-ezbake-dependencies"
+  describe '#ezbake_install_name' do
+    it 'should return the installation name from example configuration' do
+      expect(subject).to receive(:ezbake_config) {{
+        :package_version => '1.1.1',
+        :project => 'myproject',
+      }}
+      expect(subject.ezbake_install_name).to eq "myproject-1.1.1"
     end
   end
 
-  def install_from_ezbake_common_expects
-    expect(subject).to receive(:`).with(/rake package:tar/).ordered
-    expect(subject).to receive(:scp_to).
-      with( kind_of(Beaker::Host), anything(), anything()).ordered
-    expect(subject).to receive(:on).
-      with( kind_of(Beaker::Host), /tar -xzf/).ordered
-    expect(subject).to receive(:on).
-      with( kind_of(Beaker::Host), /make -e install-#{EZBAKE_CONFIG_EXAMPLE[:real_name]}/).ordered
+  describe '#ezbake_install_dir' do
+    it 'should return the full path from ezbake_install_name' do
+      expect(subject).to receive(:ezbake_install_name) {
+        "mynewproject-2.3.4"
+      }
+      expect(subject.ezbake_install_dir).to eq "/root/mynewproject-2.3.4"
+    end
   end
 
-  describe '#install_from_ezbake' do
-    let( :platform ) { Beaker::Platform.new('redhat-7-i386') }
-    let(:host) do
-      FakeHost.create('fakevm', platform.to_s)
+  describe '#ezbake_installsh' do
+    it 'run on command correctly when invoked' do
+      expect(subject).to receive(:on).with(host,
+                                           /install.sh my_task/)
+      subject.ezbake_installsh host, "my_task"
+    end
+  end
+
+  describe '#conditionally_clone' do
+    it 'when repo exists, just do fetch and checkout' do
+      expect(subject).to receive(:ezbake_local_cmd).
+        with(/git status/) { true }
+      expect(subject).to receive(:ezbake_local_cmd).
+        with(/git fetch origin/)
+      expect(subject).to receive(:ezbake_local_cmd).
+        with(/git checkout/)
+      subject.conditionally_clone("my_url", "my_local_path")
     end
 
-    before do
-      allow(subject).to receive(:ezbake_tools_available?) { true }
+    it 'when repo does not exist, do clone and checkout' do
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/git status/) { false }
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/git clone/)
+      expect(subject).to receive(:ezbake_local_cmd).
+                          with(/git checkout/)
+      subject.conditionally_clone("my_url", "my_local_path")
     end
-
-    context "for non *nix-like platforms" do
-      let( :platform ) { Beaker::Platform.new('windows-7-i386') }
-      it "raises an exception" do
-        expect{ 
-          subject.install_from_ezbake host, "blah", "blah"
-        }.to raise_error(RuntimeError, /Beaker::DSL::EZBakeUtils unsupported platform:/)
-      end
-    end
-
-    it "raises an exception for unsupported *nix-like platforms" do
-      allow( Dir ).to receive( :chdir ).and_yield()
-      install_from_ezbake_common_expects
-      expect{ 
-        subject.install_from_ezbake host, "blah", "blah"
-      }.to raise_error(RuntimeError, /No ezbake installation step for/)
-    end
-
-    context "When Beaker::DSL::EZBakeUtils.config is nil" do
-      let( :platform ) { Beaker::Platform.new('el-7-i386') }
-      before do
-        allow( Dir ).to receive( :chdir ).and_yield()
-        subject.wipe_out_ezbake_config
-      end
-
-      it "runs ezbake_stage" do
-        expect(subject).to receive(:ezbake_stage) {
-          Beaker::DSL::EZBakeUtils.config = EZBAKE_CONFIG_EXAMPLE
-        }.ordered
-        install_from_ezbake_common_expects
-        expect(subject).to receive(:on).
-          with( kind_of(Beaker::Host), /install-rpm-sysv-init/).ordered
-        subject.install_from_ezbake host, "blah", "blah"
-      end
-
-    end
-
-    context "When Beaker::DSL::EZBakeUtils.config is a hash" do
-      let( :platform ) { Beaker::Platform.new('el-7-i386') }
-      before do
-        allow( Dir ).to receive( :chdir ).and_yield()
-        subject.initialize_ezbake_config
-      end
-
-      it "skips ezbake_stage" do
-        install_from_ezbake_common_expects
-        expect(subject).to receive(:on).
-          with( kind_of(Beaker::Host), /install-rpm-sysv-init/).ordered
-        subject.install_from_ezbake host, "blah", "blah"
-      end
-
-    end
-
   end
 
 end


### PR DESCRIPTION
This involves a rework of the ezbake_utils to provide more capability to fully
install PuppetDB using these helpers.

* Some of the original API has been simplified, and the YAGNI parts removed
  since no one was using them today.
* We now do the lein install process, but using a local maven repository to
  avoid collision with other projects running on the same host.
* install_termini_from_ezbake now added to install that component
* I've switched to using the install.sh methodology on ezbake.
* This now is compatible with lein-ezbake.
* ezbake_local_cmd has been added to generalize this kind of system invocation
  and simplify testing.
* ezbake_installsh generalizes the way we invoke install.sh, and simplifies testing.
* install_ezbake_tarball_on_host has been created to generalize this step for
  the termini and service based installations to re-use. Its idempotent, in
  that it checks to ensure its not already installed.
* conditionally_clone was modified to support being passed a branch if required,
  so in the future we can simplify working on a development branch.
* Lots of yarddoc cleanups
* Some rspec coverage

Signed-off-by: Ken Barber <ken@bob.sh>