### PR TITLE
(BKR-148) Stop vagrant from generating ssh key

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -23,6 +23,7 @@ module Beaker
       #generate the VagrantFile
       v_file = "Vagrant.configure(\"2\") do |c|\n"
       v_file << "  c.ssh.forward_agent = true\n" if options[:forward_ssh_agent] == true
+      v_file << "  c.ssh.insert_key = false\n"
       hosts.each do |host|
         host['ip'] ||= randip #use the existing ip, otherwise default to a random ip
         v_file << "  c.vm.define '#{host.name}' do |v|\n"

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -34,6 +34,7 @@ module Beaker
       vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
       expect( vagrantfile ).to be === <<-EOF
 Vagrant.configure("2") do |c|
+  c.ssh.insert_key = false
   c.vm.define 'vm1' do |v|
     v.vm.hostname = 'vm1'
     v.vm.box = 'vm1_of_my_box'
@@ -185,7 +186,7 @@ EOF
       allow( file ).to receive( :path ).and_return( '/path/sshconfig' )
       allow( file ).to receive( :rewind ).and_return( true )
 
-      expect( Tempfile ).to receive( :new ).with( "#{host.name}").and_return( file ) 
+      expect( Tempfile ).to receive( :new ).with( "#{host.name}").and_return( file )
       expect( file ).to receive( :write ).with("Host ip.address.for.#{name}\n    HostName 127.0.0.1\n    User root\n    Port 2222\n    UserKnownHostsFile /dev/null\n    StrictHostKeyChecking no\n    PasswordAuthentication no\n    IdentityFile /home/root/.vagrant.d/insecure_private_key\n    IdentitiesOnly yes")
 
       vagrant.set_ssh_config( host, 'root' )


### PR DESCRIPTION
Hashicorp added new behavior that generates a new SSH key
when generating a box, and will remove any existing "insecure"
key found on a box. See https://github.com/mitchellh/vagrant/pull/4707

This has the unfortunate side effect of breaking the automation
used in Beaker to setup SSH keys, since it relied on the default
"insecure" vagrant keys being used. This workaround disables
the new Vagrant behavior with the `ssh.insert_key = false` config option.