### PR TITLE
(MAINT) Fix Vagrantfile syntax error

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -36,7 +36,7 @@ module Beaker
         if /windows/i.match(host['platform'])
           v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"
-          v_file << "    v.vm.guest = :windows"
+          v_file << "    v.vm.guest = :windows\n"
         end
 
         if /osx/i.match(host['platform'])


### PR DESCRIPTION
Missed new line:

```
/Users/petersouter/projects/puppet-chocolatey/.vagrant/beaker_vagrant_files/default.yml/Vagrantfile:9: syntax error, unexpected tIDENTIFIER, expecting keyword_end
    v.vm.guest = :windows    v.vm.provider :virtualbox do |vb|
```