### PR TITLE
(BKR-283)/(BKR-262) missing @metadata/@logger accessors for beaker-rspec

### DIFF
--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -18,6 +18,7 @@ module Beaker
     # * the module {Beaker::DSL::Roles} that provides access to the various hosts implementing
     #   {Beaker::Host}'s interface to act upon
     # * the module {Beaker::DSL::Wrappers} the provides convenience methods for {Beaker::DSL::Command} creation
+    # * a method *metadata* that yields a hash
     #
     #
     module Helpers

--- a/lib/beaker/dsl/helpers/test_helpers.rb
+++ b/lib/beaker/dsl/helpers/test_helpers.rb
@@ -10,7 +10,7 @@ module Beaker
         #
         # @return [String] Test name, or nil if it hasn't been set
         def current_test_name()
-          @metadata[:case] && @metadata[:case][:name] ? @metadata[:case][:name] : nil
+          metadata[:case] && metadata[:case][:name] ? metadata[:case][:name] : nil
         end
 
         # Gets the currently executing test's filename, which is set from the
@@ -22,7 +22,7 @@ module Beaker
         #
         # @return [String] Test filename, or nil if it hasn't been set
         def current_test_filename()
-          @metadata[:case] && @metadata[:case][:file_name] ? @metadata[:case][:file_name] : nil
+          metadata[:case] && metadata[:case][:file_name] ? metadata[:case][:file_name] : nil
         end
 
         # Gets the currently executing test's currently executing step name.
@@ -30,7 +30,7 @@ module Beaker
         #
         # @return [String] Step name, or nil if it hasn't been set
         def current_step_name()
-          @metadata[:step] && @metadata[:step][:name] ? @metadata[:step][:name] : nil
+          metadata[:step] && metadata[:step][:name] ? metadata[:step][:name] : nil
         end
 
         # Sets the currently executing test's name.
@@ -40,8 +40,8 @@ module Beaker
         # @return nil
         # @api private
         def set_current_test_name(name)
-          @metadata[:case] ||= {}
-          @metadata[:case][:name] = name
+          metadata[:case] ||= {}
+          metadata[:case][:name] = name
         end
 
         # Sets the currently executing test's filename.
@@ -51,8 +51,8 @@ module Beaker
         # @return nil
         # @api private
         def set_current_test_filename(filename)
-          @metadata[:case] ||= {}
-          @metadata[:case][:file_name] = filename
+          metadata[:case] ||= {}
+          metadata[:case][:file_name] = filename
         end
 
         # Sets the currently executing step's name.
@@ -62,8 +62,8 @@ module Beaker
         # @return nil
         # @api private
         def set_current_step_name(name)
-          @metadata[:step] ||= {}
-          @metadata[:step][:name] = name
+          metadata[:step] ||= {}
+          metadata[:step][:name] = name
         end
 
       end

--- a/lib/beaker/dsl/install_utils/puppet_utils.rb
+++ b/lib/beaker/dsl/install_utils/puppet_utils.rb
@@ -602,9 +602,9 @@ module Beaker
                   fedora_prefix, version, repo, arch ]
 
               unless link_exists?( link )
-                @logger.debug("couldn't find link at '#{repo}', falling back to next option...")
+                logger.debug("couldn't find link at '#{repo}', falling back to next option...")
               else
-                @logger.debug("found link at '#{repo}'")
+                logger.debug("found link at '#{repo}'")
                 break
               end
             end
@@ -646,16 +646,16 @@ module Beaker
               repo_path = "/root/#{package_name}/#{codename}/#{repo}"
               repo_check = on(host, "[[ -d #{repo_path} ]]", :acceptable_exit_codes => [0,1])
               if repo_check.exit_code == 0
-                @logger.debug("found repo at '#{repo_path}'")
+                logger.debug("found repo at '#{repo_path}'")
                 repo_name = repo
                 break
               else
-                @logger.debug("couldn't find repo at '#{repo_path}', falling back to next option...")
+                logger.debug("couldn't find repo at '#{repo_path}', falling back to next option...")
               end
             end
             if repo_name.nil?
               repo_name = 'main'
-              @logger.debug("using default repo '#{repo_name}'")
+              logger.debug("using default repo '#{repo_name}'")
             end
 
             search = "deb\\s\\+http:\\/\\/#{hostname}.*$"

--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -33,6 +33,10 @@ module Beaker
     # an instance of {Beaker::Logger}.
     attr_accessor :logger
 
+    # Necessary for many methods in {Beaker::DSL::Helpers}.  Assumed to be 
+    # a hash.
+    attr_accessor :metadata
+
     #The full log for this test
     attr_accessor :sublog
 

--- a/spec/beaker/dsl/helpers/test_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/test_helpers_spec.rb
@@ -17,60 +17,60 @@ describe ClassMixedWithDSLHelpers do
 
   describe '#current_test_name' do
     it 'returns nil if the case is undefined' do
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_name ).to be_nil
     end
 
     it 'returns nil if the name is undefined' do
       @metadata = { :case => {} }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_name ).to be_nil
     end
 
     it 'returns the set value' do
       name = 'holyGrail_testName'
       @metadata = { :case => { :name => name } }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_name ).to be === name
     end
   end
 
   describe '#current_test_filename' do
     it 'returns nil if the case is undefined' do
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_filename ).to be_nil
     end
 
     it 'returns nil if the name is undefined' do
       @metadata = { :case => {} }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_filename ).to be_nil
     end
 
     it 'returns the set value' do
       name = 'holyGrail_testFilename'
       @metadata = { :case => { :file_name => name } }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_test_filename ).to be === name
     end
   end
 
   describe '#current_step_name' do
     it 'returns nil if the step is undefined' do
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_step_name ).to be_nil
     end
 
     it 'returns nil if the name is undefined' do
       @metadata = { :step => {} }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_step_name ).to be_nil
     end
 
     it 'returns the set value' do
       name = 'holyGrail_stepName'
       @metadata = { :step => { :name => name } }
