### PR TITLE
(BKR-311) Allow AWS IP Fallback

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -473,7 +473,7 @@ module Beaker
       @hosts.each do |host|
         @logger.notify("aws-sdk: Populate DNS for #{host.name}")
         instance = host['instance']
-        host['ip'] = instance.ip_address
+        host['ip'] = instance.ip_address ? instance.ip_address : instance.private_ip_address
         host['private_ip'] = instance.private_ip_address
         host['dns_name'] = instance.dns_name
         @logger.notify("aws-sdk: name: #{host.name} ip: #{host['ip']} private_ip: #{host['private_ip']} dns_name: #{instance.dns_name}")

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -92,5 +92,70 @@ module Beaker
         expect { aws.group_id([]) }.to raise_error(ArgumentError, "Ports list cannot be nil or empty")
       end
     end
+
+    describe '#populate_dns' do
+      let( :vpc_instance ) { {ip_address: nil, private_ip_address: "vpc_private_ip", dns_name: "vpc_dns_name"} }
+      let( :ec2_instance ) { {ip_address: "ec2_public_ip", private_ip_address: "ec2_private_ip", dns_name: "ec2_dns_name"} }
+
+      context 'on a public EC2 instance' do
+        before :each do
+          @hosts.each {|host| host['instance'] = make_instance ec2_instance}
+        end
+
+        it 'sets host ip to instance.ip_address' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['ip']).to eql(ec2_instance[:ip_address])
+          end
+        end
+
+        it 'sets host private_ip to instance.private_ip_address' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['private_ip']).to eql(ec2_instance[:private_ip_address])
+          end
+        end
+
+        it 'sets host dns_name to instance.dns_name' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['dns_name']).to eql(ec2_instance[:dns_name])
+          end
+        end
+      end
+
+      context 'on a VPC based instance' do
+        before :each do
+          @hosts.each {|host| host['instance'] = make_instance vpc_instance}
+        end
+
+        it 'sets host ip to instance.private_ip_address' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['ip']).to eql(vpc_instance[:private_ip_address])
+          end
+        end
+
+        it 'sets host private_ip to instance.private_ip_address' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['private_ip']).to eql(vpc_instance[:private_ip_address])
+          end
+        end
+
+        it 'sets host dns_name to instance.dns_name' do
+          aws.populate_dns();
+          hosts =  aws.instance_variable_get( :@hosts )
+          hosts.each do |host|
+            expect(host['dns_name']).to eql(vpc_instance[:dns_name])
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -100,4 +100,8 @@ module HostHelpers
     hosts
   end
 
+  def make_instance instance_data = {}
+    OpenStruct.new instance_data
+  end
+
 end


### PR DESCRIPTION
When bringing up an instance in a VPC there won't always be a public address.  This allows fallback to assign the private ip to host['ip'] for instances without a public address.

When the hypervisor is set to ec2, beaker can't currently connect to an instance that we're provisioning unless we have provisioned first then set a R53 public ip for subsequent runs.  This change would allow users inside a VPC to achieve complete end-to-end beaker runs from either a bastion or across whatever VPN solution they have set up.

Either insight on anything we might be missing or a merge would both be much appreciated!  Thanks :)
