### PR TITLE
(QENG-1758) beaker bash completion script should not prevent filename co...

### DIFF
--- a/ext/completion/beaker-completion.bash
+++ b/ext/completion/beaker-completion.bash
@@ -50,4 +50,4 @@ _beaker_complete()
 }
 
 # Register _beaker_complete to provide completion for the following commands
-complete -F _beaker_complete beaker pe-beaker
+complete -F _beaker_complete -o default beaker pe-beaker


### PR DESCRIPTION
...mpletion

This change specifies -o default to use the default completion method
when a completion is not found with this script. This allows completion
of filenames as well as beaker's options.