### PR TITLE
GH-700 - Allow Docker::options to be set from config hash

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -8,7 +8,9 @@ module Beaker
       @hosts = hosts
 
       # increase the http timeouts as provisioning images can be slow
-      docker_options = ::Docker.options.empty? ? @options[:docker_options] : ::Docker.options
+      unless ::Docker.options.nil?
+        docker_options = ::Docker.options.empty? ? @options[:docker_options] : ::Docker.options
+      end
       ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(docker_options || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -7,10 +7,11 @@ module Beaker
       @logger = options[:logger]
       @hosts = hosts
 
-      # increase the http timeouts as provisioning images can be slow
+      # Set docker options to the entry in the options hash, unless we've already set them elsewhere:
       unless ::Docker.options.nil?
         docker_options = ::Docker.options.empty? ? @options[:docker_options] : ::Docker.options
       end
+      # increase the http timeouts as provisioning images can be slow
       ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(docker_options || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -8,7 +8,8 @@ module Beaker
       @hosts = hosts
 
       # increase the http timeouts as provisioning images can be slow
-      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(::Docker.options || {})
+      docker_options = ::Docker.options.empty? ? @options[:docker_options] : ::Docker.options
+      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(docker_options || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch
       begin

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -7,12 +7,10 @@ module Beaker
       @logger = options[:logger]
       @hosts = hosts
 
-      # Set docker options to the entry in the options hash, unless we've already set them elsewhere:
-      unless ::Docker.options.nil?
-        docker_options = ::Docker.options.empty? ? @options[:docker_options] : ::Docker.options
-      end
       # increase the http timeouts as provisioning images can be slow
-      ::Docker.options = { :write_timeout => 300, :read_timeout => 300 }.merge(docker_options || {})
+      default_docker_options = { :write_timeout => 300, :read_timeout => 300 }.merge(::Docker.options || {})
+      # Merge docker options from the entry in hosts file
+      ::Docker.options = default_docker_options.merge(@options[:docker_options] || {})
       # assert that the docker-api gem can talk to your docker
       # enpoint.  Will raise if there is a version mismatch
       begin


### PR DESCRIPTION
Addresses #700 - This allows `docker_options` to be set in the nodeset YAML, allowing the timeouts to be easily extended.