### PR TITLE
[BKR-181] docker hypervisor changes for centos/redhat images

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -508,7 +508,7 @@ module Beaker
           host.exec(Command.new("service ssh restart"))
         when /el-|centos|fedora|redhat|oracle|scientific|eos/
           host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
-          host.exec(Command.new("/sbin/service sshd restart"))
+          host.exec(Command.new("/sbin/service sshd restart")) unless host['hypervisor'] == 'docker'
         when /sles/
           host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
           host.exec(Command.new("rcsshd restart"))

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -135,7 +135,7 @@ module Beaker
       when /^el-/, /centos/, /fedora/, /redhat/, /eos/
         dockerfile += <<-EOF
           RUN yum clean all
-          RUN yum install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
+          RUN yum install -y sudo openssh-server openssh-clients tar #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
           RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
           RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
         EOF


### PR DESCRIPTION
Some minor changes to the centos/redhat docker images, so we can use them for testing. 

- by default we need to install the tar package on centos/redhat images, so we can use commands like 'puppet module install MODULENAME'

- Also we shouldn't restart the ssh service as defined in host_prebuilt_steps.rb if the hypervisor is docker and the image is centos/redhat based, because this images don't have the necessary packages to support that. 