### PR TITLE
(maint) Add ruby to windows PATH

### DIFF
--- a/lib/beaker/host/windows.rb
+++ b/lib/beaker/host/windows.rb
@@ -43,8 +43,8 @@ module Windows
         'sitemoduledir'     => 'C:/usr/share/puppet/modules',
         'hieralibdir'       => '`cygpath -w /opt/puppet-git-repos/hiera/lib`',
         'hierapuppetlibdir' => '`cygpath -w /opt/puppet-git-repos/hiera-puppet/lib`',
-        #let's just add both potential bin dirs to the path
-        'puppetbindir'  => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/bin',
+        #let's just add both potential bin dirs to the path, include ruby too for `gem`, `ruby`, etc
+        'puppetbindir'  => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/bin:/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/sys/ruby/bin',
         'hierabindir'       => '/opt/puppet-git-repos/hiera/bin',
         'pathseparator'     => ';',
       })


### PR DESCRIPTION
Previously, beaker would add `puppetbindir` to the `~/.ssh/environment`,
which on Windows, excluded the ruby that the MSI installs. As a result,
puppet setup steps that rely on `gem`, e.g. when adding sources, would
fail.

This commit adds the ruby in the MSI to the `~/.ssh/environment` simply by
it being included in `puppetbindir`. Note the actual location depends on
whether we are installing x86 puppet on x64 windows, or not, so we
include both possibilities like we do for puppet's main bin directory.