### PR TITLE
(MAINT) Fix mkdir bug on PSWindows and fix test

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -344,7 +344,8 @@ module Beaker
       if self.is_cygwin?
         cmd = "mkdir -p #{dir}"
       else
-        cmd = "if not exist #{dir.gsub!('/','\\')} (md #{dir.gsub!('/','\\')})"
+        windows_dirstring = dir.gsub('/','\\')
+        cmd = "if not exist #{windows_dirstring} (md #{windows_dirstring})"
       end
 
       result = exec(Beaker::Command.new(cmd), :acceptable_exit_codes => [0, 1])

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -355,7 +355,7 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("if not exist test\\test\\test (md )")
+        expect( Beaker::Command ).to receive(:new).with("if not exist test\\test\\test (md test\\test\\test)")
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end


### PR DESCRIPTION
Introduced in f551c0ad124bb8ab782f7dd90ab30ae9cc49fafa


This actually breaks Beaker, because the host variable is nil:

```
/opt/rubies/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/beaker-136d9c3cccbc/lib/beaker/host.rb:305:in `mkdir_p': undefined local variable or method `host' for #<FreeBSD::Host:0x007f8abe0e20b8> (NameError)
	from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/beaker-136d9c3cccbc/lib/beaker/host.rb:364:in `block in do_scp_to'
	from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/beaker-136d9c3cccbc/lib/beaker/host.rb:361:in `each'
	from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/beaker-136d9c3cccbc/lib/beaker/host.rb:361:in `do_scp_to'
	from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/bundler/gems/beaker-136d9c3cccbc/lib/beaker/dsl/helpers.rb:207:in `block in scp_to'
```