### PR TITLE
(QENG-1629) Add expect_failure() to Beaker DSL (the code is provided)

### DIFF
--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -1,3 +1,4 @@
+require 'beaker/dsl/assertions'
 module Beaker
   module DSL
     # These are simple structural elements necessary for writing
@@ -21,6 +22,11 @@ module Beaker
     #
     #       step 'Test the things' do
     #         ...tests...
+    #       end
+    #
+    #       step 'Expect this to fail' do
+    #         expect_failure('expected to fail due to PE-1234') do
+    #         assert_equal(400, response.code, 'bad response code from API call')
     #       end
     #     end
     #
@@ -55,8 +61,69 @@ module Beaker
       #     on(master, puppet_resource('file', '/etc/puppet/modules',
       #       'ensure=absent', 'purge=true'))
       #   end
+      # @api dsl
       def teardown &block
         @teardown_procs << block
+      end
+
+      # Wrap an assert that is supposed to fail due to a product bug, an
+      # undelivered feature, or some similar situation.
+      #
+      # This converts failing asserts into passing asserts (so we can continue to
+      # run the test even though there are underlying product bugs), and converts
+      # passing asserts into failing asserts (so we know when the underlying product
+      # bug has been fixed).
+      #
+      # Pass an assert as a code block, and pass an explanatory message as a
+      # parameter. The assert's logic will be inverted (so passes turn into fails
+      # and fails turn into passes).
+      #
+      # @example Typical usage
+      #   expect_failure('expected to fail due to PE-1234') do
+      #     assert_equal(400, response.code, 'bad response code from API call')
+      #   end
+      #
+      # @example Output when a product bug would normally cause the assert to fail
+      #   Warning: An assertion was expected to fail, and did.
+      #   This is probably due to a known product bug, and is probably not a problem.
+      #   Additional info: 'expected to fail due to PE-6995'
+      #   Failed assertion: 'bad response code from API call.
+      #   <400> expected but was <409>.'
+      #
+      # @example Output when the product bug has been fixed
+      #   <RuntimeError: An assertion was expected to fail, but passed.
+      #   This is probably because a product bug was fixed, and "expect_failure()"
+      #   needs to be removed from this assert.
+      #   Additional info: 'expected to fail due to PE-6996'>
+      #
+      # @param [String] explanation A description of why this assert is expected to
+      #                             fail
+      # @param block [Proc] block of code is expected to either raise an
+      #                     {Beaker::Assertions} or else return a value that
+      #                     will be ignored
+      # @raise [RuntimeError] if the code block passed to this method does not raise
+      #                       a {Beaker::Assertions} (i.e., if the assert
+      #                       passes)
+      # @author Chris Cowell-Shah (<tt>ccs@puppetlabs.com</tt>)
+      # @api dsl
+      def expect_failure(explanation, &block)
+        begin
+          yield if block_given?  # code block should contain an assert that you expect to fail
+        rescue Beaker::DSL::Assertions, Minitest::Assertion => failed_assertion
+          # Yay! The assert in the code block failed, as expected.
+          # Swallow the failure so the test passes.
+          logger.notify 'An assertion was expected to fail, and did. ' +
+                          'This is probably due to a known product bug, ' +
+                          'and is probably not a problem. ' +
+                          "Additional info: '#{explanation}' " +
+                          "Failed assertion: '#{failed_assertion}'"
+          return
+        end
+        # Uh-oh! The assert in the code block unexpectedly passed.
+        fail('An assertion was expected to fail, but passed. ' +
+                 'This is probably because a product bug was fixed, and ' +
+                 '"expect_failure()" needs to be removed from this test. ' +
+                 "Additional info: '#{explanation}'")
       end
     end
   end

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -5,7 +5,8 @@ class ClassMixedWithDSLStructure
 end
 
 describe ClassMixedWithDSLStructure do
-  let(:logger) { Object.new }
+  include Beaker::DSL::Assertions
+  let(:logger) { double }
   describe '#step' do
     it 'requires a name' do
       expect { subject.step do; end }.to raise_error ArgumentError
@@ -55,6 +56,32 @@ describe ClassMixedWithDSLStructure do
       block = lambda { 'blah' }
       expect( teardown_array ).to receive( :<< ).with( block )
       subject.teardown &block
+    end
+  end
+
+  describe '#expect_failure' do
+    it 'passes when a MiniTest assertion is raised' do
+      expect( subject ).to receive( :logger ).and_return( logger )
+      expect( logger ).to receive( :notify )
+      block = lambda { assert_equal('1', '2', '1 should not equal 2') }
+      expect{ subject.expect_failure 'this is an expected failure', &block }.to_not raise_error
+    end
+
+    it 'passes when a Beaker assertion is raised' do
+      expect( subject ).to receive( :logger ).and_return( logger )
+      expect( logger ).to receive( :notify )
+      block = lambda { assert_no_match('1', '1', '1 and 1 should not match') }
+      expect{ subject.expect_failure 'this is an expected failure', &block }.to_not raise_error
+    end
+
+    it 'fails when a non-Beaker, non-MiniTest assertion is raised' do
+      block = lambda { raise 'not a Beaker or MiniTest error' }
+      expect{ subject.expect_failure 'this has a non-Beaker, non-MiniTest exception', &block }.to raise_error(RuntimeError, /not a Beaker or MiniTest error/)
+    end
+
+    it 'fails when no assertion is raised' do
+      block = lambda { assert_equal('1', '1', '1 should equal 1') }
+      expect{ subject.expect_failure 'this has no failure', &block }.to raise_error(RuntimeError, /An assertion was expected to fail, but passed/)
     end
   end
 end


### PR DESCRIPTION
- add expect_failure method
- add expect_failure spec tests