### PR TITLE
(QENG-1970) Guard against merging custom answers on Windows

### DIFF
--- a/lib/beaker/answers/version20.rb
+++ b/lib/beaker/answers/version20.rb
@@ -109,7 +109,7 @@ module Beaker
       master = only_host_with_role(@hosts, 'master')
       @hosts.each do |h|
         the_answers[h.name] = host_answers(h, master, dashboard, @options)
-        if h[:custom_answers]
+        if the_answers[h.name] && h[:custom_answers]
           the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
         end
         h[:answers] = the_answers[h.name]

--- a/lib/beaker/answers/version28.rb
+++ b/lib/beaker/answers/version28.rb
@@ -109,7 +109,7 @@ module Beaker
       master = only_host_with_role(@hosts, 'master')
       @hosts.each do |h|
         the_answers[h.name] = host_answers(h, master, dashboard, @options)
-        if h[:custom_answers]
+        if the_answers[h.name] && h[:custom_answers]
           the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
         end
         h[:answers] = the_answers[h.name]

--- a/lib/beaker/answers/version30.rb
+++ b/lib/beaker/answers/version30.rb
@@ -211,7 +211,7 @@ module Beaker
         else
           the_answers[h.name] = host_answers(h, master, database, dashboard, @options)
         end
-        if h[:custom_answers]
+        if the_answers[h.name] && h[:custom_answers]
           the_answers[h.name] = the_answers[h.name].merge(h[:custom_answers])
         end
         h[:answers] = the_answers[h.name]


### PR DESCRIPTION
Before this commit Beaker would attempt to merge custom answers on
platforms where answers are not used. This commit guards against merging
custom answers unless there are already answers specified.