### PR TITLE
(BKR-313) Beaker is using pe-httpd as the puppet master service...

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_defaults.rb
+++ b/lib/beaker/dsl/install_utils/pe_defaults.rb
@@ -79,6 +79,12 @@ module Beaker
             host['group'] = 'pe-puppet'
           end
           host['type'] = 'pe'
+          # newer pe requires a different puppetservice name, set it here on the master
+          if host['roles'].include?('master')
+            if host['pe_ver'] and (not version_is_less(host['pe_ver'], '3.4'))
+              host['puppetservice'] = 'pe-puppetserver'
+            end
+          end
         end
 
         # Add the appropriate pe defaults to an array of hosts

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -359,10 +359,6 @@ module Beaker
           unless masterless
             pre30database = version_is_less(opts[:pe_ver] || database['pe_ver'], '3.0')
             pre30master = version_is_less(opts[:pe_ver] || master['pe_ver'], '3.0')
-
-            unless version_is_less(opts[:pe_ver] || master['pe_ver'], '3.4')
-              master['puppetservice'] = 'pe-puppetserver'
-            end
           end
 
           # Set PE distribution for all the hosts, create working dir

--- a/spec/beaker/dsl/install_utils/pe_defaults_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_defaults_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLInstallUtils
+  include Beaker::DSL::InstallUtils
+  include Beaker::DSL::Wrappers
+  include Beaker::DSL::Helpers
+  include Beaker::DSL::Structure
+  include Beaker::DSL::Roles
+  include Beaker::DSL::Patterns
+
+  attr_accessor :hosts
+
+  def logger
+    @logger ||= RSpec::Mocks::Double.new('logger').as_null_object
+  end
+end
+
+describe ClassMixedWithDSLInstallUtils do
+  let(:presets)       { Beaker::Options::Presets.new }
+  let(:opts)          { presets.presets.merge(presets.env_vars) }
+  let(:basic_hosts)   { make_hosts( { :pe_ver => @pe_ver || '3.0',
+                                       :platform => 'linux',
+                                       :roles => [ 'agent' ] }, 4 ) }
+  let(:hosts)         { basic_hosts[0][:roles] = ['master', 'database', 'dashboard']
+                        basic_hosts[1][:platform] = 'windows'
+                        basic_hosts[2][:platform] = 'osx-10.9-x86_64'
+                        basic_hosts[3][:platform] = 'eos'
+                        basic_hosts  }
+  let(:hosts_sorted)  { [ hosts[1], hosts[0], hosts[2], hosts[3] ] }
+  let(:winhost)       { make_host( 'winhost', { :platform => 'windows',
+                                                :pe_ver => '3.0',
+                                                :working_dir => '/tmp' } ) }
+  let(:machost)       { make_host( 'machost', { :platform => 'osx-10.9-x86_64',
+                                                :pe_ver => '3.0',
+                                                :working_dir => '/tmp' } ) }
+  let(:unixhost)      { make_host( 'unixhost', { :platform => 'linux',
+                                                 :pe_ver => '3.0',
+                                                 :working_dir => '/tmp',
+                                                 :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-debian-7-i386' } ) }
+  let(:eoshost)       { make_host( 'eoshost', { :platform => 'eos',
+                                                :pe_ver => '3.0',
+                                                :working_dir => '/tmp',
+                                                :dist => 'puppet-enterprise-3.7.1-rc0-78-gffc958f-eos-4-i386' } ) }
+
+  describe '#add_platform_pe_defaults' do
+    it 'sets puppetservice on master to be pe-httpd on pre-3.4 pe' do
+      @pe_ver = '3.3'
+      subject.add_platform_pe_defaults(hosts[0], 'unix')
+      expect(hosts[0]['puppetservice']).to be == 'pe-httpd'
+
+    end
+
+    it 'sets puppetservice on master to be pe-puppetserver on post-3.4 pe' do
+      @pe_ver = '3.7'
+      subject.add_platform_pe_defaults(hosts[0], 'unix')
+      expect(hosts[0]['puppetservice']).to be == 'pe-puppetserver'
+    end
+
+  end
+
+end


### PR DESCRIPTION
... in method 'with_puppet_running_on'

- use pe-httpd pre 3.4, pe-puppetserver post 3.4