### PR TITLE
(QENG-1867) Add ETIMEDOUT rescue to host.rb

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -81,7 +81,7 @@ module Beaker
           TCPSocket.new(reachable_name, port).close
           return true
         end
-      rescue Errno::ECONNREFUSED, Timeout::Error
+      rescue Errno::ECONNREFUSED, Timeout::Error, Errno::ETIMEDOUT
         return false
       end
     end


### PR DESCRIPTION
This commit adds `Errno::ETIMEDOUT` to the rescue logic of the
port_open? method in lib/beaker/host.rb.

Adding this this rescue prevents the ETIMEDOUT error from short circuiting of
the logical intention of the port_open? method.