### PR TITLE
Added support for rsync

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-ssh', '~> 2.9'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 2.0'
+  s.add_runtime_dependency 'rsync', '~> 1.0.9'
 
   # Optional provisioner specific support
   s.add_runtime_dependency 'rbvmomi', '~> 1.8'

--- a/lib/beaker/dsl/install_utils.rb
+++ b/lib/beaker/dsl/install_utils.rb
@@ -1318,6 +1318,8 @@ module Beaker
       #                   Location where the module should be installed, will default
       #                    to host['distmoduledir']/modules
       # @option opts [Array] :ignore_list
+      # @option opts [String] :protocol
+      #                   Name of the underlying transfer method. Valid options are 'scp' or 'rsync'.
       # @raise [ArgumentError] if not host is provided or module_name is not provided and can not be found in Modulefile
       #
       def copy_module_to(one_or_more_hosts, opts = {})
@@ -1333,7 +1335,17 @@ module Beaker
           else
             _, module_name = parse_for_modulename( source )
           end
-          scp_to host, source, File.join(target_module_dir, module_name), {:ignore => ignore_list}
+
+          opts[:protocol] ||= 'scp'
+          case opts[:protocol]
+            when 'scp'
+              scp_to host, source, File.join(target_module_dir, module_name), {:ignore => ignore_list}
+            when 'rsync'
+              rsync_to host, source, File.join(target_module_dir, module_name), {:ignore => ignore_list}
+            else
+              logger.debug "Unsupported transfer protocol, returning nil"
+              nil
+          end
         end
       end
       alias :copy_root_module_to :copy_module_to


### PR DESCRIPTION
During my testing from Belfast, using vcloud+beaker is very, very slow over the built-in SCP. It is common for an acceptance test to take 5 or 10 minutes to start due to the module upload. Rsync reduced this to literally a few seconds!

As such, I have created some code to add rsync support for beaker. It requires the 'rsync' gem which is a wrapper for the system binary (thus, you need rsync already on your system). To use it, you simply use the following in your spec helpers:

```
copy_module_to(host, :source => proj_root, :module_name => 'firewall', :protocol => 'rsync')
```
or

```
# Same arguments as scp_to 
rsync_to host, proj_root, "#{host['distmoduledir']}/netscaler", {:ignore => [".bundle", ".git", ".vagrant"]}
```
or

```
create_remote_file(master, File.join(path, "site.pp"), pp, :protocol => 'rsync')
```

It's not fully comprehensive just yet, but I feel these are a good start, especially since the main slowdown is the initial module copy.

I have written some basic unit tests for my new code which work almost pretty well, except I'm having an issue which I'll make a separate comment for.

Thanks!