### PR TITLE
(gh-704) Add an option to do_scp_to to allow the use of rsync

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'fog', '~> 1.25'
+  s.add_runtime_dependency 'rsync'
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -1318,13 +1318,17 @@ module Beaker
       #                   Location where the module should be installed, will default
       #                    to host['distmoduledir']/modules
       # @option opts [Array] :ignore_list
+      # @options opts [String] :copy_method (:scp)
+      #                   When copying modules from a local system the underyling protocol to use
+      #                     can be :scp or :rsync
       # @raise [ArgumentError] if not host is provided or module_name is not provided and can not be found in Modulefile
       #
       def copy_module_to(one_or_more_hosts, opts = {})
         block_on one_or_more_hosts do |host|
           opts = {:source => './',
                   :target_module_path => host['distmoduledir'],
-                  :ignore_list => PUPPET_MODULE_INSTALL_IGNORE}.merge(opts)
+                  :ignore_list => PUPPET_MODULE_INSTALL_IGNORE,
+                  :copy_method => :scp}.merge(opts)
           ignore_list = build_ignore_list(opts)
           target_module_dir = on( host, "echo #{opts[:target_module_path]}" ).stdout.chomp
           source = File.expand_path( opts[:source] )
@@ -1333,7 +1337,7 @@ module Beaker
           else
             _, module_name = parse_for_modulename( source )
           end
-          scp_to host, source, File.join(target_module_dir, module_name), {:ignore => ignore_list}
+          scp_to host, source, File.join(target_module_dir, module_name), {:ignore => ignore_list, :copy_method => opts[:copy_method]}
         end
       end
       alias :copy_root_module_to :copy_module_to

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -1035,6 +1035,7 @@ describe ClassMixedWithDSLInstallUtils do
     let(:source){ File.expand_path('./')}
     let(:target){'/etc/puppetlabs/puppet/modules/testmodule'}
     let(:module_parse_name){'testmodule'}
+    let(:copy_method){:scp}
 
     shared_examples 'copy_module_to' do  |opts|
       it{
@@ -1056,7 +1057,7 @@ describe ClassMixedWithDSLInstallUtils do
         allow( File ).to receive(:exists?).with(any_args()).and_return(false)
         allow( File ).to receive(:directory?).with(any_args()).and_return(false)
 
-        expect( subject ).to receive(:scp_to).with(host,source, target, {:ignore => ignore_list})
+        expect( subject ).to receive(:scp_to).with(host,source, target, {:ignore => ignore_list, :copy_method => copy_method})
         if opts.nil?
           subject.copy_module_to(host)
         else
@@ -1093,6 +1094,11 @@ describe ClassMixedWithDSLInstallUtils do
         expect( subject ).to receive( :scp_to ).twice
         subject.copy_module_to( hosts )
       end
+    end
+
+    describe 'should accept rsync copy_method and pass it to host' do
+      let(:copy_method){:rsync}
+      it_should_behave_like 'copy_module_to', {:module_name => 'testmodule', :copy_method => :rsync}
     end
   end
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -381,6 +381,19 @@ module Beaker
         host.do_scp_to *args
       end
 
+      it 'do_scp_to uses rsync when specified' do
+        create_files(['tmp/tests/source'])
+        @options = { :logger => logger }
+        conn = double(:connection)
+        host.instance_variable_set :@connection, conn
+        rsync_args = [ 'tmp/tests', 'target', nil ]
+        args = [ 'tmp/tests', 'target', :copy_method =>  :rsync ]
+
+        expect( host ).to receive( :rsync_to ).with( *rsync_args ).and_return(Beaker::Result.new(host, 'output!'))
+
+        host.do_scp_to *args
+      end
+
       it 'throws an IOError when the file given doesn\'t exist' do
         expect { host.do_scp_to "/does/not/exist", "does/not/exist/over/there", {} }.to raise_error(IOError)
       end


### PR DESCRIPTION
Without this patch copying a large number of files can take a long time. This patch allows the use of rsync, by adding a :copy_method argument to puppet_module_install_on or scp_to command, which speeds up file transfers. Syncing files instead of blind copying them itself does not provide a performance increase, but rather the lack of encryption significantly increases speed. Puppet_module_install_on is still slow (although faster than scp) with this patch, because the :ignore method is used with causes each file to be individually synced.