### PR TITLE
(BKR-209) check for package and host prebuild sles10

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -19,6 +19,9 @@ module Unix::Pkg
 
   def check_for_package(name)
     case self['platform']
+      when /sles-10/
+        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :acceptable_exit_codes => (0...127))
+        result.stdout =~ /No packages found/ ? (return false) : (return result.exit_code == 0)
       when /sles-/
         result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :acceptable_exit_codes => (0...127))
       when /el-4/

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -16,6 +16,7 @@ module Beaker
     FREEBSD_PACKAGES = ['curl']
     WINDOWS_PACKAGES = ['curl']
     PSWINDOWS_PACKAGES = []
+    SLES10_PACKAGES = ['curl']
     SLES_PACKAGES = ['curl', 'ntp']
     DEBIAN_PACKAGES = ['curl', 'ntpdate', 'lsb-release']
     CUMULUS_PACKAGES = ['addons', 'ntpdate', 'lsb-release']
@@ -88,6 +89,8 @@ module Beaker
       logger = opts[:logger]
       block_on host do |host|
         case
+        when host['platform'] =~ /sles-10/
+          check_and_install_packages_if_needed(host, SLES10_PACKAGES)
         when host['platform'] =~ /sles-/
           check_and_install_packages_if_needed(host, SLES_PACKAGES)
         when host['platform'] =~ /debian/


### PR DESCRIPTION
this change fixes check_for_package on sles10 in which zypper always
returns 0, even if a package is not found.
This change also removes ntp package from the host pre-build steps.
sles10 comes with ntp_command installed.