### PR TITLE
 (BKR-8) PE 3.8 on Sles11 can't find puppet in path after install...

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -160,6 +160,7 @@ module Beaker
           :pe_version_file_win    => 'LATEST-win',
           :host_env               => {},
           :ssh_env_file           => '~/.ssh/environment',
+          :profile_d_env_file     => '/etc/profile.d/beaker_env.sh',
           :answers                => {
                                      :q_puppet_enterpriseconsole_auth_user_email    => 'admin@example.com',
                                      :q_puppet_enterpriseconsole_auth_password      => '~!@#$%^*-/ aZ',


### PR DESCRIPTION
... completes successfully.

- add the ~/.ssh/environment to a /etc/profile.d/beaker_env.sh script
- ensure that beaker_env.sh is kept up to date and correct with state of
  current env