### PR TITLE
(BKR-242) Docker swarm

### DIFF
--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -59,6 +59,7 @@ module Beaker
 
     let (:docker) { ::Beaker::Docker.new( hosts, options ) }
     let(:docker_options) { nil }
+    let (:version) { {"ApiVersion"=>"1.18", "Arch"=>"amd64", "GitCommit"=>"4749651", "GoVersion"=>"go1.4.2", "KernelVersion"=>"3.16.0-37-generic", "Os"=>"linux", "Version"=>"1.6.0"} }
 
     before :each do
       # Stub out all of the docker-api gem. we should never really call it
@@ -67,6 +68,7 @@ module Beaker
       allow( ::Docker ).to receive(:options).and_return(docker_options)
       allow( ::Docker ).to receive(:options=)
       allow( ::Docker ).to receive(:logger=)
+      allow( ::Docker ).to receive(:version).and_return(version)
       allow( ::Docker::Image ).to receive(:build).and_return(image)
       allow( ::Docker::Container ).to receive(:create).and_return(container)
       allow_any_instance_of( ::Docker::Container ).to receive(:start)


### PR DESCRIPTION
Several fixes to be able to use Swarm with beaker.

When we want the IP address of the container with running swarm we have to fetch the IP of the swarm slave it self.
This is required since DOCKER_HOST env var will point to the Swarm Master and not the resulting docker host where the image will be running.

By default the build command is ran on a random node, the Container create + run command could be executed on a completely different node causing the create to fail since that node does not have just built image.

To distribute the same built image between all swarm slaves we need to push the image to a private registry.
If the image does not exist yet ( first build ) we tag + push it, If it does exist we will re-use it.
If we built the image on Node A but then the run command is executed on
node B we will pull the image automatically and run it.

The only downside is that we will always build the image since we need to know the resulting image ID.
Hopefully this can be improved in the future.