### PR TITLE
(gh-687) [openstack] multi node root user enable

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -133,7 +133,7 @@ module Beaker
         @vms << vm
 
         #enable root if user is not root
-        enable_root_on_hosts()
+        enable_root(host)
       end
     end
 
@@ -152,8 +152,10 @@ module Beaker
       end
     end
 
-    # Enables root for instances with custom username like ubuntu-amis
-    #
+    # Enables root access for a host when username is not root
+    # This method ripped from the aws_sdk implementation and is probably wrong
+    # because it iterates on a collection when there's no guarantee the collection
+    # has all been brought up in openstack yet and will thus explode
     # @return [void]
     # @api private
     def enable_root_on_hosts
@@ -162,10 +164,8 @@ module Beaker
       end
     end
 
-    # Enables root access for a host when username is not root
-    #
-    # @return [void]
-    # @api private
+    # enable root on a single host (the current one presumably) but only
+    # if the username isn't 'root'
     def enable_root(host)
       if host['user'] != 'root'
         copy_ssh_to_root(host, @options)


### PR DESCRIPTION
This PR enables root access on each node in turn, after it is provisioned.  Previously,
the code did all nodes on the first pass, before some were even a twinkle in Openstack's
eye.