### PR TITLE
(BKR-281) VirtualBox: Add support for storage arrays

### DIFF
--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -5,11 +5,53 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
     super
   end
 
+  # Generate a VM customization string
+  def self.vb_customize(command, args)
+    "      vb.customize ['#{command}', #{args.map{|a| "'#{a.to_s}'"}.join(", ")}]\n"
+  end
+
+  # Generate a VM customization string for the current VM
+  def self.vb_customize_vm(command, args)
+    "      vb.customize ['#{command}', :id, #{args.map{|a| "'#{a.to_s}'"}.join(", ")}]\n"
+  end
+
   def self.provider_vfile_section(host, options)
     provider_section  = ""
     provider_section << "    v.vm.provider :virtualbox do |vb|\n"
     provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{options['vagrant_memsize'] ||= '1024'}']\n"
     provider_section << "      vb.vbguest.auto_update = false" if options[:vbguest_plugin] == 'disable'
+
+    # Guest volume support
+    # - Creates a new AHCI controller with the requisite number of ports,
+    #   the default controller is limited in its number of supported ports (2).
+    #   The AHCI emulation is generic enough for acceptance testing, and
+    #   presents the devices as SCSI devices in /sys/class/scsi_disk.
+    # - Creates the defined volumes in beaker's temporary folder and attaches
+    #   them to the controller in order starting at port 0.  This presents disks
+    #   as 2:0:0:0, 3:0:0:0 ... much like you'd see on commercial storage boxes
+    if host['volumes']
+      provider_section << self.vb_customize_vm('storagectl', [
+        '--name', 'SATA Controller',
+        '--add', 'sata',
+        '--controller', 'IntelAHCI',
+        '--portcount', host['volumes'].length
+      ])
+      host['volumes'].keys.each_with_index do |volume, index|
+        volume_path = "#{host.name}-#{volume}.vdi"
+        provider_section << self.vb_customize('createhd', [
+          '--filename', volume_path,
+          '--size', host['volumes'][volume]['size'],
+        ])
+        provider_section << self.vb_customize_vm('storageattach', [
+          '--storagectl', 'SATA Controller',
+          '--port', index,
+          '--device', 0,
+          '--type', 'hdd',
+          '--medium', volume_path,
+        ])
+      end
+    end
+
     if host['disk_path']
       unless File.exist?(host['disk_path'])
         host['disk_path'] = File.join(host['disk_path'], "#{host.name}.vmdk")


### PR DESCRIPTION
Extends the Vagrant VirtualBox hypervisor to allow per host definitions
of storage volumes, for testing things like ceph and other storage
technologies.

An example nodeset provisions the VM with 3 attached storage volumes
available as sdb, sdc, sdd (on linux systems) at at SCSI addresses
2:0:0:0, 3:0:0:0, 4:0:0:0.  Sizes are specified in MB.

  HOSTS:
    osd0:
      hypervisor: vagrant
      volumes:
        osd0_0:
          size: 10000
        osd0_1:
          size: 10000
        journal:
          size: 1000