### PR TITLE
(QENG-1891) added /opt/puppetlabs/bin directory to path for AIO

### DIFF
--- a/lib/beaker/host/unix.rb
+++ b/lib/beaker/host/unix.rb
@@ -64,7 +64,7 @@ module Unix
       h = self.foss_defaults
       h['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
       h['puppetservice']  = 'puppetserver'
-      h['puppetbindir']   = '/opt/puppetlabs/agent/bin'
+      h['puppetbindir']   = '/opt/puppetlabs/agent/bin:/opt/puppetlabs/bin'
       h['puppetbin']      = "#{h['puppetbindir']}/puppet"
       h['puppetpath']     = '/etc/puppetlabs/agent'
       h['puppetconfdir']  = "#{h['puppetpath']}/config"


### PR DESCRIPTION
this is a stop-gap measure to unblock testing, as opposed to the larger work to update all paths to the latest spec, which will be done in QENG-1841.