### PR TITLE
(BKR-292) Cisco platform changes + prepend command functionality

### DIFF
--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -70,6 +70,7 @@ module Beaker
     #                      interface.
     # @param [String] cmd  An command to call.
     # @param [Hash]   env  An optional hash of environment variables to be used
+    # @param [String] pc   An optional list of commands to prepend 
     #
     # @return [String] This returns the fully formed command line invocation.
     def cmd_line host, cmd = @command, env = @environment, pc = @prepend_cmds

--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -50,6 +50,11 @@ module Beaker
       @args    = args
       @environment = {}
       @cmdexe = @options.delete(:cmdexe) || false
+      @prepend_cmds = {}
+      if @options[:prepend_cmds]
+        @prepend_cmds = @options[:prepend_cmds]
+        @options.delete(:prepend_cmds)
+      end
 
       # this is deprecated and will not allow you to use a command line
       # option of `--environment`, please use ENV instead.
@@ -67,13 +72,13 @@ module Beaker
     # @param [Hash]   env  An optional hash of environment variables to be used
     #
     # @return [String] This returns the fully formed command line invocation.
-    def cmd_line host, cmd = @command, env = @environment
+    def cmd_line host, cmd = @command, env = @environment, pc = @prepend_cmds
       env_string = env.nil? ? '' : environment_string_for( host, env )
 
       cygwin = ((host['platform'] =~ /windows/) and host.is_cygwin? and @cmdexe) ? 'cmd.exe /c' : nil
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
-      [env_string, cygwin, cmd, options_string, args_string].compact.reject(&:empty?).join(' ')
+      [env_string, cygwin, pc, cmd, options_string, args_string].compact.reject(&:empty?).join(' ')
     end
 
     # @param [Hash] opts These are the options that the command takes

--- a/lib/beaker/command_factory.rb
+++ b/lib/beaker/command_factory.rb
@@ -16,7 +16,10 @@ module Beaker
     end
 
     def execute(command, options={}, &block)
-      result = self.exec(Command.new(command), options)
+      options[:prepend_cmds] ? 
+        pc = options.select {|k,v| k == :prepend_cmds} :
+        pc = {:prepend_cmds => ""}
+      result = self.exec(Command.new(command, [], pc), options)
 
       if block_given?
         yield result

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -19,29 +19,27 @@ module Unix::Pkg
 
   def check_for_package(name, opts = {})
     opts = {:accept_all_exit_codes => true}.merge(opts)
-    opts[:prepend_cmds] ? pc = opts.select {|k,v| k == :prepend_cmds} :
-                          pc = {:prepend_cmds => ""}
     case self['platform']
       when /sles-10/
-        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}", [], pc), opts)
+        result = execute("zypper se -i --match-exact #{name}", opts) { |result| result }
         result.stdout =~ /No packages found/ ? (return false) : (return result.exit_code == 0)
       when /sles-/
-        result = exec(Beaker::Command.new("zypper se -i --match-exact #{name}", [], pc), opts)
+        result = execute("zypper se -i --match-exact #{name}", opts) { |result| result }
       when /el-4/
         @logger.debug("Package query not supported on rhel4")
         return false
       when /cisco|fedora|centos|eos|el-/
-        result = exec(Beaker::Command.new("rpm -q #{name}", [], pc), opts)
+        result = execute("rpm -q #{name}", opts) { |result| result }
       when /ubuntu|debian|cumulus/
-        result = exec(Beaker::Command.new("dpkg -s #{name}", [], pc), opts)
+        result = execute("dpkg -s #{name}", opts) { |result| result }
       when /solaris-11/
-        result = exec(Beaker::Command.new("pkg info #{name}", [], pc), opts)
+        result = execute("pkg info #{name}", opts) { |result| result }
       when /solaris-10/
-        result = exec(Beaker::Command.new("pkginfo #{name}", [], pc), opts)
+        result = execute("pkginfo #{name}", opts) { |result| result }
       when /freebsd-9/
-        result = exec(Beaker::Command.new("pkg_info #{name}", [], pc), opts)
+        result = execute("pkg_info #{name}", opts) { |result| result }
       when /freebsd-10/
-        result = exec(Beaker::Command.new("pkg info #{name}", [], pc), opts)
+        result = execute("pkg info #{name}", opts) { |result| result }
       else
         raise "Package #{name} cannot be queried on #{self}"
     end

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(freebsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus)\-.+\-.+$/
+    PLATFORMS = /^(cisco|freebsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus)\-.+\-.+$/
 
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =


### PR DESCRIPTION
This proposed change adds the following
(#1) Support for cisco platforms in  lib/beaker/platform.rb 
(#2) Capability to prepend commands to the various package methods in lib/beaker/host/unix/pkg.rb

Background for (#2): On cisco platforms we need the ability to prepend the following information to the various yum commands when installing, updating or removing RPM packages.
- Linux network namespace information
- Proxy information
- Path information
- Target host or guest information

This update changes all commands in the following method to support prepending commands via addition of the opts argument to methods (check_for_package, install_package, uninstall_package, upgrade_package) while maintaining the current default behavior.