### PR TITLE
(BKR-306) Overwriting rsync ignore options adds on every iteration which eventually fails

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -454,10 +454,10 @@ module Beaker
       end
 
       if opts.has_key?(:ignore) and not opts[:ignore].empty?
-        opts[:ignore].map! do |value|
+        ignoreargs = opts[:ignore].map do |value|
           "--exclude '#{value}'"
         end
-        rsync_args << opts[:ignore].join(' ')
+        rsync_args << ignoreargs.join(' ')
       end
 
       # We assume that the *contents* of the directory 'from_path' needs to be

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -579,6 +579,7 @@ module Beaker
         host.do_rsync_to *args
 
         expect(Rsync.host).to eq('root@host.example.org')
+        expect(args[2][:ignore]).to eq(['.bundle'])
       end
 
       it 'throws an IOError when the file given doesn\'t exist' do


### PR DESCRIPTION
In do_rsync_to, map bang is called on the ignore options, which adds to the array on
every iteration, which after 3 goes causes the rsync to fail.  This patch fixes that.

    puppetmaster executed in 0.01 seconds
    Using rsync to transfer /var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules to /etc/puppet/modules/
    rsync: localhost:/var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules/ to root@docker:/etc/puppet/modules/ {:ignore => ["--exclude '.bundle'", "--exclude '.git'", "--exclude '.idea'", "--exclude '.vagrant'", "--exclude '.vendor'", "--exclude 'vendor'", "--exclude 'acceptance'", "--exclude 'bundle'", "--exclude 'spec'", "--exclude 'tests'", "--exclude 'log'", "--exclude '.'", "--exclude '..'"]}

    puppetserver executed in 0.01 seconds
    Using rsync to transfer /var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules to /etc/puppet/modules/
    rsync: localhost:/var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules/ to root@docker:/etc/puppet/modules/ {:ignore => ["--exclude '--exclude '.bundle''", "--exclude '--exclude '.git''", "--exclude '--exclude '.idea''", "--exclude '--exclude '.vagrant''", "--exclude '--exclude '.vendor''", "--exclude '--exclude 'vendor''", "--exclude '--exclude 'acceptance''", "--exclude '--exclude 'bundle''", "--exclude '--exclude 'spec''", "--exclude '--exclude 'tests''", "--exclude '--exclude 'log''", "--exclude '--exclude '.''", "--exclude '--exclude '..''", "--exclude '.'", "--exclude '..'"]}

    puppetserverproxy executed in 0.02 seconds
    Using rsync to transfer /var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules to /etc/puppet/modules/
    rsync: localhost:/var/lib/jenkins/workspace/gitrepo_build_cda_core-r10k/modules/ to root@docker:/etc/puppet/modules/ {:ignore => ["--exclude '--exclude '--exclude '.bundle'''", "--exclude '--exclude '--exclude '.git'''", "--exclude '--exclude '--exclude '.idea'''", "--exclude '--exclude '--exclude '.vagrant'''", "--exclude '--exclude '--exclude '.vendor'''", "--exclude '--exclude '--exclude 'vendor'''", "--exclude '--exclude '--exclude 'acceptance'''", "--exclude '--exclude '--exclude 'bundle'''", "--exclude '--exclude '--exclude 'spec'''", "--exclude '--exclude '--exclude 'tests'''", "--exclude '--exclude '--exclude 'log'''", "--exclude '--exclude '--exclude '.'''", "--exclude '--exclude '--exclude '..'''", "--exclude '--exclude '.''", "--exclude '--exclude '..''", "--exclude '.'", "--exclude '..'"]}