### PR TITLE
(gh-702) sshd restart doesn't work with some el6 variants - especiall...

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -344,7 +344,7 @@ module Beaker
         if host['platform'] =~ /debian|ubuntu|cumulus/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
-          host.exec(Command.new("sudo -E /sbin/service sshd restart"), {:pty => true})
+          host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
         else
           @logger.warn("Attempting to update ssh on non-supported platform: #{host.name}: #{host['platform']}")
         end


### PR DESCRIPTION
...y centos - with vagrant provisioner

For centos6 & vagrant, this pull fixed it: https://github.com/puppetlabs/beaker/pull/545 & fixing https://github.com/puppetlabs/beaker/issues/656 re-broke it by undoing pull 545

Instead of service sshd restart, service sshd reload fixes the issue.  Even systemctl takes reload.