### PR TITLE
(maint) Relax constraint on hocon

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'json', '~> 1.8'
-  s.add_runtime_dependency 'hocon', '~> 0.0.4'
+  s.add_runtime_dependency 'hocon', '~> 0.1'
   s.add_runtime_dependency 'net-ssh', '~> 2.9'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 2.0'


### PR DESCRIPTION
Prior to this we were using the hocon gem and pinning to a z release.

This commit relaxes the version dependency to pull in an pre-1.0 hocon
release.

This is necessary for testing the hocon module itself.