### PR TITLE
(BKR-100) merge beaker-rspec into beaker

### DIFF
--- a/acceptance/rspec/example_spec.rb
+++ b/acceptance/rspec/example_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative 'spec_helper'
 
 describe "ignore" do
 
@@ -6,10 +6,6 @@ describe "ignore" do
     hosts.each do |host|
       on host, 'echo hello'
     end
-  end
-
-  example "access options hash" do
-    install_pe
   end
 
   example "access the logger" do

--- a/acceptance/rspec/example_spec.rb
+++ b/acceptance/rspec/example_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe "ignore" do
+
+  example "ignore" do
+    hosts.each do |host|
+      on host, 'echo hello'
+    end
+  end
+
+  example "access options hash" do
+    install_pe
+  end
+
+  example "access the logger" do
+     logger.debug("hi, i'm a debug message")
+     logger.notify("hi, I'm a notify message")
+  end
+
+  context "has serverspec support" do
+    hosts.each do |node|
+      sshd = case node['platform']
+             when /windows|el-|redhat|centos|debian/
+               'sshd'
+             else
+               'ssh'
+             end
+      describe service(sshd), :node => node do
+        it { should be_running }
+      end
+
+      usr = case node['platform']
+            when /windows/
+              'Administrator'
+            else
+              'root'
+            end
+      describe user(usr), :node => node do
+         it { should exist }
+      end
+    end
+  end
+
+  context "serverspec: can access default node" do
+    usr = case default['platform']
+          when /windows/
+            'Administrator'
+          else
+            'root'
+          end
+    describe user(usr) do
+       it { should exist }
+    end
+  end
+
+  context "serverspec: can match multiline file to multiline contents" do
+    contents = "four = five\n[one]\ntwo = three"
+    create_remote_file(default, "file_with_contents.txt", contents)
+    describe file("file_with_contents.txt") do
+      it { should be_file }
+      it { should contain(contents) }
+    end
+  end
+end

--- a/acceptance/rspec/spec_helper.rb
+++ b/acceptance/rspec/spec_helper.rb
@@ -1,0 +1,3 @@
+ENV['RS_SETFILE'] ||= 'sample.cfg'
+
+require "beaker-rspec"

--- a/acceptance/rspec/spec_helper.rb
+++ b/acceptance/rspec/spec_helper.rb
@@ -1,3 +1,3 @@
-ENV['RS_SETFILE'] ||= 'sample.cfg'
+ENV['RS_SETFILE'] ||= 'acceptance/fixtures/module/spec/acceptance/nodesets/default.yml'
 
-require "beaker-rspec"
+require "beaker/rspec"

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -50,4 +50,8 @@ Gem::Specification.new do |s|
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'
+
+  # Beaker-rspec dependencies
+  s.add_runtime_dependency 'serverspec', '~> 2'
+  s.add_runtime_dependency 'specinfra', '~> 2'
 end

--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -26,7 +26,7 @@ module Beaker
       @machines = {}
       @hypervisors = nil
 
-      @options[:log_prefix]     = File.basename(@options[:hosts_file], '.yml') unless @options[:log_prefix]
+      @options[:log_prefix]     = File.basename(@options[:hosts_file] ? @options[:hosts_file] : '', '.yml') unless @options[:log_prefix]
       @options[:timestamp]      = Time.now unless @options.has_key?(:timestamp)
       @options[:xml_dated_dir]  = Beaker::Logger.generate_dated_log_folder(@options[:xml_dir], @options[:log_prefix], @options[:timestamp])
       @options[:log_dated_dir]  = Beaker::Logger.generate_dated_log_folder(@options[:log_dir], @options[:log_prefix], @options[:timestamp])

--- a/lib/beaker/rspec.rb
+++ b/lib/beaker/rspec.rb
@@ -1,0 +1,7 @@
+module BeakerRSpec
+  require 'beaker'
+
+  require 'beaker-rspec/beaker_shim'
+  require 'beaker-rspec/spec_helper'
+
+end

--- a/lib/beaker/rspec.rb
+++ b/lib/beaker/rspec.rb
@@ -1,7 +1,7 @@
 module BeakerRSpec
   require 'beaker'
 
