### PR TITLE
(gh-693) Fixes bug in determine_if_x86_64 on windows

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -202,7 +202,13 @@ module Beaker
     #Examine the host system to determine the architecture
     #@return [Boolean] true if x86_64, false otherwise
     def determine_if_x86_64
-      result = exec(Beaker::Command.new("arch | grep x86_64"), :acceptable_exit_codes => (0...127))
+      if self['is_cygwin'].nil? or self['is_cygwin'] == true
+        command = Beaker::Command.new("arch | grep x86_64")
+      else
+        command = Beaker::Command.new("echo '' | wmic os get osarchitecture | FindStr 64-bit")
+      end
+
+      result = exec(command, :acceptable_exit_codes => (0...127))
       result.exit_code == 0
     end
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -564,5 +564,67 @@ module Beaker
       end
 
     end
+
+    describe '#determine_if_x86_64' do
+      it 'does the right thing on a 64-bit linux host, identified as is_cygwin=nil' do
+        @options = {:is_cygwin => nil}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 0 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("arch | grep x86_64")
+        expect( host.determine_if_x86_64 ).to be == true
+      end
+
+      it 'does the right thing on a 32-bit linux host, identified as is_cygwin=nil' do
+        @options = {:is_cygwin => nil}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 1 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("arch | grep x86_64")
+        expect( host.determine_if_x86_64 ).to be == false
+      end
+
+      it 'does the right thing on a 64-bit windows host, identified as is_cygwin=true' do
+        @options = {:is_cygwin => true}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 0 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("arch | grep x86_64")
+        expect( host.determine_if_x86_64 ).to be == true
+      end
+
+      it 'does the right thing on a 32-bit windows host, identified as is_cygwin=true' do
+        @options = {:is_cygwin => true}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 1 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("arch | grep x86_64")
+        expect( host.determine_if_x86_64 ).to be == false
+      end
+
+      it 'does the right thing on a 64-bit windows host, identified as is_cygwin=false' do
+        @options = {:is_cygwin => false}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 0 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("echo '' | wmic os get osarchitecture | FindStr 64-bit")
+        expect( host.determine_if_x86_64 ).to be == true
+      end
+
+      it 'does the right thing on a 32-bit windows host, identified as is_cygwin=false' do
+        @options = {:is_cygwin => false}
+        result = double
+        allow( result ).to receive( :exit_code ).and_return( 1 )
+        allow( host ).to receive( :exec ).and_return( result )
+
+        expect( Beaker::Command ).to receive(:new).with("echo '' | wmic os get osarchitecture | FindStr 64-bit")
+        expect( host.determine_if_x86_64 ).to be == false
+      end
+    end
   end
 end


### PR DESCRIPTION
The determine_if_x86_64 function does not work on windows
with is_cygwin=false as the commands arch and grep are not
avaliable outside of cygwin on windows.

This commit corrects the behaviour of the method so when the option
is_cygwin=false is configured it uses standard dos commands to
determin the architecture