### PR TITLE
(maint) Allow installing 32-bit Puppet-Agent on Windows

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -272,7 +272,8 @@ module Beaker
               host['dist'] = "puppet-enterprise-#{version}-#{host['platform']}"
             elsif host['platform'] =~ /windows/
               version = host[:pe_ver] || opts['pe_ver_win']
-              should_install_64bit = !(version_is_less(version, '3.4')) && host.is_x86_64? && !host['install_32'] && !opts['install_32']
+              is_config_32 = true == (host['ruby_arch'] == 'x86') || host['install_32'] || opts['install_32']
+              should_install_64bit = !(version_is_less(version, '3.4')) && host.is_x86_64? && !is_config_32
               #only install 64bit builds if
               # - we are on pe version 3.4+
               # - we do not have install_32 set on host

--- a/lib/beaker/dsl/install_utils/puppet_utils.rb
+++ b/lib/beaker/dsl/install_utils/puppet_utils.rb
@@ -347,7 +347,8 @@ module Beaker
           # - we do not have install_32 set on host
           # - we do not have install_32 set globally
           version = opts[:version]
-          if !(version_is_less(version, '3.7')) and host.is_x86_64? and not host['install_32'] and not opts['install_32']
+          is_config_32 = true == (host['ruby_arch'] == 'x86') || host['install_32'] || opts['install_32']
+          if !(version_is_less(version, '3.7')) && host.is_x86_64? && !is_config_32
             host['dist'] = "puppet-#{version}-x64"
           else
             host['dist'] = "puppet-#{version}"
@@ -693,7 +694,8 @@ module Beaker
           when /^windows$/
             release_path << 'windows'
             onhost_copy_base = '`cygpath -smF 35`/'
-            should_install_64bit = host.is_x86_64? && !host['install_32'] && !opts['install_32']
+            is_config_32 = true == (host['ruby_arch'] == 'x86') || host['install_32'] || opts['install_32']
+            should_install_64bit = host.is_x86_64? && !is_config_32
             # only install 64bit builds if
             # - we do not have install_32 set on host
             # - we do not have install_32 set globally

--- a/lib/beaker/dsl/install_utils/puppet_utils.rb
+++ b/lib/beaker/dsl/install_utils/puppet_utils.rb
@@ -693,7 +693,11 @@ module Beaker
           when /^windows$/
             release_path << 'windows'
             onhost_copy_base = '`cygpath -smF 35`/'
-            arch_suffix = arch =~ /64/ ? '64' : '86'
+            should_install_64bit = host.is_x86_64? && !host['install_32'] && !opts['install_32']
+            # only install 64bit builds if
+            # - we do not have install_32 set on host
+            # - we do not have install_32 set globally
+            arch_suffix = should_install_64bit ? '64' : '86'
             release_file = "puppet-agent-x#{arch_suffix}.msi"
           else
             raise "No repository installation step for #{variant} yet..."


### PR DESCRIPTION
 - Previously, install_utils was modified to be able to install PE
   based on a configuration switch called `install_32` in
   6f8deb7dbc7bc75b8624df754c261f4d2b58b999

   This allows a 64-bit Windows OS to ask to install a 32-bit Ruby /
   Puppet version.  This is important given 64-bit support wasn't
   added to Puppet or PE until 3.7.

   When installing the puppet-agent through install_puppetagent_dev_repo
   helper, allow for selecting the build in a similar fashion.