-  require 'beaker-rspec/beaker_shim'
-  require 'beaker-rspec/spec_helper'
+  require 'beaker/rspec/beaker_shim'
+  require 'beaker/rspec/spec_helper'
 
 end

--- a/lib/beaker/rspec.rb
+++ b/lib/beaker/rspec.rb
@@ -1,7 +1,8 @@
-module BeakerRSpec
-  require 'beaker'
+module Beaker
+  module RSpec
+    require 'beaker'
 
-  require 'beaker/rspec/beaker_shim'
-  require 'beaker/rspec/spec_helper'
-
+    require 'beaker/rspec/beaker_shim'
+    require 'beaker/rspec/spec_helper'
+  end
 end

--- a/lib/beaker/rspec/beaker_shim.rb
+++ b/lib/beaker/rspec/beaker_shim.rb
@@ -1,77 +1,79 @@
 require 'beaker'
 
-module BeakerRSpec
-  # BeakerShim Module
-  #
-  # This module provides the connection between rspec and the Beaker DSL.
-  # Additional wrappers are provided around commonly executed sets of Beaker
-  # commands.
-  module BeakerShim
-    include Beaker::DSL
-
-    # Accessor for logger
-    # @return Beaker::Logger object
-    def logger
-      RSpec.configuration.logger
-    end
-
-    # Accessor for options hash
-    # @return Hash options
-    def options
-      RSpec.configuration.options
-    end
-
-    # Provision the hosts to run tests on.
-    # Assumes #setup has already been called.
+module Beaker
+  module RSpec
+    # BeakerShim Module
     #
-    def provision
-      @network_manager = Beaker::NetworkManager.new(options, @logger)
-      RSpec.configuration.hosts = @network_manager.provision
-    end
+    # This module provides the connection between rspec and the Beaker DSL.
+    # Additional wrappers are provided around commonly executed sets of Beaker
+    # commands.
+    module BeakerShim
+      include Beaker::DSL
 
-    # Validate that the SUTs are up and correctly configured.  Checks that required
-    # packages are installed and if they are missing attempt installation.
-    # Assumes #setup and #provision has already been called.
-    def validate
-      @network_manager.validate
-    end
+      # Accessor for logger
+      # @return Beaker::Logger object
+      def logger
+        ::RSpec.configuration.logger
+      end
 
-    # Run configuration steps to have hosts ready to test on (such as ensuring that 
-    # hosts are correctly time synched, adding keys, etc).
-    # Assumes #setup, #provision and #validate have already been called.
-    def configure
-      @network_manager.configure
-    end
+      # Accessor for options hash
+      # @return Hash options
+      def options
+        ::RSpec.configuration.options
+      end
 
-    # Setup the testing environment
-    # @param [Array<String>] args The argument array of options for configuring Beaker
-    # See 'beaker --help' for full list of supported command line options
-    def setup(args = [])
-      options_parser = Beaker::Options::Parser.new
-      options = options_parser.parse_args(args)
-      options[:debug] = true
-      RSpec.configuration.logger = Beaker::Logger.new(options)
-      options[:logger] = logger
-      RSpec.configuration.hosts = []
-      RSpec.configuration.options = options
-    end
+      # Provision the hosts to run tests on.
+      # Assumes #setup has already been called.
+      #
+      def provision
+        @network_manager = Beaker::NetworkManager.new(options, @logger)
+        ::RSpec.configuration.hosts = @network_manager.provision
+      end
 
-    # Accessor for hosts object
-    # @return [Array<Beaker::Host>]
-    def hosts
-      RSpec.configuration.hosts
-    end
+      # Validate that the SUTs are up and correctly configured.  Checks that required
+      # packages are installed and if they are missing attempt installation.
+      # Assumes #setup and #provision has already been called.
+      def validate
+        @network_manager.validate
+      end
 
