### PR TITLE
(BKR-7) beaker's prebuild_steps corrupts PATH on windows+cygwin

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -453,7 +453,7 @@ module Beaker
     def construct_env host, opts
       env = additive_hash_merge(host[:host_env], opts[:host_env])
 
-      #Add PATH and RUBYLIB
+      #Add PATH
 
       #prepend any PATH already set for this host
 
@@ -463,14 +463,6 @@ module Beaker
       env['PATH'] = env['PATH'].compact.reject(&:empty?)
       #run the paths through echo to see if they have any subcommands that need processing
       env['PATH'].map! { |val| echo_on_host(host, val) }
-
-      #prepend any RUBYLIB already set for this host
-      env['RUBYLIB'] =  (%w(hieralibdir hierapuppetlibdir pluginlibpath puppetlibdir facterlibdir) << env['RUBYLIB']).compact.reject(&:empty?)
-      #get the RUBYLIB defaults
-      env['RUBYLIB'].map! { |val| host[val] }
-      env['RUBYLIB'] = env['RUBYLIB'].compact.reject(&:empty?)
-      #run the paths through echo to see if they have any subcommands that need processing
-      env['RUBYLIB'].map! { |val| echo_on_host(host, val) }
 
       env.each_key do |key|
         separator = host['pathseparator']
@@ -529,7 +521,6 @@ module Beaker
           host.exec(Command.new("chmod 0600 #{Pathname.new(host[:ssh_env_file]).dirname}"))
           host.exec(Command.new("touch #{host[:ssh_env_file]}"))
           #add the constructed env vars to this host
-          host.add_env_var('RUBYLIB', '$RUBYLIB')
           host.add_env_var('PATH', '$PATH')
         end
         #add the env var set to this test host

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -473,7 +473,11 @@ module Beaker
       env['RUBYLIB'].map! { |val| echo_on_host(host, val) }
 
       env.each_key do |key|
-        env[key] = env[key].join(host['pathseparator'])
+        separator = host['pathseparator']
+        if key == 'PATH' && host.is_cygwin?
+          separator = ':'
+        end
+        env[key] = env[key].join(separator)
       end
       env
     end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -514,7 +514,6 @@ describe Beaker do
       expect( Beaker::Command ).to receive( :new ).with( "chmod 0600 #{Pathname.new(host[:ssh_env_file]).dirname}" ).once
       expect( Beaker::Command ).to receive( :new ).with( "touch #{host[:ssh_env_file]}" ).once
       expect( Beaker::Command ).to receive( :new ).with( "cat #{host[:ssh_env_file]}" ).once
-      expect( host ).to receive( :add_env_var ).with( 'RUBYLIB', '$RUBYLIB' ).once
       expect( host ).to receive( :add_env_var ).with( 'PATH', '$PATH' ).once
       opts.each_pair do |key, value|
         expect( host ).to receive( :add_env_var ).with( key, value ).once


### PR DESCRIPTION
- use correct path separator for cygwin vs. correct separator for
  non-cygwin windows

- remove un-used RUBYLIB env var
  * no dependencies on this anywhere, might as well pull it out