### PR TITLE
(BKR-183) simplecov busted in beaker

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,15 +1,15 @@
 SimpleCov.configure do
   add_filter 'spec/'
+  add_filter 'vendor/'
   add_filter do |file|
     file.lines_of_code < 10
   end
-  add_group 'DSL', '/dsl'
-  add_group 'Host', '/host'
-  add_group 'Utils' do |file|
-    files = %w(cli.rb logger.rb options_parsing.rb test_config.rb utils/)
-    files.any? {|f| file.filename =~ Regexp.new( Regexp.quote(f) ) }
-  end
-  add_group 'Hypervisors', '/hypervisor'
+  add_group 'Answers', '/answers/'
+  add_group 'DSL', '/dsl/'
+  add_group 'Host', '/host/'
+  add_group 'Hypervisors', '/hypervisor/'
+  add_group 'Options', '/options/'
+  add_group 'Shared', '/shared/'
 end
 
-SimpleCov.start if ENV['COVERAGE']
+SimpleCov.start if ENV['BEAKER_COVERAGE']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'simplecov'
 require 'beaker'
 require 'fakefs/spec_helpers'
 require 'mocks'


### PR DESCRIPTION
- accidentally busted when we dropped ruby 1.8 support
- updated to look nice with the current beaker directory structure
- updated env var to meet beaker standards