### PR TITLE
[BKR-301] add warning when empty fog file is encountered

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -28,7 +28,11 @@ module Beaker
       creds = {}
 
       if fog = read_fog_file(dot_fog)
-        creds[:vmpooler_token] = fog[:default][:vmpooler_token]
+        if fog[:default] && fog[:default][:vmpooler_token]
+          creds[:vmpooler_token] = fog[:default][:vmpooler_token]
+        else
+          @logger.warn "Credentials file (#{dot_fog}) is missing a :default section with a :vmpooler_token value; proceeding without authentication"
+        end
       else
         @logger.warn "Credentials file (#{dot_fog}) is empty; proceeding without authentication"
       end

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -15,6 +15,8 @@ module Beaker
       Errno::ENETUNREACH,
     ]
 
+    attr_reader :options, :logger, :hosts, :credentials
+
     def initialize(vmpooler_hosts, options)
       @options = options
       @logger = options[:logger]
@@ -26,7 +28,7 @@ module Beaker
       creds = {}
 
       begin
-        fog = YAML.load_file(dot_fog)
+        fog = read_fog_file(dot_fog)
         default = fog[:default]
 
         creds[:vmpooler_token] = default[:vmpooler_token]
@@ -35,6 +37,10 @@ module Beaker
       end
 
       creds
+    end
+
+    def read_fog_file(dot_fog = '.fog')
+      YAML.load_file(dot_fog)
     end
 
     def check_url url

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -27,15 +27,16 @@ module Beaker
     def load_credentials(dot_fog = '.fog')
       creds = {}
 
-      begin
-        fog = read_fog_file(dot_fog)
-        default = fog[:default]
-
-        creds[:vmpooler_token] = default[:vmpooler_token]
-      rescue Errno::ENOENT
-        @logger.warn "Credentials file (#{@options[:dot_fog]}) not found; proceeding without authentication"
+      if fog = read_fog_file(dot_fog)
+        creds[:vmpooler_token] = fog[:default][:vmpooler_token]
+      else
+        @logger.warn "Credentials file (#{dot_fog}) is empty; proceeding without authentication"
       end
 
+      creds
+
+    rescue Errno::ENOENT
+      @logger.warn "Credentials file (#{dot_fog}) not found; proceeding without authentication"
       creds
     end
 

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -7,13 +7,14 @@ module Beaker
       vms = make_hosts()
       MockVsphereHelper.set_config( fog_file_contents )
       MockVsphereHelper.set_vms( vms )
-     stub_const( "VsphereHelper", MockVsphereHelper )
-     stub_const( "Net", MockNet )
+      stub_const( "VsphereHelper", MockVsphereHelper )
+      stub_const( "Net", MockNet )
       allow( JSON ).to receive( :parse ) do |arg|
         arg
       end
       allow( Socket ).to receive( :getaddrinfo ).and_return( true )
-      allow_any_instance_of( Beaker::Vmpooler ).to receive(:load_credentials).and_return(fog_file_contents)
+      allow_any_instance_of( Beaker::Vmpooler ).to \
+        receive(:load_credentials).and_return(fog_file_contents)
     end
 
     describe '#get_template_url' do
@@ -23,7 +24,7 @@ module Beaker
         uri = vmpooler.get_template_url("http://pooling.com", "template")
         expect( uri ).to be === "http://pooling.com/vm/template"
       end
-      
+
       it 'adds a missing scheme to a given URL' do
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
         uri = vmpooler.get_template_url("pooling.com", "template")
@@ -39,13 +40,11 @@ module Beaker
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
         expect{ vmpooler.get_template_url("pooling.com", "t!e&m*p(l\\a/t e")}.to raise_error ArgumentError
       end
-      
     end
 
     describe "#provision" do
 
-      it 'provisions hosts from the pool' do 
-
+      it 'provisions hosts from the pool' do
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
         allow( vmpooler ).to receive( :require ).and_return( true )
         allow( vmpooler ).to receive( :sleep ).and_return( true )
@@ -55,9 +54,7 @@ module Beaker
         hosts.each do | host |
           expect( host['vmhostname'] ).to be === 'pool'
         end
-        
       end
-
     end
 
     describe "#cleanup" do

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -75,10 +75,35 @@ module Beaker
           expect( vm.runtime.powerState ).to be === "poweredOn" #handed back to the pool, stays on
         end
       end
-
-
     end
-
   end
 
+  describe Vmpooler do
+
+    before :each do
+      vms = make_hosts()
+      MockVsphereHelper.set_config( fog_file_contents )
+      MockVsphereHelper.set_vms( vms )
+      stub_const( "VsphereHelper", MockVsphereHelper )
+      stub_const( "Net", MockNet )
+      allow( JSON ).to receive( :parse ) do |arg|
+        arg
+      end
+      allow( Socket ).to receive( :getaddrinfo ).and_return( true )
+    end
+
+    describe "#load_credentials" do
+
+      it 'continues without credentials when fog file is missing' do
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:read_fog_file).and_raise(Errno::ENOENT.new)
+
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect( vmpooler.credentials ).to be == {}
+      end
+
+      it 'continues without credentials when fog file is empty' do
+      end
+    end
+  end
 end

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -103,6 +103,11 @@ module Beaker
       end
 
       it 'continues without credentials when fog file is empty' do
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:read_fog_file).and_return(false)
+
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect( vmpooler.credentials ).to be == {}
       end
     end
   end

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -109,6 +109,36 @@ module Beaker
         vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
         expect( vmpooler.credentials ).to be == {}
       end
+
+      it 'continues without credentials when fog file contains no :default section' do
+        data = { :some => { :other => :data } }
+
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:read_fog_file).and_return(data)
+
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect( vmpooler.credentials ).to be == { }
+      end
+
+      it 'continues without credentials when fog file :default section has no :vmpooler_token' do
+        data = { :default => { :something_else => "TOKEN" } }
+
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:read_fog_file).and_return(data)
+
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect( vmpooler.credentials ).to be == { }
+      end
+
+      it 'stores vmpooler token when found in fog file' do
+        data = { :default => { :vmpooler_token => "TOKEN" } }
+
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:read_fog_file).and_return(data)
+
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        expect( vmpooler.credentials ).to be == { :vmpooler_token => "TOKEN" }
+      end
     end
   end
 end


### PR DESCRIPTION
![](https://github-images.s3.amazonaws.com/skitch/skitched-20150603-161719.jpg)

When beaker's vmpooler is provided with an empty `~/.fog` file, a failure with a cryptic message has been the result.  This changes that behavior to be more user-friendly (continuing without authentication, posting a friendly warning); as well as improving test coverage in this area, and making other failures more user-friendly as well.

/cc @anodelman @kevpl 