### PR TITLE
(BKR-215) Document all of the options to #on and friends

### DIFF
--- a/lib/beaker/dsl/helpers/facter_helpers.rb
+++ b/lib/beaker/dsl/helpers/facter_helpers.rb
@@ -6,13 +6,22 @@ module Beaker
       #
       module FacterHelpers
 
-        # @!macro common_opts
+        # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
         #   @option opts [Boolean] :silent (false) Do not produce log output
         #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
         #     (or range) of integer exit codes that should be considered
         #     acceptable.  An error will be thrown if the exit code does not
         #     match one of the values in this list.
+        #   @option opts [Boolean] :accept_all_exit_codes (false) Consider all 
+        #     exit codes as passing.
+        #   @option opts [Boolean] :dry_run (false) Do not actually execute any
+        #     commands on the SUT
+        #   @option opts [String] :stdin (nil) Input to be provided during command
+        #     execution on the SUT.
+        #   @option opts [Boolean] :pty (false) Execute this command in a pseudoterminal.
+        #   @option opts [Boolean] :expect_connection_failure (false) Expect this command
+        #     to result in a connection failure, reconnect and continue execution.
         #   @option opts [Hash{String=>String}] :environment ({}) These will be
         #     treated as extra environment variables that should be set before
         #     running the command.

--- a/lib/beaker/dsl/helpers/hiera_helpers.rb
+++ b/lib/beaker/dsl/helpers/hiera_helpers.rb
@@ -5,17 +5,6 @@ module Beaker
       # for these methods to execute correctly
       module HieraHelpers
 
-        # @!macro common_opts
-        #   @param [Hash{Symbol=>String}] opts Options to alter execution.
-        #   @option opts [Boolean] :silent (false) Do not produce log output
-        #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
-        #     (or range) of integer exit codes that should be considered
-        #     acceptable.  An error will be thrown if the exit code does not
-        #     match one of the values in this list.
-        #   @option opts [Hash{String=>String}] :environment ({}) These will be
-        #     treated as extra environment variables that should be set before
-        #     running the command.
-        
         # Write hiera config file on one or more provided hosts
         #
         # @param[Host, Array<Host>, String, Symbol] host    One or more hosts to act upon,

--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -5,13 +5,22 @@ module Beaker
       # methods do not require puppet to be installed to execute correctly
       module HostHelpers
 
-        # @!macro common_opts
+        # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
         #   @option opts [Boolean] :silent (false) Do not produce log output
         #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
         #     (or range) of integer exit codes that should be considered
         #     acceptable.  An error will be thrown if the exit code does not
         #     match one of the values in this list.
+        #   @option opts [Boolean] :accept_all_exit_codes (false) Consider all 
+        #     exit codes as passing.
+        #   @option opts [Boolean] :dry_run (false) Do not actually execute any
+        #     commands on the SUT
+        #   @option opts [String] :stdin (nil) Input to be provided during command
+        #     execution on the SUT.
+        #   @option opts [Boolean] :pty (false) Execute this command in a pseudoterminal.
+        #   @option opts [Boolean] :expect_connection_failure (false) Expect this command
+        #     to result in a connection failure, reconnect and continue execution.
         #   @option opts [Hash{String=>String}] :environment ({}) These will be
         #     treated as extra environment variables that should be set before
         #     running the command.

--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -414,11 +414,11 @@ module Beaker
           logger.debug "  Trying command #{max_retries} times."
           logger.debug ".", add_newline=false
 
-          result = on host, command, {:acceptable_exit_codes => (0...127), :silent => !verbose}, &block
+          result = on host, command, {:accept_all_exit_codes => true, :silent => !verbose}, &block
           num_retries = 0
           until desired_exit_codes.include?(result.exit_code)
             sleep retry_interval
-            result = on host, command, {:acceptable_exit_codes => (0...127), :silent => !verbose}, &block
+            result = on host, command, {:accept_all_exit_codes => true, :silent => !verbose}, &block
             num_retries += 1
             logger.debug ".", add_newline=false
             if (num_retries > max_retries)

--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -9,18 +9,26 @@ module Beaker
       # for these methods to execute correctly
       module PuppetHelpers
 
