### PR TITLE
Fix ezbake version string extraction

### DIFF
--- a/lib/beaker/dsl/install_utils/ezbake_utils.rb
+++ b/lib/beaker/dsl/install_utils/ezbake_utils.rb
@@ -169,7 +169,7 @@ module Beaker
 
             load 'ezbake.rb'
             ezbake = EZBake::Config
-            ezbake[:package_version] = `echo -n $(rake pl:print_build_param[ref] | tail -n 1)`
+            ezbake[:package_version] = `printf $(rake pl:print_build_param[ref] | tail -n 1)`
             EZBakeUtils.config = ezbake
           end
         end


### PR DESCRIPTION
This previously used 'echo -n', which is not a universally available
feature of echo. When running with an OS X host, this caused the string
to look like "-n PACKAGE-1.2.3\n", which caused cascading failures in
the code that uses this data. printf is a more portable replacement.