### PR TITLE
(BKR-300) Always manage_etc_hosts in cloud-init

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -100,6 +100,7 @@ module Beaker
           :image_ref  => image(host[:image]).id,
           :nics       => [ {'net_id' => network(@options[:openstack_network]).id } ],
           :name       => host[:vmhostname],
+          :user_data  => "#cloud-config\nmanage_etc_hosts: true\n",
         }
         options[:key_name] = key_name(host)
         vm = @compute_client.servers.create(options)


### PR DESCRIPTION
Some cloud-init configuration does not have `manage_etc_host: true` so the VM does not have a valid FQDN which is quite annoying because some services refuse to start without a valid FQDN.

This patch force cloud-init to manage `/etc/host` and thus set a valid fqdn.