### PR TITLE
(BKR-161) Beaker tagging improvements

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -111,6 +111,7 @@ module Beaker
       @logger.notify 'Tagging vmpooler VMs'
 
       tags = {
+        'beaker_version' => Beaker::Version::STRING,
         'jenkins_build_url' => @options[:jenkins_build_url],
         'department' => @options[:department],
         'project' => @options[:project],

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -11,9 +11,12 @@ module Beaker
       # us to define multiple environment variables for the same
       # configuration value. They are checked in the order they are arrayed
       # so that preferred and "fallback" values work as expected.
+      #
+      # 'JOB_NAME' and 'BUILD_URL' envs are supplied by Jenkins
+      # https://wiki.jenkins-ci.org/display/JENKINS/Building+a+software+project
       ENVIRONMENT_SPEC = {
         :home                 => 'HOME',
-        :project              => ['BEAKER_PROJECT', 'BEAKER_project'],
+        :project              => ['BEAKER_PROJECT', 'BEAKER_project', 'JOB_NAME'],
         :department           => ['BEAKER_DEPARTMENT', 'BEAKER_department'],
         :jenkins_build_url    => ['BEAKER_BUILD_URL', 'BUILD_URL'],
         :created_by           => ['BEAKER_CREATED_BY'],


### PR DESCRIPTION
- Use JOB_NAME for 'project' tag default if it exists
- Set 'beaker_version' tag in vmpooler hypervisor