### PR TITLE
(BKR-276) Fixes `#echo_to_file` for FreeBSD

### DIFF
--- a/lib/beaker/host/freebsd/exec.rb
+++ b/lib/beaker/host/freebsd/exec.rb
@@ -5,6 +5,6 @@ module FreeBSD::Exec
     # FreeBSD gets weird about special characters, we have to go a little OTT here
     escaped_str = str.gsub(/\t/,'\\t').gsub(/\n/,'\\n')
 
-    exec(Beaker::Command.new("printf #{escaped_str} > #{filename}"))
+    exec(Beaker::Command.new("printf \"#{escaped_str}\" > #{filename}"))
   end
 end

--- a/spec/beaker/host/freebsd/exec_spec.rb
+++ b/spec/beaker/host/freebsd/exec_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module Beaker
+  describe FreeBSD::Exec do
+    class FreeBSDExecTest
+      include FreeBSD::Exec
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { FreeBSDExecTest.new(opts, logger) }
+
+    context "echo_to_file" do
+
+      it "runs the correct echo command" do
+        expect( Beaker::Command ).to receive(:new).with('printf "127.0.0.1\tlocalhost localhost.localdomain\n10.255.39.23\tfreebsd-10-x64\n" > /etc/hosts').and_return('')
+        expect( instance ).to receive(:exec).with('').and_return(generate_result("hello", {:exit_code => 0}))
+        instance.echo_to_file('127.0.0.1\tlocalhost localhost.localdomain\n10.255.39.23\tfreebsd-10-x64\n', '/etc/hosts')
+      end
+
+    end
+  end
+end
+


### PR DESCRIPTION
Previous command didn't wrap printf string in `"`
Stops command working:

```

freebsd-9-x64 executed in 0.04 seconds
Warning: ssh connection to 10.255.52.108 has been terminated

freebsd-9-x64 20:12:47$ printf 127.0.0.1\tlocalhost localhost.localdomain\n10.255.52.108\tfreebsd-9-x64\n > /etc/hosts
Attempting ssh connection to 10.255.52.108, user: root, opts: {:config=>"/var/folders/nn/408ddhln26s1b356ry19q6yr0000gp/T/freebsd-9-x6420150518-65951-3jag0b"}
printf: missing format character
```