### PR TITLE
Upgrade google-api-client dependency to fix Ruby 1.9.x compatibility

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   # Optional provisioner specific support
   s.add_runtime_dependency 'rbvmomi', '~> 1.8'
   s.add_runtime_dependency 'fission', '~> 0.4'
-  s.add_runtime_dependency 'google-api-client', '~> 0.7'
+  s.add_runtime_dependency 'google-api-client', '~> 0.8'
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'fog', '~> 1.25'


### PR DESCRIPTION
Retriable was upgraded today (Jan 30th) and they shipped a version 2.0.0 that
requires Ruby >=2.0.0.

In google-api-client 0.7.1, we were pulling in version >= 1.4 of retriable. In 0.8.2
they have a fix that pulls in ~> 1.4 version of retriable, thus pinning the ceiling
on the upgrade to retriable 2.0.0.

You can see the failure here: https://jenkins.puppetlabs.com/job/platform_puppetdb_intn-sys_pr/506/BEAKER_CONFIG=ec2-west-el7-64mda-el7-64a,BEAKER_OPTIONS=postgres,label=beaker-ec2/console

Signed-off-by: Ken Barber <ken@bob.sh>