### PR TITLE
(BKR-217) aws_sdk: given CONFIG subnet_ids, try each in turn

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -46,9 +46,6 @@ module Beaker
       # Perform the main launch work
       launch_all_nodes()
 
-      # Wait for each node to reach status :running
-      wait_for_status(:running)
-
       # Add metadata tags to each instance
       add_tags()
 
@@ -322,6 +319,7 @@ module Beaker
         @logger.notify("aws-sdk: Launched #{host.name} (#{amitype}:#{amisize}) using snapshot/image_type #{image_type}")
       end
 
+      wait_for_status(:running)
       nil
     end
 


### PR DESCRIPTION

    (BKR-217) aws_sdk: given CONFIG subnet_ids, try each in turn

    This should help alleviate the EC2 InsufficientInstanceCapacity.

    The new policy will only be applied to a host if there isn't a CONFIG
    subnet_id and there isn't a host-specific subnet_id.  When it does
    apply, try each subnet in subnet_ids once for each relevant host.

    The new option can be used like this:

      CONFIG
        vpc_id: foo
        subnet_ids:
          - x
          - y
          - z