-        # @!macro common_opts
+        # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
         #   @option opts [Boolean] :silent (false) Do not produce log output
         #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
         #     (or range) of integer exit codes that should be considered
         #     acceptable.  An error will be thrown if the exit code does not
         #     match one of the values in this list.
+        #   @option opts [Boolean] :accept_all_exit_codes (false) Consider all 
+        #     exit codes as passing.
+        #   @option opts [Boolean] :dry_run (false) Do not actually execute any
+        #     commands on the SUT
+        #   @option opts [String] :stdin (nil) Input to be provided during command
+        #     execution on the SUT.
+        #   @option opts [Boolean] :pty (false) Execute this command in a pseudoterminal.
+        #   @option opts [Boolean] :expect_connection_failure (false) Expect this command
+        #     to result in a connection failure, reconnect and continue execution.
         #   @option opts [Hash{String=>String}] :environment ({}) These will be
         #     treated as extra environment variables that should be set before
         #     running the command.
         #
-
 
         # Return the name of the puppet user.
         #
@@ -322,7 +330,7 @@ module Beaker
         #
         # @option opts [Boolean]  :expect_changes (false) This option enables
         #                         detailed exit codes and causes a test failure
-  #                         if `puppet --apply` indicates that there were
+        #                         if `puppet --apply` indicates that there were
         #                         no resource changes during its execution.
         #
         # @option opts [Boolean]  :expect_failures (false) This option enables

--- a/lib/beaker/dsl/helpers/tk_helpers.rb
+++ b/lib/beaker/dsl/helpers/tk_helpers.rb
@@ -9,18 +9,6 @@ module Beaker
       # Convenience methods for modifying and reading TrapperKeeper configs
       module TKHelpers
 
-        # @!macro common_opts
-        #   @param [Hash{Symbol=>String}] opts Options to alter execution.
-        #   @option opts [Boolean] :silent (false) Do not produce log output
-        #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
-        #     (or range) of integer exit codes that should be considered
-        #     acceptable.  An error will be thrown if the exit code does not
-        #     match one of the values in this list.
-        #   @option opts [Hash{String=>String}] :environment ({}) These will be
-        #     treated as extra environment variables that should be set before
-        #     running the command.
-        #
-
         # Modify the given TrapperKeeper config file.
         #
         # @param [Host] host  A host object

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -4,18 +4,6 @@ module Beaker
       # Convenience methods for checking links and moving web content to hosts
       module WebHelpers
 
-        # @!macro common_opts
-        #   @param [Hash{Symbol=>String}] opts Options to alter execution.
-        #   @option opts [Boolean] :silent (false) Do not produce log output
-        #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
-        #     (or range) of integer exit codes that should be considered
-        #     acceptable.  An error will be thrown if the exit code does not
-        #     match one of the values in this list.
-        #   @option opts [Hash{String=>String}] :environment ({}) These will be
-        #     treated as extra environment variables that should be set before
-        #     running the command.
-        #
-
         # Blocks until the port is open on the host specified, returns false
         # on failure
         def port_open_within?( host, port = 8140, seconds = 120 )

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -479,7 +479,7 @@ module Beaker
           prev_sleep = 0
           cur_sleep = 1
           while (res.stdout !~ higgs_re) and (attempts < tries)
-            res = on host, "cd #{host['working_dir']}/#{host['dist']} && cat #{host['higgs_file']}", :acceptable_exit_codes => (0..255)
+            res = on host, "cd #{host['working_dir']}/#{host['dist']} && cat #{host['higgs_file']}", :accept_all_exit_codes => true
             attempts += 1
             sleep( cur_sleep )
             prev_sleep = cur_sleep

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -238,14 +238,14 @@ module Beaker
     def determine_if_x86_64
       if is_cygwin?
         if self[:platform] =~ /osx|solaris/
-          result = exec(Beaker::Command.new("uname -a | grep x86_64"), :acceptable_exit_codes => (0...127))
+          result = exec(Beaker::Command.new("uname -a | grep x86_64"), :accept_all_exit_codes => true)
           result.exit_code == 0
         else
-          result = exec(Beaker::Command.new("arch | grep x86_64"), :acceptable_exit_codes => (0...127))
+          result = exec(Beaker::Command.new("arch | grep x86_64"), :accept_all_exit_codes => true)
           result.exit_code == 0
         end
       else