-      subject.instance_variable_set( :@metadata, metadata )
+      allow(subject).to receive(:metadata).and_return(metadata)
       expect( subject.current_step_name ).to be === name
     end
   end

--- a/spec/beaker/dsl/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/puppet_utils_spec.rb
@@ -14,6 +14,7 @@ class ClassMixedWithDSLInstallUtils
 end
 
 describe ClassMixedWithDSLInstallUtils do
+  let(:metadata)      { @metadata ||= {} }
   let(:presets)       { Beaker::Options::Presets.new }
   let(:opts)          { presets.presets.merge(presets.env_vars) }
   let(:basic_hosts)   { make_hosts( { :pe_ver => '3.0',
@@ -82,6 +83,7 @@ describe ClassMixedWithDSLInstallUtils do
       cmd         = 'cd /path/to/repo/name && git describe || true'
       logger = double.as_null_object
 
+      allow( subject ).to receive( :metadata ).and_return( metadata )
       expect( subject ).to receive( :logger ).and_return( logger )
       expect( subject ).to receive( :on ).with( host, cmd ).and_yield
       expect( subject ).to receive( :stdout ).and_return( '2' )
@@ -130,6 +132,7 @@ describe ClassMixedWithDSLInstallUtils do
       host = { 'platform' => 'debian' }
       logger = double.as_null_object
 
+      allow( subject ).to receive( :metadata ).and_return( metadata )
       expect( subject ).to receive( :logger ).exactly( 3 ).times.and_return( logger )
       expect( subject ).to receive( :on ).exactly( 4 ).times
 
@@ -147,6 +150,7 @@ describe ClassMixedWithDSLInstallUtils do
       cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:rev]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
       host   = { 'platform' => 'debian' }
       logger = double.as_null_object
+      allow( subject ).to receive( :metadata ).and_return( metadata )
       expect( subject ).to receive( :logger ).exactly( 3 ).times.and_return( logger )
       expect( subject ).to receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
       # this is the the command we want to test
@@ -169,6 +173,7 @@ describe ClassMixedWithDSLInstallUtils do
       cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:depth_branch]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
       host   = { 'platform' => 'debian' }
       logger = double.as_null_object
+      allow( subject ).to receive( :metadata ).and_return( metadata )
       expect( subject ).to receive( :logger ).exactly( 3 ).times.and_return( logger )
       expect( subject ).to receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
       # this is the the command we want to test

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -7,14 +7,20 @@ end
 
 describe ClassMixedWithDSLStructure do
   include Beaker::DSL::Assertions
-  let(:logger) { double }
+
+  let (:logger) { double }
+  let (:metadata) { @metadata ||= {} }
+
+  before :each do
+    allow( subject ).to receive(:metadata).and_return(metadata)
+  end
+
   describe '#step' do
     it 'requires a name' do
       expect { subject.step do; end }.to raise_error ArgumentError
     end
 
     it 'notifies the logger' do
-      subject.instance_variable_set(:@metadata, {})
       allow( subject ).to receive( :set_current_step_name )
       expect( subject ).to receive( :logger ).and_return( logger )
       expect( logger ).to receive( :notify )
@@ -22,7 +28,6 @@ describe ClassMixedWithDSLStructure do
     end
 
     it 'yields if a block is given' do
-      subject.instance_variable_set(:@metadata, {})
       expect( subject ).to receive( :logger ).and_return( logger )
       allow(  subject ).to receive( :set_current_step_name )
       expect( logger ).to receive( :notify )
@@ -33,29 +38,27 @@ describe ClassMixedWithDSLStructure do
     end
 
     it 'sets the metadata' do
-      subject.instance_variable_set(:@metadata, {})
       allow( subject ).to receive( :logger ).and_return( logger )
       allow( logger ).to receive( :notify )
       step_name = 'pierceBrosnanTests'
       subject.step step_name
-      expect( subject.instance_variable_get(:@metadata)[:step][:name] ).to be === step_name
+      expect( metadata[:step][:name] ).to be === step_name
     end
   end
 
   describe '#test_name' do
+
     it 'requires a name' do
       expect { subject.test_name do; end }.to raise_error ArgumentError
     end
 
     it 'notifies the logger' do
-      subject.instance_variable_set(:@metadata, {})
       expect( subject ).to receive( :logger ).and_return( logger )
       expect( logger ).to receive( :notify )
       subject.test_name 'blah'
     end
 
     it 'yields if a block is given' do
-      subject.instance_variable_set(:@metadata, {})
       expect( subject ).to receive( :logger ).and_return( logger )
       expect( logger ).to receive( :notify )
       expect( subject ).to receive( :foo )
@@ -65,12 +68,11 @@ describe ClassMixedWithDSLStructure do
     end
 
     it 'sets the metadata' do
-      subject.instance_variable_set(:@metadata, {})
       allow( subject ).to receive( :logger ).and_return( logger )
       allow( logger ).to receive( :notify )
       test_name = '15-05-08\'s weather is beautiful'
       subject.test_name test_name
-      expect( subject.instance_variable_get(:@metadata)[:case][:name] ).to be === test_name
+      expect( metadata[:case][:name] ).to be === test_name
     end
   end
 


### PR DESCRIPTION
- beaker-rspec needs access to @metadata, broken with beaker 2.12.0
- Beaker-rspec missing @logger accessor

Added both logger and metadata accessors so that beaker-rspec can be
repaired to work with latest beaker releases.