### PR TITLE
(gh-688) Fixing the powershell wrapper to use an array of arguments

### DIFF
--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -131,7 +131,7 @@ module Beaker
         ps_opts.merge!(args)
 
         arguments = " #{ps_opts.sort.map{|k,v| v.eql?('') ? "-#{k}" : "-#{k} #{v}" }.join(' ')} -Command \"#{command}\""
-        Command.new('powershell.exe', arguments, {})
+        Command.new('powershell.exe', arguments.split(' '), {})
       end
     end
   end

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -600,7 +600,7 @@ describe ClassMixedWithDSLInstallUtils do
         entry = { 'ip' => '23.251.154.122', 'name' => 'forge.puppetlabs.com' }
         expect(subject).to receive(:on) do |host, command|
           expect(command.command).to eq('powershell.exe')
-          expect(command.args).to eq(" -ExecutionPolicy Bypass -InputFormat None -NoLogo -NoProfile -NonInteractive -Command \"$text = \\\"23.251.154.122`t`tforge.puppetlabs.com\\\"; Add-Content -path 'C:\\Windows\\System32\\Drivers\\etc\\hosts' -value $text\"")
+          expect(command.args).to eq(['-ExecutionPolicy','Bypass','-InputFormat','None','-NoLogo','-NoProfile','-NonInteractive','-Command', '"$text', '=', '\"23.251.154.122`t`tforge.puppetlabs.com\";', 'Add-Content', '-path', '\'C:\\Windows\\System32\\Drivers\\etc\\hosts\'', '-value', '$text"'])
         end
 
 

--- a/spec/beaker/dsl/wrappers_spec.rb
+++ b/spec/beaker/dsl/wrappers_spec.rb
@@ -62,14 +62,14 @@ describe ClassMixedWithDSLWrappers do
     it 'should pass "powershell.exe <args> -Command <command>" to Command' do
       command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'")
       expect(command.command ).to be === 'powershell.exe'
-      expect( command.args).to be === ' -ExecutionPolicy Bypass -InputFormat None -NoLogo -NoProfile -NonInteractive -Command "Set-Content -path \'fu.txt\' -value \'fu\'"'
+      expect( command.args).to be === [ '-ExecutionPolicy', 'Bypass', '-InputFormat', 'None', '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '"Set-Content', '-path', '\'fu.txt\'', '-value', '\'fu\'"' ]
       expect( command.options ).to be === {}
     end
 
     it 'should merge the arguments provided with the defaults' do
       command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'ExecutionPolicy' => 'Unrestricted'})
       expect( command.command).to be === 'powershell.exe'
-      expect( command.args ).to be === ' -ExecutionPolicy Unrestricted -InputFormat None -NoLogo -NoProfile -NonInteractive -Command "Set-Content -path \'fu.txt\' -value \'fu\'"'
+      expect( command.args ).to be === [ '-ExecutionPolicy', 'Unrestricted', '-InputFormat', 'None', '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '"Set-Content', '-path', '\'fu.txt\'', '-value', '\'fu\'"' ]
       expect( command.options ).to be === {}
     end
   end


### PR DESCRIPTION
Fix for #688 