### PR TITLE
(MAINT) Show error from docker

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -16,7 +16,7 @@ module Beaker
       begin
         ::Docker.validate_version!
       rescue Excon::Errors::SocketError => e
-        raise "Docker instance not found.\nif you are on OSX, you might not have Boot2Docker setup correctly\nCheck your DOCKER_HOST variable has been set"
+        raise "Docker instance not connectable.\nError was: #{e}\nIf you are on OSX, you might not have Boot2Docker setup correctly\nCheck your DOCKER_HOST variable has been set"
       end
 
       # Pass on all the logging from docker-api to the beaker logger instance

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -78,7 +78,8 @@ module Beaker
         allow( ::Docker ).to receive(:validate_version!).and_raise(Excon::Errors::SocketError.new( StandardError.new('oops') ))
       end
       it 'should fail when docker not present' do
-        expect { docker }.to raise_error(RuntimeError, /Docker instance not found/)
+        expect { docker }.to raise_error(RuntimeError, /Docker instance not connectable./)
+        expect { docker }.to raise_error(RuntimeError, /Error was: oops/)
       end
     end
 


### PR DESCRIPTION
As @richardc pointed out, the commit 25909d02608f9ec6fb69be972750d39ed08f2c41 actually removes being able to see the error raised.

This fixes that, so you can actually see what the issue is.