### PR TITLE
Provide a means of supplying a custom Vagrantfile

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -38,6 +38,8 @@ module Beaker
           end
         when /^vagrant$/
           Beaker::Vagrant
+        when /^vagrant_custom$/
+          Beaker::VagrantCustom
         when /^vagrant_libvirt$/
           Beaker::VagrantLibvirt
         when /^vagrant_virtualbox$/

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -131,6 +131,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_custom', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/lib/beaker/hypervisor/vagrant_custom.rb
+++ b/lib/beaker/hypervisor/vagrant_custom.rb
@@ -1,6 +1,6 @@
 require 'beaker/hypervisor/vagrant'
 
-class Beaker::VagrantVirtualbox < Beaker::Vagrant
+class Beaker::VagrantCustom < Beaker::Vagrant
   def provision(provider = 'vagrant_custom')
     super
   end

--- a/lib/beaker/hypervisor/vagrant_custom.rb
+++ b/lib/beaker/hypervisor/vagrant_custom.rb
@@ -1,7 +1,7 @@
 require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantCustom < Beaker::Vagrant
-  def provision(provider = 'vagrant_custom')
+  def provision(provider = nil)
     super
   end
 

--- a/lib/beaker/hypervisor/vagrant_custom.rb
+++ b/lib/beaker/hypervisor/vagrant_custom.rb
@@ -1,0 +1,11 @@
+require 'beaker/hypervisor/vagrant'
+
+class Beaker::VagrantVirtualbox < Beaker::Vagrant
+  def provision(provider = 'vagrant_custom')
+    super
+  end
+
+  def make_vfile hosts, options = {}
+    FileUtils.cp(@options[:vagrantfile], @vagrant_file)
+  end
+end


### PR DESCRIPTION
This branch adds vagrant_custom to the hypervisor list, reading the path to a Vagrantfile from CONFIG: vagrantfile:

```
> cat spec/acceptance/nodesets/default.yml
HOSTS:
  trusty:
    roles:
      - apache
    platform: ubuntu-1404-x86_64
    hypervisor: vagrant_custom
    box: trusty64
CONFIG:
  vagrantfile: ./spec/acceptance/nodesets/Vagrantfile
```

With this ability to set your own Vagrantfile in its entirety, you can make use of all of Vagrant's features and plugins with no added code. Thus, Openstack support comes for free with the vagrant-openstack-plugin, and similarly for vsphere, etc.

https://tickets.puppetlabs.com/browse/PUP-3984