### PR TITLE
(QENG-1695) Improves OSX Support

### DIFF
--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -827,9 +827,14 @@ module Beaker
       # @return nil
       # @api private
       def install_puppet_from_dmg( host, opts )
+
         puppet_ver = opts[:version]
         facter_ver = opts[:facter_version]
         hiera_ver = opts[:hiera_version]
+
+        if [puppet_ver, facter_ver, hiera_ver].include?(nil)
+          raise "You need to specify versions for OSX host\n eg. install_puppet({:version => '3.6.2',:facter_version => '2.1.0',:hiera_version  => '1.3.4',})"
+        end
 
         on host, "curl -O #{opts[:mac_download_url]}/puppet-#{puppet_ver}.dmg"
         on host, "curl -O #{opts[:mac_download_url]}/facter-#{facter_ver}.dmg"

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -39,6 +39,11 @@ module Beaker
           v_file << "    v.vm.guest = :windows"
         end
 
+        if /osx/i.match(host['platform'])
+          v_file << "    v.vm.network 'private_network', ip: '10.0.1.10'\n"
+          v_file << "    v.vm.synced_folder '.', '/vagrant', :nfs => true\n"
+        end
+
         v_file << self.class.provider_vfile_section(host, options)
 
         v_file << "  end\n"

--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -18,6 +18,8 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
       provider_section << "      vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium','#{host['disk_path']}']\n"
       provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
       provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
+      provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
+      provider_section << "      [\"modifyvm\", :id, \"--cpuidset\", \"1\",\"000206a7\",\"02100800\",\"1fbae3bf\",\"bfebfbff\"\]" if /osx/i.match(host['platform'])
     end
     provider_section << "    end\n"
 


### PR DESCRIPTION
* Fixes for root key location copy
* Adds a Vagrant VB OSX option
* Fixes PermitRootLogin regex
* Adds option to enable GUI
* Raises error if version not given for DMG

Now works with an example OSX Virtualbox image :+1: