### PR TITLE
Create /etc/hosts for Docker instances

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -321,11 +321,7 @@ module Beaker
     def hack_etc_hosts hosts, opts
       etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
       hosts.each do |host|
-        if host['hypervisor'] == 'docker'
-          etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host.name}\n"
-        else
-          etc_hosts += "#{host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
-        end
+        etc_hosts += "#{host['etc_host_ip'] || host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
       end
       hosts.each do |host|
         set_etc_hosts(host, etc_hosts)

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -321,7 +321,11 @@ module Beaker
     def hack_etc_hosts hosts, opts
       etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
       hosts.each do |host|
-        etc_hosts += "#{host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
+        if host['hypervisor'] == 'docker'
+          etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host.name}\n"
+        else
+          etc_hosts += "#{host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
+        end
       end
       hosts.each do |host|
         set_etc_hosts(host, etc_hosts)

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -66,18 +66,8 @@ module Beaker
         host['docker_image'] = image
       end
 
-      hack_docker_etc_hosts @hosts, @options
+      hack_etc_hosts @hosts, @options
 
-    end
-
-    def hack_docker_etc_hosts hosts, opts
-      etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
-      hosts.each do |host|
-        etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host.name}\n"
-      end
-      hosts.each do |host|
-        set_etc_hosts(host, etc_hosts)
-      end
     end
 
     def cleanup

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -65,6 +65,16 @@ module Beaker
         host['docker_container'] = container
         host['docker_image'] = image
       end
+
+      ## Set /etc/hosts :
+      etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
+      @hosts.each do |host|
+        etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host[:vmhostname] || host.name}\n"
+      end
+      @hosts.each do |host|
+        set_etc_hosts(host, etc_hosts)
+      end
+
     end
 
     def cleanup

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -66,15 +66,18 @@ module Beaker
         host['docker_image'] = image
       end
 
-      ## Set /etc/hosts :
+      hack_docker_etc_hosts @hosts, @options
+
+    end
+
+    def hack_docker_etc_hosts hosts, opts
       etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
-      @hosts.each do |host|
-        etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host[:vmhostname] || host.name}\n"
+      hosts.each do |host|
+        etc_hosts += "#{host['docker_container'].json["NetworkSettings"]["IPAddress"]}\t#{host.name}\n"
       end
-      @hosts.each do |host|
+      hosts.each do |host|
         set_etc_hosts(host, etc_hosts)
       end
-
     end
 
     def cleanup

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -64,6 +64,8 @@ module Beaker
         @logger.debug("node available as  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@#{ip} -p #{port}")
         host['docker_container'] = container
         host['docker_image'] = image
+        host['etc_host_ip'] = container.json["NetworkSettings"]["IPAddress"].to_s
+
       end
 
       hack_etc_hosts @hosts, @options

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -198,6 +198,15 @@ module Beaker
 
       end
 
+      it "should generate a new /etc/hosts file referencing each host" do
+        ENV['DOCKER_HOST'] = nil
+        docker.provision
+        hosts.each do |host|
+          expect( docker ).to receive( :set_etc_hosts ).with( host, "127.0.0.1\tlocalhost localhost.localdomain\n192.0.2.1\tvm1\n192.0.2.1\tvm2\n192.0.2.1\tvm3\n" ).once
+        end
+        docker.hack_docker_etc_hosts( hosts, options )
+      end
+
       it 'should record the image and container for later' do
         docker.provision
 

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -10,7 +10,7 @@ end
 
 module Beaker
   describe Docker do
-    let(:hosts) { make_hosts(:hypervisor => 'docker') }
+    let(:hosts) { make_hosts }
 
     let(:logger) do
       logger = double('logger')

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -10,7 +10,7 @@ end
 
 module Beaker
   describe Docker do
-    let(:hosts) { make_hosts }
+    let(:hosts) { make_hosts(:hypervisor => 'docker') }
 
     let(:logger) do
       logger = double('logger')
@@ -204,7 +204,7 @@ module Beaker
         hosts.each do |host|
           expect( docker ).to receive( :set_etc_hosts ).with( host, "127.0.0.1\tlocalhost localhost.localdomain\n192.0.2.1\tvm1\n192.0.2.1\tvm2\n192.0.2.1\tvm3\n" ).once
         end
-        docker.hack_docker_etc_hosts( hosts, options )
+        docker.hack_etc_hosts( hosts, options )
       end
 
       it 'should record the image and container for later' do


### PR DESCRIPTION
This PR adds support for adding hosts to `/etc/hosts` on all docker instances in the nodeset; we cannot use the `hack_etc_hosts` method here, since the `host['ip']` for the docker instance is set to `0.0.0.0` and the ssh port which has been exposed for the particular container, therefore using `hack_etc_hosts` results in a hosts file which contains `0.0.0.0` for all entries. Instead, I've created a `hack_docker_etc_hosts` method, and used the correct entry in the `docker_container` key to set the IPs.