### PR TITLE
(BKR-113) Adds FreeBSD Vagrantfile logic

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -46,6 +46,25 @@ module Beaker
           v_file << "    v.vm.synced_folder '.', '/vagrant', :nfs => true\n"
         end
 
+        if /freebsd/i.match(host['platform'])
+          v_file << "    v.ssh.shell = 'sh'\n"
+          v_file << "    v.vm.guest = :freebsd\n"
+
+          # FreeBSD NFS has a character restriction of 88 characters
+          # So you can enable it but if your module has a long name it probably won't work...
+          # So to keep things simple let's rsync by default!
+          #
+          # Further reading if interested:
+          # http://www.secnetix.de/olli/FreeBSD/mnamelen.hawk
+          # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=167105
+          #
+          if host['vagrant_freebsd_nfs'].nil?
+            v_file << "    v.vm.synced_folder '.', '/vagrant', type: 'rsync'\n"
+          else
+            v_file << "    v.vm.synced_folder '.', '/vagrant', :nfs => true\n"
+          end
+        end
+
         v_file << self.class.provider_vfile_section(host, options)
 
         v_file << "  end\n"


### PR DESCRIPTION
With Vagrant we use rsync for folder sync, as nfs has a character restriction of  88 characters. So depending on the module name and where it's being stored, it can error out with:

```
==> default: Mounting NFS shared folders...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mount -t nfs '10.0.1.1:/Users/petersouter/projects/reallylongpathnameover88characterssothatmountfswillfail12345678910111213141516' '/vagrant'

Stdout from the command:

Stderr from the command:

mount_nfs: 10.0.1.1:/Users/petersouter/projects/reallylongpathnameover88characterssothatmountfswillfail12345678910111213141516: File name too long
```

Further reading if interested:
http://www.secnetix.de/olli/FreeBSD/mnamelen.hawk
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=167105