-    # Accessor for default node
-    # @return [Beaker::Host]
-    def default_node
-      RSpec.configuration.default_node ||= find_only_one :default
-    end
+      # Run configuration steps to have hosts ready to test on (such as ensuring that 
+      # hosts are correctly time synched, adding keys, etc).
+      # Assumes #setup, #provision and #validate have already been called.
+      def configure
+        @network_manager.configure
+      end
 
-    # Cleanup the testing framework, shut down test boxen and tidy up
-    def cleanup
-      @network_manager.cleanup
-    end
+      # Setup the testing environment
+      # @param [Array<String>] args The argument array of options for configuring Beaker
+      # See 'beaker --help' for full list of supported command line options
+      def setup(args = [])
+        options_parser = Beaker::Options::Parser.new
+        options = options_parser.parse_args(args)
+        options[:debug] = true
+        ::RSpec.configuration.logger = Beaker::Logger.new(options)
+        options[:logger] = logger
+        ::RSpec.configuration.hosts = []
+        ::RSpec.configuration.options = options
+      end
 
+      # Accessor for hosts object
+      # @return [Array<Beaker::Host>]
+      def hosts
+        ::RSpec.configuration.hosts
+      end
+
+      # Accessor for default node
+      # @return [Beaker::Host]
+      def default_node
+        ::RSpec.configuration.default_node ||= find_only_one :default
+      end
+
+      # Cleanup the testing framework, shut down test boxen and tidy up
+      def cleanup
+        @network_manager.cleanup
+      end
+
+    end
   end
 end

--- a/lib/beaker/rspec/beaker_shim.rb
+++ b/lib/beaker/rspec/beaker_shim.rb
@@ -1,0 +1,77 @@
+require 'beaker'
+
+module BeakerRSpec
+  # BeakerShim Module
+  #
+  # This module provides the connection between rspec and the Beaker DSL.
+  # Additional wrappers are provided around commonly executed sets of Beaker
+  # commands.
+  module BeakerShim
+    include Beaker::DSL
+
+    # Accessor for logger
+    # @return Beaker::Logger object
+    def logger
+      RSpec.configuration.logger
+    end
+
+    # Accessor for options hash
+    # @return Hash options
+    def options
+      RSpec.configuration.options
+    end
+
+    # Provision the hosts to run tests on.
+    # Assumes #setup has already been called.
+    #
+    def provision
+      @network_manager = Beaker::NetworkManager.new(options, @logger)
+      RSpec.configuration.hosts = @network_manager.provision
+    end
+
+    # Validate that the SUTs are up and correctly configured.  Checks that required
+    # packages are installed and if they are missing attempt installation.
+    # Assumes #setup and #provision has already been called.
+    def validate
+      @network_manager.validate
+    end
+
+    # Run configuration steps to have hosts ready to test on (such as ensuring that 
+    # hosts are correctly time synched, adding keys, etc).
+    # Assumes #setup, #provision and #validate have already been called.
+    def configure
+      @network_manager.configure
+    end
+
+    # Setup the testing environment
+    # @param [Array<String>] args The argument array of options for configuring Beaker
+    # See 'beaker --help' for full list of supported command line options
+    def setup(args = [])
+      options_parser = Beaker::Options::Parser.new
+      options = options_parser.parse_args(args)
+      options[:debug] = true
+      RSpec.configuration.logger = Beaker::Logger.new(options)
+      options[:logger] = logger
+      RSpec.configuration.hosts = []
+      RSpec.configuration.options = options
+    end
+
+    # Accessor for hosts object
+    # @return [Array<Beaker::Host>]
+    def hosts
+      RSpec.configuration.hosts
+    end
+
+    # Accessor for default node
+    # @return [Beaker::Host]
+    def default_node
+      RSpec.configuration.default_node ||= find_only_one :default
+    end
+
+    # Cleanup the testing framework, shut down test boxen and tidy up
+    def cleanup
+      @network_manager.cleanup
+    end
+
+  end
+end

