### PR TITLE
(QENG-1955) Windows::File.file_exist? fails on 2003

### DIFF
--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -14,7 +14,7 @@ module Windows::File
   end
 
   def file_exist?(path)
-    result = exec(Beaker::Command.new("test -e #{path}"), :acceptable_exit_codes => [0, 1])
+    result = exec(Beaker::Command.new("test -e '#{path}'"), :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end
 end


### PR DESCRIPTION
 - In 9c32cac7a7a5bf52f21b628b14ddba9bfc44510c a change was
   introduced to add a new Windows::File.file_exist? method
   that relied on using test -e.  The code assumes that the
   path does not contain spaces and does not need to be
   quoted.

   Unfortunately, this assumption is incorrect and causes
   pre-suites to fail because this test is performed on
   Puppets :vardir.  On Windows, Puppets :vardir is always
   rooted at %ALLUSERSPROFILE%\PuppetLabs

   When running on Windows 2008 or higher, the
   %ALLUSERSPROFILE% directory is C:\ProgramData\

   However, on Windows 2003, the path structure is different
   and that directory is located at
   C:\Documents and Settings\All Users\Application Data

   With an unquoted path passed to test -e a failure is
   generated, which breaks Windows pre-suites on 2003.