### PR TITLE
(QENG-1714) fixed get_type for a machine with only non-agent roles

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -49,6 +49,7 @@ module Beaker
       # related through 'type' and the differences between the assumption of our two
       # configurations we have for many of our products
       type = @options.get_type
+      type = :foss if type == :aio && !@options['HOSTS'][@name]['roles'].include?('agent')
       @defaults = merge_defaults_for_type @options, type
       pkg_initialize
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -56,6 +56,24 @@ module Beaker
         expect(host.is_using_passenger?).to be_truthy
         expect(host.graceful_restarts?).to be_truthy
       end
+
+      it 'can be an AIO host' do
+        options['type'] = 'aio'
+        expect(host.is_pe?).to be_falsy
+        expect(host.use_service_scripts?).to be_falsy
+        expect(host.is_using_passenger?).to be_falsy
+      end
+
+      it 'sets the paths correctly for an AIO agent host' do
+        options['type'] = 'aio'
+        expect(host['puppetvardir']).to be === Unix::Host::aio_defaults[:puppetvardir]
+      end
+
+      it 'sets the paths correctly for an AIO non-agent host' do
+        options['type'] = 'aio'
+        options['roles'] = ['master']
+        expect(host['puppetvardir']).to be === Unix::Host::foss_defaults[:puppetvardir]
+      end
     end
 
     describe "uses_passenger!" do


### PR DESCRIPTION
The issue here is that when you either have a machine with the roles master and agent, or agent, the AIO paths were set correctly when the Beaker run was given the `:type` parameter with the value 'aio'.

The issue is that if you have a machine that doesn't have the agent role at all, it is still getting the 'aio' paths.  In the simple case of having two separate master and agent machines, the master machine currently has an incorrect path.  This fix queries the roles, and if the system doesn't have the 'agent' role, it will come back as FOSS, which is the default for this setup.