### PR TITLE
(QENG-2009) Fix windows MSI name for 3.99

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -277,7 +277,7 @@ module Beaker
               # - we are on pe version 3.4+
               # - we do not have install_32 set on host
               # - we do not have install_32 set globally
-              if !(version_is_less(version, '4.0'))
+              if !(version_is_less(version, '3.99'))
                 if should_install_64bit
                   host['dist'] = "puppet-agent-#{version}-x64"
                 else

--- a/spec/beaker/dsl/install_utils/pe_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_utils_spec.rb
@@ -253,7 +253,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :version_is_less ).with('3.0', '4.0').and_return( true )
       allow( subject ).to receive( :version_is_less ).with('3.0', '3.4').and_return( true )
       allow( subject ).to receive( :version_is_less ).with('3.0', '3.0').and_return( false )
-      allow( subject ).to receive( :version_is_less ).with('3.0', '3.4').and_return( true )
+      allow( subject ).to receive( :version_is_less ).with('3.0', '3.99').and_return( true )
       allow( subject ).to receive( :wait_for_host_in_dashboard ).and_return( true )
       allow( subject ).to receive( :puppet_agent ) do |arg|
         "puppet agent #{arg}"


### PR DESCRIPTION
We were only using puppet-agent for 4.0, this
commit bumps that down to 3.99.