### PR TITLE
(MAINT) Rolling back change for windows in the vagrant hypervisor

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -72,9 +72,7 @@ module Beaker
         end
         #replace hostname with ip
         ssh_config = ssh_config.gsub(/Host #{host.name}/, "Host #{host['ip']}") unless not host['ip']
-        if host['platform'] =~ /windows/
-          ssh_config = ssh_config.gsub(/127\.0\.0\.1/, host['ip']) unless not host['ip']
-        end
+
         #set the user
         ssh_config = ssh_config.gsub(/User vagrant/, "User #{user}")
         f.write(ssh_config)


### PR DESCRIPTION
Rolling back the change made in bf353c1 as it is no longer required.

The subsequent change in 3aa080c for vagrant 1.7 properly fixed the issue
and so the work around can now be removed.