--- a/lib/beaker/rspec/helpers/serverspec.rb
+++ b/lib/beaker/rspec/helpers/serverspec.rb
@@ -1,0 +1,288 @@
+require 'serverspec'
+require 'specinfra'
+require 'specinfra/backend/powershell/script_helper'
+
+# Set specinfra backend to use our custom backend
+set :backend, 'BeakerDispatch'
+
+module Specinfra
+
+  # Accessor for current example
+  def cur_example
+    Specinfra.backend.example
+  end
+
+  def get_working_node
+    example = cur_example
+    if example and example.metadata[:node]
+      node = example.metadata[:node]
+    else
+      node = default_node
+    end
+    node
+  end
+
+  # The cygwin backend
+  def cygwin_backend
+    @cygwin_backend ||= Specinfra::Backend::BeakerCygwin.instance
+  end
+
+  # Backend for everything non-cygwin
+  def exec_backend
+    @exec_backend ||= Specinfra::Backend::BeakerExec.instance
+  end
+
+end
+
+
+# Override existing specinfra configuration to avoid conflicts
+# with beaker's shell, stdout, stderr defines
+module Specinfra
+  module Configuration
+    class << self
+      VALID_OPTIONS_KEYS = [
+        :backend,
+        :env,
+        :path,
+        :pre_command,
+        :sudo_path,
+        :disable_sudo,
+        :sudo_options,
+        :docker_image,
+        :docker_url,
+        :lxc,
+        :request_pty,
+        :ssh_options,
+        :dockerfile_finalizer,
+      ].freeze
+    end
+
+  end
+end
+
+module Specinfra::Helper::Os
+  private
+
+  # Override detect_os to look at the node platform, short circuit discoverability
+  # when we know that we have a windows node
+  def detect_os
+    return Specinfra.configuration.os if Specinfra.configuration.os
+    backend = Specinfra.backend
+    node = get_working_node
+    if node['platform'] =~ /windows/
+      return {:family => 'windows'}
+    end
+    Specinfra::Helper::DetectOs.subclasses.each do |c|
+      res = c.detect
+      if res
+        res[:arch] ||= Specinfra.backend.run_command('uname -m').stdout.strip
+        return res
+      end
+    end
+  end
+end
+
+class Specinfra::CommandFactory
+  class << self
+    # Force creation of a windows command
+    def get_windows_cmd(meth, *args)
+
+      action, resource_type, subaction = breakdown(meth)
+      method =  action
+      method += "_#{subaction}" if subaction
+
+      common_class = Specinfra::Command
+      base_class = common_class.const_get('Base')
+      os_class = common_class.const_get('Windows')
+      version_class = os_class.const_get('Base')
+      command_class = version_class.const_get(resource_type.to_camel_case)
+
+      command_class = command_class.create
+      if command_class.respond_to?(method)
+        command_class.send(method, *args)
+      else
+        raise NotImplementedError.new("#{method} is not implemented in #{command_class}")
+      end
+    end
+
+  end
+end
+
+module Specinfra
+  # Rewrite the runner to use the appropriate backend based upon platform information
+  class Runner
+
+    def self.method_missing(meth, *args)
+      backend = Specinfra.backend
+      node = get_working_node
+      if node['platform'] !~ /windows/
+        processor = Specinfra::Processor
+        if processor.respond_to?(meth)
+          processor.send(meth, *args)
+        elsif backend.respond_to?(meth)
+          backend.send(meth, *args)
+        else
+          run(meth, *args)
+        end
+      else
+        if backend.respond_to?(meth)
+          backend.send(meth, *args)
+        else
+          run(meth, *args)
+        end
+      end
+    end
+
+    private
+
+    def self.run(meth, *args)
+      backend = Specinfra.backend
+      cmd = Specinfra.command.get(meth, *args)
+      backend = Specinfra.backend
+      ret = backend.run_command(cmd)
+      if meth.to_s =~ /^check/
+        ret.success?
+      else
+        ret
+      end
+    end
+  end
+end
+
+module Specinfra::Backend::PowerShell
+  class Command
+    # Do a better job at escaping regexes, handle both LF and CRLF (YAY!)
+    def convert_regexp(target)
+      case target
+      when Regexp
+        target.source
+      else
+        Regexp.escape(target.to_s.gsub '/', '\/').gsub('\n', '(\r\n|\n)')
+      end
+    end
+  end
+end
+
+module Specinfra::Backend
+  class BeakerBase < Specinfra::Backend::Base
+    # Example accessor
+    def example
+      @example
+    end
+
+    # Execute the provided ssh command
+    # @param [String] command The command to be executed
+    # @return [Hash] Returns a hash containing :exit_status, :stdout and :stderr
+    def ssh_exec!(node, command)
+      r = on node, command, { :acceptable_exit_codes => (0..127) }
+      {
+        :exit_status => r.exit_code,
+        :stdout      => r.stdout,
+        :stderr      => r.stderr
+      }
+    end
+
+  end
+end
+
+# Used as a container for the two backends, dispatches as windows/nix depending on node platform
+module Specinfra::Backend
+  class BeakerDispatch < BeakerBase
+
+    def dispatch_method(meth, *args)
+      if get_working_node['platform'] =~ /windows/
+        cygwin_backend.send(meth, *args)
+      else
+        exec_backend.send(meth, *args)
+      end
+    end
+
+    def run_command(cmd, opts={})
+      dispatch_method('run_command', cmd, opts)
+    end
+
+    def build_command(cmd)
+      dispatch_method('build_command', cmd)
+    end
+
+    def add_pre_command(cmd)
+      dispatch_method('add_pre_command', cmd)
+    end
+  end
+end
+
+# Backend for running serverspec commands on windows test nodes
+module Specinfra::Backend
+  class BeakerCygwin < BeakerBase
+    include Specinfra::Backend::PowerShell::ScriptHelper
+
+    # Run a windows style command using serverspec.  Defaults to running on the 'default_node'
+    # test node, otherwise uses the node specified in @example.metadata[:node]
+    # @param [String] cmd The serverspec command to executed
+    # @param [Hash] opt No currently supported options
+    # @return [Hash] Returns a hash containing :exit_status, :stdout and :stderr
+    def run_command(cmd, opt = {})
+      node = get_working_node
+      script = create_script(cmd)
+      on node, "rm -f script.ps1"
+      create_remote_file(node, 'script.ps1', script)
+      # cygwin support /dev/null, if running from winrm would use < NULL
+      ret = ssh_exec!(node, "powershell.exe -File script.ps1 < /dev/null")
+
+      if @example
+        @example.metadata[:command] = script
+        @example.metadata[:stdout]  = ret[:stdout]
+      end
+
+      CommandResult.new ret
+    end
+  end
+end
+
+# Backend for running serverspec commands on non-windows test nodes
+module Specinfra::Backend
+  class BeakerExec < BeakerBase
+
+    # Run a unix style command using serverspec.  Defaults to running on the 'default_node'
+    # test node, otherwise uses the node specified in @example.metadata[:node]
+    # @param [String] cmd The serverspec command to executed
+    # @param [Hash] opt No currently supported options
+    # @return [Hash] Returns a hash containing :exit_status, :stdout and :stderr
+    def run_command(cmd, opt = {})
+      node = get_working_node
+      cmd = build_command(cmd)
+      cmd = add_pre_command(cmd)
+      ret = ssh_exec!(node, cmd)
+
+      if @example
+        @example.metadata[:command] = cmd
+        @example.metadata[:stdout]  = ret[:stdout]
+      end
+
+      CommandResult.new ret
+    end
+
+    def build_command(cmd)
+      useshell = '/bin/sh'
+      cmd = cmd.shelljoin if cmd.is_a?(Array)
+      cmd = "#{useshell.shellescape} -c #{cmd.shellescape}"
+
+      path = Specinfra.configuration.path
+      if path
+        cmd = %Q{env PATH="#{path}" #{cmd}}
+      end
+
+      cmd
+    end
+
+    def add_pre_command(cmd)
+      if Specinfra.configuration.pre_command
+        pre_cmd = build_command(Specinfra.configuration.pre_command)
+        "#{pre_cmd} && #{cmd}"
+      else
+        cmd
+      end
+    end
+
+  end
+end

--- a/lib/beaker/rspec/spec_helper.rb
+++ b/lib/beaker/rspec/spec_helper.rb
@@ -1,8 +1,8 @@
 require 'beaker/rspec/beaker_shim'
 require "beaker/rspec/helpers/serverspec"
-include BeakerRSpec::BeakerShim
+include Beaker::RSpec::BeakerShim
 
-RSpec.configure do |c|
+::RSpec.configure do |c|
   # Enable color
   c.tty = true
 
@@ -49,7 +49,7 @@ RSpec.configure do |c|
     when 'no'
       # Don't cleanup
     when 'onpass'
-      c.cleanup if RSpec.world.filtered_examples.values.flatten.none?(&:exception)
+      c.cleanup if ::RSpec.world.filtered_examples.values.flatten.none?(&:exception)
     else
       c.cleanup
     end

--- a/lib/beaker/rspec/spec_helper.rb
+++ b/lib/beaker/rspec/spec_helper.rb
@@ -1,0 +1,57 @@
+require 'beaker-rspec/beaker_shim'
+require "beaker-rspec/helpers/serverspec"
+include BeakerRSpec::BeakerShim
+
+RSpec.configure do |c|
+  # Enable color
+  c.tty = true
+
+  # Define persistant hosts setting
+  c.add_setting :hosts, :default => []
+  # Define persistant options setting
+  c.add_setting :options, :default => {}
+  # Define persistant logger object
+  c.add_setting :logger, :default => nil
+  # Define persistant default node
+  c.add_setting :default_node, :default => nil
+
+  #default option values
+  defaults = {
+    :nodeset     => 'default',
+  }
+  #read env vars
+  env_vars = {
+    :nodeset     => ENV['BEAKER_set'] || ENV['RS_SET'],
+    :nodesetfile => ENV['BEAKER_setfile'] || ENV['RS_SETFILE'],
+    :provision   => ENV['BEAKER_provision'] || ENV['RS_PROVISION'],
+    :keyfile     => ENV['BEAKER_keyfile'] || ENV['RS_KEYFILE'],
+    :debug       => ENV['BEAKER_debug'] || ENV['RS_DEBUG'],
+    :destroy     => ENV['BEAKER_destroy'] || ENV['RS_DESTROY'],
+  }.delete_if {|key, value| value.nil?}
+  #combine defaults and env_vars to determine overall options
+  options = defaults.merge(env_vars)
+
+  # process options to construct beaker command string
+  nodesetfile = options[:nodesetfile] || File.join('spec/acceptance/nodesets',"#{options[:nodeset]}.yml")
+  fresh_nodes = options[:provision] == 'no' ? '--no-provision' : nil
+  keyfile = options[:keyfile] ? ['--keyfile', options[:keyfile]] : nil
+  debug = options[:debug] ? ['--log-level', 'debug'] : nil
+
+  # Configure all nodes in nodeset
+  c.setup([fresh_nodes, '--hosts', nodesetfile, keyfile, debug].flatten.compact)
+  c.provision
+  c.validate
+  c.configure
+
+  # Destroy nodes if no preserve hosts
+  c.after :suite do
+    case options[:destroy]
+    when 'no'
+      # Don't cleanup
+    when 'onpass'
+      c.cleanup if RSpec.world.filtered_examples.values.flatten.none?(&:exception)
+    else
+      c.cleanup
+    end
+  end
+end

--- a/lib/beaker/rspec/spec_helper.rb
+++ b/lib/beaker/rspec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'beaker-rspec/beaker_shim'
-require "beaker-rspec/helpers/serverspec"
+require 'beaker/rspec/beaker_shim'
+require "beaker/rspec/helpers/serverspec"
 include BeakerRSpec::BeakerShim
 
 RSpec.configure do |c|


### PR DESCRIPTION
These are the tests run locally before submitting

- normal rspec testing
- beaker normal acceptance testing
- added beaker rspec-style acceptance testing `bundle exec rspec acceptance/rspec`

also tested this as beaker gem against puppetlabs-inifile & -haproxy successfully.  To reproduce this, you can just change `beaker-rspec` references to `beaker/rspec`, and make sure beaker-rspec isn't in the gem spec.  (I'll be doing a preliminary doc on this conversion later today internally)