### PR TITLE
(QENG-1809) removed master path resets for AIO test setups

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -54,7 +54,6 @@ module Beaker
       # related through 'type' and the differences between the assumption of our two
       # configurations we have for many of our products
       type = @options.get_type
-      type = :foss if type == :aio && !@options['HOSTS'][@name]['roles'].include?('agent')
       @defaults = merge_defaults_for_type @options, type
       pkg_initialize
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -64,15 +64,9 @@ module Beaker
         expect(host.is_using_passenger?).to be_falsy
       end
 
-      it 'sets the paths correctly for an AIO agent host' do
+      it 'sets the paths correctly for an AIO host' do
         options['type'] = 'aio'
         expect(host['puppetvardir']).to be === Unix::Host::aio_defaults[:puppetvardir]
-      end
-
-      it 'sets the paths correctly for an AIO non-agent host' do
-        options['type'] = 'aio'
-        options['roles'] = ['master']
-        expect(host['puppetvardir']).to be === Unix::Host::foss_defaults[:puppetvardir]
       end
     end
 


### PR DESCRIPTION
Originally, I had assumed that machines with the master role would keep their old paths, or be updated
with a completely new set.  It looks like the master pathing will actually be based upon the agent though,
since masters will be installed on top of agents now