### PR TITLE
(BKR-192) can't run beaker without a host file specified

### DIFF
--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -26,7 +26,16 @@ module Beaker
       @machines = {}
       @hypervisors = nil
 
-      @options[:log_prefix]     = File.basename(@options[:hosts_file], '.yml') unless @options[:log_prefix]
+      # user provided prefix has top priority
+      if not @options[:log_prefix]
+        # name it after the hosts file
+        if @options[:hosts_file]
+          @options[:log_prefix] = File.basename(@options[:hosts_file], '.yml')
+        else
+          #here be the default
+          @options[:log_prefix] = @options[:default_log_prefix]
+        end
+      end
       @options[:timestamp]      = Time.now unless @options.has_key?(:timestamp)
       @options[:xml_dated_dir]  = Beaker::Logger.generate_dated_log_folder(@options[:xml_dir], @options[:log_prefix], @options[:timestamp])
       @options[:log_dated_dir]  = Beaker::Logger.generate_dated_log_folder(@options[:log_dir], @options[:log_prefix], @options[:timestamp])

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -137,6 +137,7 @@ module Beaker
           :xml_dir                => 'junit',
           :xml_file               => 'beaker_junit.xml',
           :xml_stylesheet         => 'junit.xsl',
+          :default_log_prefix     => 'beaker_logs',
           :log_dir                => 'log',
           :log_sut_event          => 'sut.log',
           :color                  => true,

--- a/spec/beaker/network_manager_spec.rb
+++ b/spec/beaker/network_manager_spec.rb
@@ -11,7 +11,9 @@ module Beaker
       make_opts.merge({
         'logger' => double().as_null_object,
         :logger_sut => mock_provisioning_logger,
-        :log_prefix => 'log_prefix_dummy'
+        :log_prefix => @log_prefix,
+        :hosts_file => @hosts_file,
+        :default_log_prefix => 'hello_default',
       })
     }
     let( :network_manager ) { NetworkManager.new(options, options[:logger]) }
@@ -19,6 +21,10 @@ module Beaker
     let( :host ) { hosts[0] }
 
     describe '#log_sut_event' do
+      before :each do
+        @log_prefix = 'log_prefix_dummy'
+        @hosts_file = 'dummy_hosts'
+      end
 
       it 'creates the correct content for an event' do
         log_line = network_manager.log_sut_event host, true
@@ -53,6 +59,30 @@ module Beaker
         options.delete(:logger_sut)
         expect{ nm.log_sut_event(host, true) }.to raise_error(ArgumentError)
       end
+    end
+
+    it 'uses user defined log prefix if it is provided' do
+      @log_prefix = 'dummy_log_prefix'
+      @hosts_file = 'dummy_hosts'
+      nm = network_manager
+      cur_prefix = options[:log_prefix]
+      expect(cur_prefix).to be === @log_prefix
+    end
+
+    it 'uses host based log prefix, when there is not user defined log prefix' do
+      @log_prefix = nil
+      @hosts_file = 'dummy_hosts'
+      nm = network_manager
+      cur_prefix = options[:log_prefix]
+      expect(cur_prefix).to be === @hosts_file
+    end
+
+    it 'uses default log prefix, when there is no user defined and no host file' do
+      @log_prefix = nil
+      @hosts_file = nil
+      nm = network_manager
+      cur_prefix = options[:log_prefix]
+      expect(cur_prefix).to be === 'hello_default'
     end
   end
 end


### PR DESCRIPTION
- the hosts file was being defaulted to to provide a log name prefix -
  it needs a default value for when there is no user provided value plus
  no hosts file