### PR TITLE
(BKR-326) Fixes enabling user environments

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -521,7 +521,7 @@ module Beaker
           host.exec(Command.new("stopsrc -g ssh"))
           host.exec(Command.new("startsrc -g ssh"))
         when /freebsd/
-          host.echo_to_file('\nPermitUserEnvironment yes', '/etc/ssh/sshd_config')
+          host.exec(Command.new("sudo perl -pi -e 's/^#?PermitUserEnvironment no/PermitUserEnvironment yes/' /etc/ssh/sshd_config"), {:pty => true} )
           host.exec(Command.new("sudo /etc/rc.d/sshd restart"))
         end
 

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -13,7 +13,7 @@ module Beaker
     SLEEPWAIT = 5
     TRIES = 5
     UNIX_PACKAGES = ['curl', 'ntpdate']
-    FREEBSD_PACKAGES = ['curl']
+    FREEBSD_PACKAGES = ['curl', 'perl5']
     WINDOWS_PACKAGES = ['curl']
     PSWINDOWS_PACKAGES = []
     SLES10_PACKAGES = ['curl']

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -46,6 +46,11 @@ describe Beaker do
     "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""
   ], true
 
+  # FreeBSD
+  it_should_behave_like 'enables_root_login', 'freesbd', [
+    "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""
+  ], true
+
   it_should_behave_like 'enables_root_login', 'osx', [
     "sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' /etc/sshd_config",
     "sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /etc/sshd_config"
@@ -538,6 +543,14 @@ describe Beaker do
         "startsrc -g ssh"
       ]
       set_env_helper('aix', commands)
+    end
+
+    it "can set the environment on a FreeBSD host" do
+      commands = [
+        "sudo perl -pi -e 's/^#?PermitUserEnvironment no/PermitUserEnvironment yes/' /etc/ssh/sshd_config",
+        "sudo /etc/rc.d/sshd restart",
+      ]
+      set_env_helper('freebsd', commands)
     end
 
     def set_env_helper(platform_name, host_specific_commands_array)


### PR DESCRIPTION
Currently this step uses `echo_to_file`, which actually overwrites the file with the one line. This changes it to use the perl regex instead.