### PR TITLE
(BKR-307) Add Beaker::Platform support for debian jessie (aka 8)

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -7,10 +7,14 @@ module Beaker
 
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
-      { :debian => { "wheezy"  => "7",
+      { :debian => { "jessie"  => "8",
+                     "wheezy"  => "7",
                      "squeeze" => "6",
                    },
-        :ubuntu => { "trusty"  => "1404",
+        :ubuntu => { "wily"    => "1510",
+                     "vivid"   => "1504",
+                     "utopic"  => "1410",
+                     "trusty"  => "1404",
                      "saucy"   => "1310",
                      "raring"  => "1304",
                      "quantal" => "1210",


### PR DESCRIPTION
@anodelman @melissa @camlow325 
This should fix the debian8 failure on the puppet-server pipeline. I believe the Beaker team will be releasing a new dot release this afternoon, hopefully this patch will be included which would minimize the effort necessary to get the debian8 cells green on the puppet-server master branch pipeline.