### PR TITLE
(BKR-239) Remove dependency on puppet-dashboard rake tasks for...

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -345,7 +345,10 @@ module Beaker
               if host['roles'].include?('frictionless') &&  (! version_is_less(version, '3.2.0'))
                 # If We're *not* running the classic installer, we want
                 # to make sure the master has packages for us.
-                deploy_frictionless_to_master(host)
+                # Only for pre 3.99
+                if version_is_less(version, '3.99')
+                  deploy_frictionless_to_master(host)
+                end
                 on host, installer_cmd(host, opts)
               elsif host['platform'] =~ /osx|eos/
                 # If we're not frictionless, we need to run the OSX special-case


### PR DESCRIPTION
... shallow gravy.

- wrap rake test call in version check, only run if pre 3.99