### PR TITLE
(BKR-305)Adding function to have custom docker options per host

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -65,10 +65,24 @@ module Beaker
         end
 
         @logger.debug("Creating container from image #{image_name}")
-        container = ::Docker::Container.create({
-          'Image' => image_name,
-          'Hostname' => host.name,
-        })
+        image_hash = {
+           'Image' => image_name,
+           'Hostname' => host.name,
+        }
+
+        if options[:dockeropts]
+          options[:dockeropts].each do |k,v|
+            image_hash[k] = v
+          end
+        end
+
+        if host[:dockeropts]
+          host[:dockeropts].each do |k,v|
+            image_hash[k] = v
+          end
+        end
+
+        container = ::Docker::Container.create(image_hash)
 
         @logger.debug("Starting container #{container.id}")
         container.start({"PublishAllPorts" => true, "Privileged" => true})


### PR DESCRIPTION
Sometimes, one needs to pass custom options to Docker when creating a host.

This patch allows a :dockeropts key to be added to the nodeset, which is passed to the Docker API