### PR TITLE
(BKR-304) Prevent redundant copying when doing scp

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -376,6 +376,9 @@ module Beaker
 
         # copy each file to the host
         dir_source.each do |s|
+          # Copy files, not directories (as they are copied recursively)
+          next if File.directory?(s)
+
           s_path = Pathname.new(s)
           if s_path.absolute?
             file_path = File.join(target, File.dirname(s).gsub(/#{Regexp.escape(File.dirname(File.absolute_path(source)))}/,''))


### PR DESCRIPTION
Before this commit, the method Beaker::Host.do_scp_to would request
copying of both directories and files from the underlying scp
connection. This resulted in a lot of redundant copying since the
scp connection, when handed a directory, would copy it recursively.

This commit ensures that only the files are copied. This is safe
because all remote directories are already created in a preceding
step.