### PR TITLE
(BKR-113) Add FreeBSD host class

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -39,6 +39,8 @@ module Beaker
         Aix::Host.new name, options
       when /osx/
         Mac::Host.new name, options
+      when /freebsd/
+        FreeBSD::Host.new name, options
       else
         Unix::Host.new name, options
       end
@@ -595,7 +597,14 @@ module Beaker
 
   end
 
-  [ 'windows', 'pswindows', 'unix', 'aix', 'mac' ].each do |lib|
+  [
+    'windows',
+    'pswindows',
+     'unix',
+     'aix',
+     'mac',
+     'freebsd',
+  ].each do |lib|
     require "beaker/host/#{lib}"
   end
 end

--- a/lib/beaker/host/freebsd.rb
+++ b/lib/beaker/host/freebsd.rb
@@ -1,0 +1,31 @@
+[ 'host', 'command_factory' ].each do |lib|
+  require "beaker/#{lib}"
+end
+
+module FreeBSD
+  class Host < Unix::Host
+
+    def self.foss_defaults
+      h = Beaker::Options::OptionsHash.new
+      h.merge({
+        'user'              => 'root',
+        'group'             => 'puppet',
+        'puppetserver-confdir' => '/etc/puppetserver/conf.d',
+        'puppetservice'     => 'puppetmaster',
+        'puppetpath'        => '/usr/local/etc/puppet/modules',
+        'puppetvardir'      => '/var/lib/puppet',
+        'puppetbin'         => '/usr/bin/puppet',
+        'puppetbindir'      => '/usr/bin',
+        'hieralibdir'       => '/opt/puppet-git-repos/hiera/lib',
+        'hierapuppetlibdir' => '/opt/puppet-git-repos/hiera-puppet/lib',
+        'hierabindir'       => '/opt/puppet-git-repos/hiera/bin',
+        'hieradatadir'      => '/usr/local/etc/puppet/modules/hieradata',
+        'hieraconf'         => '/usr/local/etc/puppet/modules/hiera.yaml',
+        'distmoduledir'     => '/usr/local/etc/puppet/modules',
+        'sitemoduledir'     => '/usr/share/puppet/modules',
+        'pathseparator'     => ':',
+        })
+    end
+  end
+
+end

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus)\-.+\-.+$/
+    PLATFORMS = /^(freebsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus)\-.+\-.+$/
 
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =


### PR DESCRIPTION
Breaking up #615 into easier to merge chunks :+1: 

* Main change is location of Puppet data under `/usr/local/etc` rather than `/etc/`