### PR TITLE
(QENG-1813) Use puppet-server service names

### DIFF
--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -62,6 +62,8 @@ module Unix
 
     def self.aio_defaults
       h = self.foss_defaults
+      h['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
+      h['puppetservice']  = 'puppetserver'
       h['puppetbindir']   = '/opt/puppetlabs/agent/bin'
       h['puppetbin']      = "#{h['puppetbindir']}/puppet"
       h['puppetpath']     = '/etc/puppetlabs/agent'


### PR DESCRIPTION
Previously, when executing AIO acceptance tests, the beaker method
`with_puppet_running_on` would attempt to start and stop the
`puppetmaster` service. This is because the AIO defaults for
`puppetservice` and related conf.d were not specified, and would
fallback to the FOSS defaults.

This commit updates the AIO defaults to match the `puppetserver`
service, and related conf.d.