### PR TITLE
(BKR-165) hack_etc_hosts method doesn't work for Docker provider

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -313,15 +313,18 @@ module Beaker
       end
     end
 
-    #Update /etc/hosts to make it possible for each provided host to reach each other host by name.
-    #Assumes that each provided host has host[:ip] set.
+    # Update /etc/hosts to make it possible for each provided host to reach each other host by name.
+    # Assumes that each provided host has host[:ip] set; in the instance where a provider sets
+    # host['ip'] to an address which facilitates access to the host externally, but the actual host
+    # addresses differ from this, we check first for the presence of a host['vm_ip'] key first,
+    # and use that if present.
     # @param [Host, Array<Host>] hosts An array of hosts to act upon
     # @param [Hash{Symbol=>String}] opts Options to alter execution.
     # @option opts [Beaker::Logger] :logger A {Beaker::Logger} object
     def hack_etc_hosts hosts, opts
       etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
       hosts.each do |host|
-        etc_hosts += "#{host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
+        etc_hosts += "#{host['vm_ip'] || host['ip'].to_s}\t#{host[:vmhostname] || host.name}\n"
       end
       hosts.each do |host|
         set_etc_hosts(host, etc_hosts)

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -64,7 +64,12 @@ module Beaker
         @logger.debug("node available as  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@#{ip} -p #{port}")
         host['docker_container'] = container
         host['docker_image'] = image
+        host['vm_ip'] = container.json["NetworkSettings"]["IPAddress"].to_s
+
       end
+
+      hack_etc_hosts @hosts, @options
+
     end
 
     def cleanup

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -199,6 +199,15 @@ module Beaker
 
       end
 
+      it "should generate a new /etc/hosts file referencing each host" do
+        ENV['DOCKER_HOST'] = nil
+        docker.provision
+        hosts.each do |host|
+          expect( docker ).to receive( :set_etc_hosts ).with( host, "127.0.0.1\tlocalhost localhost.localdomain\n192.0.2.1\tvm1\n192.0.2.1\tvm2\n192.0.2.1\tvm3\n" ).once
+        end
+        docker.hack_etc_hosts( hosts, options )
+      end
+
       it 'should record the image and container for later' do
         docker.provision
 


### PR DESCRIPTION
This replaces #742 - with a new branch tied to an issue in JIRA

This PR adds support for adding hosts to `/etc/hosts` on all docker instances in the nodeset; using the hack_etc_hosts method without this change results in a hosts file which contains `0.0.0.0` for all entries, since the `host['ip']` for the docker instance is set to `0.0.0.0` and the ssh port which has been exposed for the particular container. Instead, we set a new key, `host['vm_ip']` in the provision method, and set the entry in the host file to this if it's present.