### PR TITLE
(BKR-155) Add simple tagging to vmpooler hosts

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -124,7 +124,7 @@ module Beaker
           hostname = parsed_response[h['template']]['hostname']
         end
 
-        uri = URI.parse(@options['pooling_api'] + '/vm/' + hostname)
+        uri = URI.parse(@options[:pooling_api] + '/vm/' + hostname)
 
         http = Net::HTTP.new(uri.host, uri.port)
         request = Net::HTTP::Put.new(uri.request_uri)

--- a/spec/mocks.rb
+++ b/spec/mocks.rb
@@ -44,6 +44,16 @@ module MockNet
       end
     end
 
+    class Put
+      def initialize uri
+        @uri = uri
+      end
+
+      def body= *args
+        hash
+      end
+    end
+
     class Delete
       def initialize uri
         @uri = uri


### PR DESCRIPTION
Manually testing this against vmpooler-dev (internal) I end up with a VM tagged as such:

```
{
  "ok": true,
  "d6nz94h38x79lrn": {
    "template": "debian-7-x86_64",
    "lifetime": 2,
    "running": 0.0,
    "tags": {
      "jenkins_build_url": "",
      "department": "unknown",
      "project": "Beaker",
      "created_by": "sschneider"
    },
    "domain": "delivery.puppetlabs.net"
  }
}
```