### PR TITLE
(BKR-60) failures caused by rubygems timeouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 gemspec


### PR DESCRIPTION
- add ability to set GEM_SOURCE to internal rubygems mirror