### PR TITLE
(gh-660) Update default aio puppetpath path for unix

### DIFF
--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -59,7 +59,7 @@ module Unix
     def self.aio_defaults
       h = self.foss_defaults
       h['puppetbindir'] = '/opt/puppetlabs/agent/bin'
-      h['puppetpath'] = '/opt/puppetlabs/agent'
+      h['puppetpath'] = '/etc/puppetlabs/agent'
       h['puppetvardir'] = '/opt/puppetlabs/agent/cache'
       h['distmoduledir'] = '/opt/puppetlabs/agent/modules'
       h['sitemoduledir'] = '/etc/puppetlabs/agent/modules'


### PR DESCRIPTION
This commit updates the default aio puppetpath to /etc/puppetlabs/agent