### PR TITLE
(BKR-70) Make SshConnection.close more robust...

### DIFF
--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -37,7 +37,7 @@ module Beaker
     end
 
     def log(logger)
-      logger.debug "Exited: #{exit_code}" unless exit_code == 0
+      logger.debug "Exited: #{exit_code}" unless exit_code == 0 or !exit_code
     end
 
     def formatted_output(limit=10)


### PR DESCRIPTION
...(so that on(host, "reboot") works correctly)

- catch IOErrors
- added additional execution option ':expect_connection_failure' for
  operations that you believe should result in the connection to the
  host being dropped or broken
- tested with rebooting centos7 box, successfully rebuilds connection
  and continues test execution