-        result = exec(Beaker::Command.new("wmic os get osarchitecture"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("wmic os get osarchitecture"), :accept_all_exit_codes => true)
         result.stdout =~ /64/
       end
     end
@@ -289,10 +289,10 @@ module Beaker
         env_file = self[:ssh_env_file]
         escaped_val = Regexp.escape(val).gsub('/', '\/').gsub(';', '\;')
         #see if the key/value pair already exists
-        if exec(Beaker::Command.new("grep #{key}=.*#{escaped_val} #{env_file}"), :acceptable_exit_codes => (0..255) ).exit_code == 0
+        if exec(Beaker::Command.new("grep #{key}=.*#{escaped_val} #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
           return #nothing to do here, key value pair already exists
         #see if the key already exists
-        elsif exec(Beaker::Command.new("grep #{key} #{env_file}"), :acceptable_exit_codes => (0..255) ).exit_code == 0
+        elsif exec(Beaker::Command.new("grep #{key} #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
           exec(Beaker::SedCommand.new(self['platform'], "s/#{key}=/#{key}=#{escaped_val}:/", env_file))
         else
           exec(Beaker::Command.new("echo \"#{key}=#{val}\" >> #{env_file}"))
@@ -302,7 +302,7 @@ module Beaker
         mirror_env_to_profile_d(env_file)
       else #powershell windows
         #see if the key/value pair already exists
-        result = exec(Beaker::Command.new("set #{key}"), :acceptable_exit_codes => (0..255))
+        result = exec(Beaker::Command.new("set #{key}"), :accept_all_exit_codes => true)
         subbed_result = result.stdout.chomp
         if result.exit_code == 0
           subbed_result = subbed_result.gsub(/#{Regexp.escape(val.gsub(/'|"/, ''))}/, '')
@@ -321,7 +321,7 @@ module Beaker
     #  host.get_env_var('path')
     def get_env_var key
       key = key.to_s.upcase
-      exec(Beaker::Command.new("env | grep #{key}"), :acceptable_exit_codes => (0..255)).stdout.chomp
+      exec(Beaker::Command.new("env | grep #{key}"), :accept_all_exit_codes => true).stdout.chomp
     end
 
     #Delete the provided key/val from the current ssh environment
@@ -345,7 +345,7 @@ module Beaker
         mirror_env_to_profile_d(env_file)
       else #powershell windows
         #get the current value of the key
-        result = exec(Beaker::Command.new("set #{key}"), :acceptable_exit_codes => (0..255))
+        result = exec(Beaker::Command.new("set #{key}"), :accept_all_exit_codes => true)
         subbed_result = result.stdout.chomp
         if result.exit_code == 0
           subbed_result = subbed_result.gsub(/#{Regexp.escape(val.gsub(/'|"/, ''))}/, '')

--- a/lib/beaker/host/pswindows/pkg.rb
+++ b/lib/beaker/host/pswindows/pkg.rb
@@ -2,7 +2,7 @@ module PSWindows::Pkg
   include Beaker::CommandFactory
 
   def check_for_command(name)
-    result = exec(Beaker::Command.new("where #{name}"), :acceptable_exit_codes => (0...127))
+    result = exec(Beaker::Command.new("where #{name}"), :accept_all_exit_codes => true)
     result.exit_code == 0
   end
 
@@ -29,9 +29,7 @@ module PSWindows::Pkg
   # @api private
   def identify_windows_architecture
     arch = nil
-    execute("wmic os get osarchitecture",
-    :acceptable_exit_codes => (0...127)) do |result|
-
+    execute("wmic os get osarchitecture", :accept_all_exit_codes => true) do |result|
       arch = if result.exit_code == 0
         result.stdout =~ /64/ ? '64' : '32'
       else
@@ -44,8 +42,7 @@ module PSWindows::Pkg
   # @api private
   def identify_windows_architecture_from_os_name_for_win2003
     arch = nil
-    execute("wmic os get name",
-    :acceptable_exit_codes => (0...127)) do |result|
+    execute("wmic os get name", :accept_all_exit_codes => true) do |result|
       arch = result.stdout =~ /64/ ? '64' : '32'
     end
     arch

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -8,7 +8,7 @@ module Unix::Pkg
   end
 
   def check_for_command(name)
-    result = exec(Beaker::Command.new("which #{name}"), :acceptable_exit_codes => (0...127))
+    result = exec(Beaker::Command.new("which #{name}"), :accept_all_exit_codes => true)
     case self['platform']
     when /solaris-10/
       result.stdout =~ %r|/.*/#{name}|
@@ -20,25 +20,25 @@ module Unix::Pkg
   def check_for_package(name)
     case self['platform']
       when /sles-10/
-        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :accept_all_exit_codes => true)
         result.stdout =~ /No packages found/ ? (return false) : (return result.exit_code == 0)
       when /sles-/
-        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}"), :accept_all_exit_codes => true)
       when /el-4/
         @logger.debug("Package query not supported on rhel4")
         return false
       when /fedora|centos|eos|el-/
-        result = exec(Beaker::Command.new("rpm -q #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("rpm -q #{name}"), :accept_all_exit_codes => true)
       when /ubuntu|debian|cumulus/
-        result = exec(Beaker::Command.new("dpkg -s #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("dpkg -s #{name}"), :accept_all_exit_codes => true)
       when /solaris-11/
-        result = exec(Beaker::Command.new("pkg info #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("pkg info #{name}"), :accept_all_exit_codes => true)
       when /solaris-10/
-        result = exec(Beaker::Command.new("pkginfo #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("pkginfo #{name}"), :accept_all_exit_codes => true)
       when /freebsd-9/
-        result = exec(Beaker::Command.new("pkg_info #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("pkg_info #{name}"), :accept_all_exit_codes => true)
       when /freebsd-10/
-        result = exec(Beaker::Command.new("pkg info #{name}"), :acceptable_exit_codes => (0...127))
+        result = exec(Beaker::Command.new("pkg info #{name}"), :accept_all_exit_codes => true)
       else
         raise "Package #{name} cannot be queried on #{self}"
     end

--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -2,12 +2,12 @@ module Windows::Pkg
   include Beaker::CommandFactory
 
   def check_for_command(name)
-    result = exec(Beaker::Command.new("which #{name}"), :acceptable_exit_codes => (0...127))
+    result = exec(Beaker::Command.new("which #{name}"), :accept_all_exit_codes => true)
     result.exit_code == 0
   end
 
   def check_for_package(name)
-    result = exec(Beaker::Command.new("cygcheck #{name}"), :acceptable_exit_codes => (0...127))
+    result = exec(Beaker::Command.new("cygcheck #{name}"), :accept_all_exit_codes => true)
     result.exit_code == 0
   end
 
@@ -46,9 +46,7 @@ module Windows::Pkg
   # @api private
   def identify_windows_architecture
     arch = nil
-    execute("echo '' | wmic os get osarchitecture",
-            :acceptable_exit_codes => (0...127)) do |result|
-
+    execute("echo '' | wmic os get osarchitecture", :accept_all_exit_codes => true) do |result|
       arch = if result.exit_code == 0
         result.stdout =~ /64/ ? '64' : '32'
       else
@@ -61,8 +59,7 @@ module Windows::Pkg
   # @api private
   def identify_windows_architecture_from_os_name_for_win2003
     arch = nil
-    execute("echo '' | wmic os get name | grep x64",
-            :acceptable_exit_codes => (0...127)) do |result|
+    execute("echo '' | wmic os get name | grep x64", :accept_all_exit_codes => true) do |result|
       arch = result.exit_code == 0 ? '64' : '32'
     end
     arch

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -55,7 +55,7 @@ module Beaker
           try = 0
           until try >= TRIES do
             try += 1
-            if host.exec(Command.new(ntp_command), :acceptable_exit_codes => (0..255)).exit_code == 0
+            if host.exec(Command.new(ntp_command), :accept_all_exit_codes => true).exit_code == 0
               success=true
               break
             end
@@ -139,9 +139,9 @@ module Beaker
       logger.notify "Sync root authorized_keys from github on #{host.name}"
         # Allow all exit code, as this operation is unlikely to cause problems if it fails.
         if host['platform'] =~ /solaris|eos/
-          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "bash"), :acceptable_exit_codes => (0..255))
+          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "bash"), :accept_all_exit_codes => true)
         else
-          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "env PATH=/usr/gnu/bin:$PATH bash"), :acceptable_exit_codes => (0..255))
+          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "env PATH=/usr/gnu/bin:$PATH bash"), :accept_all_exit_codes => true)
         end
       end
     rescue => e

--- a/spec/beaker/dsl/install_utils/pe_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_utils_spec.rb
@@ -356,7 +356,7 @@ describe ClassMixedWithDSLInstallUtils do
                                          "cd /tmp/2014-07-01_15.27.53/puppet-enterprise-3.0-linux ; nohup ./pe-installer <<<Y > higgs_2014-07-01_15.27.53.log 2>&1 &",
                                         opts ).once
       #check to see if the higgs installation has proceeded correctly, works on second check
-      expect( subject ).to receive( :on ).with( hosts[0], /cat #{hosts[0]['higgs_file']}/, { :acceptable_exit_codes => 0..255 }).and_return( @fail_result, @success_result )
+      expect( subject ).to receive( :on ).with( hosts[0], /cat #{hosts[0]['higgs_file']}/, { :accept_all_exit_codes => true }).and_return( @fail_result, @success_result )
       subject.do_higgs_install( hosts[0], opts )
     end
 
@@ -371,7 +371,7 @@ describe ClassMixedWithDSLInstallUtils do
                                          "cd /tmp/2014-07-01_15.27.53/puppet-enterprise-3.0-linux ; nohup ./pe-installer <<<Y > higgs_2014-07-01_15.27.53.log 2>&1 &",
                                         opts ).once
       #check to see if the higgs installation has proceeded correctly, works on second check
-      expect( subject ).to receive( :on ).with( hosts[0], /cat #{hosts[0]['higgs_file']}/, { :acceptable_exit_codes => 0..255 }).exactly(10).times.and_return( @fail_result )
+      expect( subject ).to receive( :on ).with( hosts[0], /cat #{hosts[0]['higgs_file']}/, { :accept_all_exit_codes => true }).exactly(10).times.and_return( @fail_result )
       expect{ subject.do_higgs_install( hosts[0], opts ) }.to raise_error
     end
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -29,7 +29,7 @@ module Beaker
         @opts = {'platform' => 'sles-is-me'}
         pkg = 'sles_package'
         expect( Beaker::Command ).to receive(:new).with("zypper se -i --match-exact #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
  
@@ -37,7 +37,7 @@ module Beaker
         @opts = {'platform' => 'fedora-is-me'}
         pkg = 'fedora_package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -45,7 +45,7 @@ module Beaker
         @opts = {'platform' => 'centos-is-me'}
         pkg = 'centos_package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -53,7 +53,7 @@ module Beaker
         @opts = {'platform' => 'eos-is-me'}
         pkg = 'eos-package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -61,7 +61,7 @@ module Beaker
         @opts = {'platform' => 'el-is-me'}
         pkg = 'el_package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -69,7 +69,7 @@ module Beaker
         @opts = {'platform' => 'debian-is-me'}
         pkg = 'debian_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -77,7 +77,7 @@ module Beaker
         @opts = {'platform' => 'ubuntu-is-me'}
         pkg = 'ubuntu_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -85,7 +85,7 @@ module Beaker
         @opts = {'platform' => 'cumulus-is-me'}
         pkg = 'cumulus_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -93,7 +93,7 @@ module Beaker
         @opts = {'platform' => 'solaris-11-is-me'}
         pkg = 'solaris-11_package'
         expect( Beaker::Command ).to receive(:new).with("pkg info #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -101,7 +101,7 @@ module Beaker
         @opts = {'platform' => 'solaris-10-is-me'}
         pkg = 'solaris-10_package'
         expect( Beaker::Command ).to receive(:new).with("pkginfo #{pkg}").and_return('')
-        expect( instance ).to receive(:exec).with('', :acceptable_exit_codes => (0...127)).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 


### PR DESCRIPTION
- updates shared options to be current (with info for
  accept_all_exit_codes and friends)
- yard doc does a single pass and you can't guarantee file ordering, so
  you have to have the common options macro in each file that needs it -
  duplication yay!
- update usage of acceptable_exit_codes to accept_all_exit_codes when we are just passing acceptable_exit_codes a mega array