### PR TITLE
(QENG-780) request sets of VMs instead of one VM at a time

### DIFF
--- a/spec/mocks.rb
+++ b/spec/mocks.rb
@@ -39,8 +39,8 @@ module MockNet
         @uri = uri
       end
 
-      def set_form_data hash
-
+      def body= *args
+        hash
       end
     end
 


### PR DESCRIPTION
This PR facilitates use of vmpooler's batch-request POST API
(https://github.com/puppetlabs/vmpooler#post-vm) within beaker.