### PR TITLE
(QENG-1690) added in helper installation method for packages

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -1125,6 +1125,30 @@ module Beaker
         end
       end
 
+      # Installs packages from the local development repository on the given host
+      #
+      # @param [Host] host An object implementing {Beaker::Hosts}'s
+      #                    interface.
+      # @param [Regexp] package_name The name of the package whose repository is
+      #                              being installed.
+      #
+      # @note This method only works on redhat-like and debian-like hosts.
+      # @note This method is paired to be run directly after {#install_puppetlabs_dev_repo}
+      #
+      def install_packages_from_local_dev_repo( host, package_name )
+        if host['platform'] =~ /debian|ubuntu|cumulus/
+          find_filename = '*.deb'
+          find_command  = 'dpkg -i'
+        elsif host['platform'] =~ /fedora|el|centos/
+          find_filename = '*.rpm'
+          find_command  = 'rpm -ivh'
+        else
+          raise "No repository installation step for #{host['platform']} yet..."
+        end
+        find_command = "find /root/#{package_name} -type f -name '#{find_filename}' -exec #{find_command} {} \\;"
+        on host, find_command
+      end
+
       # Install development repo of the puppet-agent on the given host
       #
       # @param [Host] host An object implementing {Beaker::Hosts}'s interface

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -843,6 +843,32 @@ describe ClassMixedWithDSLInstallUtils do
 
   end
 
+  describe '#install_packages_from_local_dev_repo' do
+    let( :package_name ) { 'puppet-agent' }
+    let( :platform ) { @platform || 'other' }
+    let( :host ) do
+      FakeHost.create('fakvm', platform, opts)
+    end
+
+    it 'sets the find command correctly for el-based systems' do
+      @platform = 'el-1-3'
+      expect( subject ).to receive( :on ).with( host, /\*\.rpm.+rpm\s-ivh/ )
+      subject.install_packages_from_local_dev_repo( host, package_name )
+    end
+
+    it 'sets the find command correctly for debian-based systems' do
+      @platform = 'debian-1-3'
+      expect( subject ).to receive( :on ).with( host, /\*\.deb.+dpkg\s-i/ )
+      subject.install_packages_from_local_dev_repo( host, package_name )
+    end
+
+    it 'fails correctly for systems not accounted for' do
+      @platform = 'eos-1-3'
+      expect{ subject.install_packages_from_local_dev_repo( host, package_name ) }.to raise_error RuntimeError
+    end
+
+  end
+
   describe '#install_puppetagent_dev_repo' do
 
     it 'raises an exception when host platform is unsupported' do


### PR DESCRIPTION
I had misunderstood the install_puppetlabs_dev_repo method before, thinking that it would install packages
from within the dev repo, but it's actually just installing the dev repo itself.  These changes add a
corresponding installation method to install the packages found in these repos after they've been installed