### PR TITLE
(maint) VcloudPooled -> Vmpooler

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -30,9 +30,11 @@ module Beaker
           Beaker::Fusion
         when /^ec2$/
           Beaker::AwsSdk
+        when /^vmpooler$/
+          Beaker::Vmpooler
         when /^vcloud$/
           if options['pooling_api']
-            Beaker::VcloudPooled
+            Beaker::Vmpooler
           else
             Beaker::Vcloud
           end
@@ -129,6 +131,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vcloud', 'vcloud_pooled', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vmpooler', 'vcloud', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -33,10 +33,10 @@ module Beaker
       expect( hypervisor.create( 'fusion', [], make_opts() ) ).to be === fusion
     end
 
-    it "creates a vcloudpooled hypervisor for vcloud hosts that are pooled" do
+    it "creates a vmpooler hypervisor for hosts that are pooled" do
       vcloud = double( 'vcloud' )
       allow( vcloud ).to receive( :provision ).and_return( true )
-      expect( VcloudPooled ).to receive( :new ).once.and_return( vcloud )
+      expect( Vmpooler ).to receive( :new ).once.and_return( vcloud )
       expect( hypervisor.create( 'vcloud', [], make_opts().merge( { 'pooling_api' => true } ) ) ).to be === vcloud
     end
 

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Beaker
-  describe VcloudPooled do
+  describe Vmpooler do
 
     before :each do
       vms = make_hosts()
@@ -18,25 +18,25 @@ module Beaker
     describe '#get_template_url' do
 
       it 'works returns the valid url when passed valid pooling_api and template name' do
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        uri = vcloud.get_template_url("http://pooling.com", "template")
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        uri = vmpooler.get_template_url("http://pooling.com", "template")
         expect( uri ).to be === "http://pooling.com/vm/template"
       end
       
       it 'adds a missing scheme to a given URL' do
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        uri = vcloud.get_template_url("pooling.com", "template")
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        uri = vmpooler.get_template_url("pooling.com", "template")
         expect( URI.parse(uri).scheme ).to_not be === nil
       end
 
       it 'raises an error on an invalid pooling api url' do
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        expect{ vcloud.get_template_url("pooling###   ", "template")}.to raise_error ArgumentError
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect{ vmpooler.get_template_url("pooling###   ", "template")}.to raise_error ArgumentError
       end
 
       it 'raises an error on an invalide template name' do
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        expect{ vcloud.get_template_url("pooling.com", "t!e&m*p(l\\a/t e")}.to raise_error ArgumentError
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect{ vmpooler.get_template_url("pooling.com", "t!e&m*p(l\\a/t e")}.to raise_error ArgumentError
       end
       
     end
@@ -45,12 +45,12 @@ module Beaker
 
       it 'provisions hosts from the pool' do 
 
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        allow( vcloud ).to receive( :require ).and_return( true )
-        allow( vcloud ).to receive( :sleep ).and_return( true )
-        vcloud.provision
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        allow( vmpooler ).to receive( :require ).and_return( true )
+        allow( vmpooler ).to receive( :sleep ).and_return( true )
+        vmpooler.provision
 
-        hosts = vcloud.instance_variable_get( :@hosts )
+        hosts = vmpooler.instance_variable_get( :@hosts )
         hosts.each do | host |
           expect( host['vmhostname'] ).to be === 'pool'
         end
@@ -64,13 +64,13 @@ module Beaker
       it "cleans up hosts in the pool" do
         MockVsphereHelper.powerOn
 
-        vcloud = Beaker::VcloudPooled.new( make_hosts, make_opts )
-        allow( vcloud ).to receive( :require ).and_return( true )
-        allow( vcloud ).to receive( :sleep ).and_return( true )
-        vcloud.provision
-        vcloud.cleanup
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        allow( vmpooler ).to receive( :require ).and_return( true )
+        allow( vmpooler ).to receive( :sleep ).and_return( true )
+        vmpooler.provision
+        vmpooler.cleanup
 
-        hosts = vcloud.instance_variable_get( :@hosts )
+        hosts = vmpooler.instance_variable_get( :@hosts )
         hosts.each do | host |
           name = host.name
           vm = MockVsphereHelper.find_vm( name )


### PR DESCRIPTION
This PR renames the 'VcloudPooled' hypervisor to 'Vmpooler', and
includes a few fixups as ride-alongs:

  - resourcepool, folder, datastore not needed for Vmpooler
  - small syntax/wording changes