### PR TITLE
(PE-8260) add answer for new NC migrate question

### DIFF
--- a/lib/beaker/answers/version38.rb
+++ b/lib/beaker/answers/version38.rb
@@ -1,0 +1,24 @@
+require 'beaker/answers/version34'
+
+module Beaker
+  # This class provides answer file information for PE version 4.0
+  #
+  # @api private
+  class Version38 < Version34
+    def generate_answers
+      masterless = @options[:masterless]
+      return super if masterless
+
+      the_answers = super
+
+      # add new answers
+      exit_for_nc_migrate = answer_for(@options, :q_exit_for_nc_migrate, 'n')
+
+      the_answers.map do |key, value|
+        the_answers[key][:q_exit_for_nc_migrate] = exit_for_nc_migrate
+      end
+
+      return the_answers
+    end
+  end
+end

--- a/lib/beaker/answers/version40.rb
+++ b/lib/beaker/answers/version40.rb
@@ -1,10 +1,10 @@
-require 'beaker/answers/version34'
+require 'beaker/answers/version38'
 
 module Beaker
   # This class provides answer file information for PE version 4.0
   #
   # @api private
-  class Version40 < Version34
+  class Version40 < Version38
     def generate_answers
       masterless = @options[:masterless]
       return super if masterless


### PR DESCRIPTION
This commit adds a 38-specific answer file to beaker, which introduces an
answer for whether to stop the upgrade and proceed to do the NC database
migration. It defaults to 'n' to enable upgrades to continue.

Signed-off-by: Moses Mendoza <moses@puppetlabs.com>