### PR TITLE
(QENG-1681) upgrade_pe method is generating errors when attempted...

### DIFF
--- a/lib/beaker/answers/version20.rb
+++ b/lib/beaker/answers/version20.rb
@@ -34,7 +34,6 @@ module Beaker
       master_a = {
         :q_puppetmaster_install => 'y',
         :q_puppetmaster_certname => master,
-        :q_puppetmaster_install => 'y',
         :q_puppetmaster_dnsaltnames => master_dns_altnames,
         :q_puppetmaster_enterpriseconsole_hostname => dashboard,
         :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),

--- a/lib/beaker/answers/version28.rb
+++ b/lib/beaker/answers/version28.rb
@@ -35,7 +35,6 @@ module Beaker
       master_a = {
         :q_puppetmaster_install => 'y',
         :q_puppetmaster_certname => master,
-        :q_puppetmaster_install => 'y',
         :q_puppetmaster_dnsaltnames => master_dns_altnames,
         :q_puppetmaster_enterpriseconsole_hostname => dashboard,
         :q_puppetmaster_enterpriseconsole_port => answer_for(options, :q_puppetmaster_enterpriseconsole_port, 443),

--- a/lib/beaker/answers/version34.rb
+++ b/lib/beaker/answers/version34.rb
@@ -37,7 +37,7 @@ module Beaker
       }
 
       # If we're installing or upgrading from a non-RBAC version, set the 'admin' password
-      if @options[:type] == :upgrade && @options[:HOSTS][dashboard.name][:pe_ver] < "3.4.0"
+      if @options[:type] == :upgrade && @options[:set_console_password]
         dashboard_password = "'#{@options[:answers][:q_puppet_enterpriseconsole_auth_password]}'"
         the_answers[dashboard.name][:q_puppet_enterpriseconsole_auth_password] = dashboard_password
       end

--- a/spec/beaker/dsl/install_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils_spec.rb
@@ -715,10 +715,11 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
+      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
       allow( subject ).to receive( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
-      expect( subject ).to receive( :do_install ).with( the_hosts, { :type => :upgrade } )
+      expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
       the_hosts.each do |h|
         expect( h['pe_installer'] ).to be === 'puppet-enterprise-upgrader'
@@ -731,10 +732,11 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
+      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
       allow( subject ).to receive( :version_is_less ).with('3.1', '3.0').and_return( false )
       version = version_win = '3.1'
       path = "/path/to/upgradepkg"
-      expect( subject ).to receive( :do_install ).with( the_hosts, { :type => :upgrade } )
+      expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
       the_hosts.each do |h|
         expect( h['pe_installer'] ).to be nil
@@ -747,10 +749,11 @@ describe ClassMixedWithDSLInstallUtils do
       the_hosts = [ hosts[0].dup, hosts[1].dup, hosts[2].dup ]
       allow( subject ).to receive( :hosts ).and_return( the_hosts )
       allow( subject ).to receive( :options ).and_return( {} )
+      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4.0').and_return( true )
       allow( subject ).to receive( :version_is_less ).with('2.8', '3.0').and_return( true )
       version = version_win = '2.8'
       path = "/path/to/upgradepkg"
-      expect( subject ).to receive( :do_install ).with( the_hosts, { :type => :upgrade } )
+      expect( subject ).to receive( :do_install ).with( the_hosts, {:type=>:upgrade, :set_console_password=>true} )
       subject.upgrade_pe( path )
       the_hosts.each do |h|
         expect( h['pe_ver'] ).to be === '2.8'


### PR DESCRIPTION
...on PE 3.7.0 and later

- do pe version comparison in the upgrader method, not the answer file
  generator
- use proper semvar dot comparison of versions, not just string compare
- handle not knowing what the pe_ver is currently installed
- unrelated nit: remove duplicate key entries in answer file generation