### PR TITLE
Revert "(QENG-1784) updated FOSS group to be root instead of puppet"

### DIFF
--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -38,7 +38,7 @@ module Unix
       h = Beaker::Options::OptionsHash.new
       h.merge({
         'user'              => 'root',
-        'group'             => 'root',
+        'group'             => 'puppet',
         'puppetserver-confdir' => '/etc/puppetserver/conf.d',
         'puppetservice'     => 'puppetmaster',
         'puppetpath'        => '/etc/puppet',


### PR DESCRIPTION
Reverts puppetlabs/beaker#667

This is because the Puppet user was being confused for the Beaker user.  

This means that people were using `host['user']` and `host['group']` for puppet stuff incorrectly.