### PR TITLE
Add helper function to write hiera.yaml file

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -1355,6 +1355,46 @@ module Beaker
           on host, "curl %s" % cmd, opts, &block
         end
       end
+
+      # Write hiera config file on one or more provided hosts
+      #
+      # @param[Host, Array<Host>, String, Symbol] host    One or more hosts to act upon,
+      #                           or a role (String or Symbol) that identifies one or more hosts.
+      # @param[Array] One or more hierarchy paths
+      def write_hiera_config_on(host, hierarchy)
+
+        block_on host do |host|
+          hiera_config=Hash.new
+          hiera_config[:backends] = 'yaml'
+          hiera_config[:yaml] = {}
+          hiera_config[:yaml][:datadir] = host[:hieradatadir]
+          hiera_config[:hierarchy] = hierarchy
+          hiera_config[:logger] = 'console'
+          create_remote_file host, host[:hieraconf], hiera_config.to_yaml
+        end
+      end
+
+      # Write hiera config file for the default host
+      # @see #write_hiera_config_on
+      def write_hiera_config(hierarchy)
+        write_hiera_config_on(default, hierarchy)
+      end
+
+      # Copy hiera data files to one or more provided hosts
+      #
+      # @param[Host, Array<Host>, String, Symbol] host    One or more hosts to act upon,
+      #                           or a role (String or Symbol) that identifies one or more hosts.
+      # @param[String]            Directory containing the hiera data files.
+      def copy_hiera_data_to(host, source)
+        scp_to host, File.expand_path(source), host[:hieradatadir]
+      end
+
+      # Copy hiera data files to the default host
+      # @see #copy_hiera_data_to
+      def copy_hiera_data(source)
+        copy_hiera_data_to(default, source)
+      end
+
     end
   end
 end

--- a/spec/beaker/dsl/helpers_spec.rb
+++ b/spec/beaker/dsl/helpers_spec.rb
@@ -1294,4 +1294,56 @@ describe ClassMixedWithDSLHelpers do
       end
     end
   end
+
+  describe "#write_hiera_config_on" do
+    let(:hierarchy) { [ 'nodes/%{::fqdn}', 'common' ] }
+    it 'on FOSS host' do
+      host = make_host('testhost', { :platform => 'ubuntu' } )
+      expect(subject).to receive(:create_remote_file).with(host, host[:hieraconf], /#{host[:hieradatadir]}/)
+      subject.write_hiera_config_on(host, hierarchy)
+    end
+
+    it 'on PE host' do
+      host = make_host('testhost', { :platform => 'ubuntu', :type => 'pe' } )
+      expect(subject).to receive(:create_remote_file).with(host, host[:hieraconf], /#{host[:hieradatadir]}/)
+      subject.write_hiera_config_on(host, hierarchy)
+    end
+
+  end
+
+  describe "#write_hiera_config" do
+    let(:hierarchy) { [ 'nodes/%{::fqdn}', 'common' ] }
+    it 'delegates to #write_hiera_config_on with the default host' do
+      allow( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :write_hiera_config_on ).with( master, hierarchy).once
+      subject.write_hiera_config( hierarchy )
+    end
+
+  end
+
+  describe "#copy_hiera_data_to" do
+    let(:path) { 'spec/fixtures/hieradata' }
+    it 'on FOSS host' do
+      host = make_host('testhost', { :platform => 'ubuntu' } )
+      expect(subject).to receive(:scp_to).with(host, File.expand_path(path), host[:hieradatadir])
+      subject.copy_hiera_data_to(host, path)
+    end
+
+    it 'on PE host' do
+      host = make_host('testhost', { :platform => 'ubuntu', :type => 'pe' } )
+      expect(subject).to receive(:scp_to).with(host, File.expand_path(path), host[:hieradatadir])
+      subject.copy_hiera_data_to(host, path)
+    end
+  end
+
+  describe "#copy_hiera_data" do
+    let(:path) { 'spec/fixtures/hieradata' }
+    it 'delegates to #copy_hiera_data_to with the default host' do
+      allow( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :copy_hiera_data_to ).with( master, path).once
+      subject.copy_hiera_data( path )
+    end
+
+  end
+
 end


### PR DESCRIPTION
This helper function allows for writing the hiera.yaml file
It currently makes the assumption only the yaml backend is used.