### PR TITLE
(BKR-325) AIO detection for install_puppet() and install_pe()

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -40,7 +40,7 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def configure_foss_defaults_on( hosts )
           block_on hosts do |host|
-            if host['type'] && host['type'] =~ /aio/
+            if (host[:version] && (not version_is_less(host[:version], '4.0'))) or host['type'] && host['type'] =~ /aio/
               # add foss defaults to host
               add_aio_defaults_on(host)
             else
@@ -250,6 +250,8 @@ module Beaker
                   raise "install_puppet() called for unsupported platform '#{host['platform']}' on '#{host.name}'"
                 end
               end
+
+              host[:version] = opts[:version]
 
               # Certain install paths may not create the config dirs/files needed
               on host, "mkdir -p #{host['puppetpath']}" unless host[:type] =~ /aio/
@@ -472,6 +474,7 @@ module Beaker
             install_a_puppet_msi_on(host, opts)
 
           end
+          configure_foss_defaults_on( host )
         end
         alias_method :install_puppet_from_msi, :install_puppet_from_msi_on
 

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -26,7 +26,7 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def configure_pe_defaults_on( hosts )
           block_on hosts do |host|
-            if host['type'] && host['type'] =~ /aio/
+            if (host[:pe_ver] && (not version_is_less(host[:pe_ver], '4.0'))) or (host['type'] && host['type'] =~ /aio/)
               # add pe defaults to host
               add_aio_defaults_on(host)
             else

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -47,6 +47,56 @@ describe ClassMixedWithDSLInstallUtils do
                                                 :dist => 'puppet-enterprise-3.7.1-rc0-78-gffc958f-eos-4-i386' } ) }
 
 
+  context '#configure_foss_defaults_on' do
+    it 'uses aio paths for hosts of type aio' do
+      hosts.each do |host|
+        host[:type] = 'aio'
+      end
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_foss_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts of type foss' do
+      hosts.each do |host|
+        host[:type] = 'foss'
+      end
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_foss_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts with no type and version < 4.0' do
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_foss_defaults_on( hosts )
+    end
+
+    it 'uses aio paths for hosts of version >= 4.0' do
+      hosts.each do |host|
+        host[:version] = '4.0'
+      end
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_foss_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts of version < 4.0' do
+      hosts.each do |host|
+        host[:version] = '3.8'
+      end
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_foss_defaults_on( hosts )
+    end
+
+  end
+
   context 'extract_repo_info_from' do
     [{ :protocol => 'git', :path => 'git://github.com/puppetlabs/project.git' },
      { :protocol => 'ssh', :path => 'git@github.com:puppetlabs/project.git' },

--- a/spec/beaker/dsl/install_utils/pe_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_utils_spec.rb
@@ -41,6 +41,55 @@ describe ClassMixedWithDSLInstallUtils do
                                                 :pe_ver => '3.0',
                                                 :working_dir => '/tmp',
                                                 :dist => 'puppet-enterprise-3.7.1-rc0-78-gffc958f-eos-4-i386' } ) }
+  context '#configure_pe_defaults_on' do
+    it 'uses aio paths for hosts of type aio' do
+      hosts.each do |host|
+        host[:type] = 'aio'
+      end
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_pe_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts of type pe' do
+      hosts.each do |host|
+        host[:type] = 'pe'
+      end
+      expect(subject).to receive(:add_pe_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_pe_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts with no type and version < 4.0' do
+      expect(subject).to receive(:add_pe_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_pe_defaults_on( hosts )
+    end
+
+    it 'uses aio paths for hosts of version >= 4.0' do
+      hosts.each do |host|
+        host[:pe_ver] = '4.0'
+      end
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_pe_defaults_on( hosts )
+    end
+
+    it 'uses foss paths for hosts of version < 4.0' do
+      hosts.each do |host|
+        host[:pe_ver] = '3.8'
+      end
+      expect(subject).to receive(:add_pe_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
+
+      subject.configure_pe_defaults_on( hosts )
+    end
+
+  end
 
   describe 'sorted_hosts' do
     it 'can reorder so that the master comes first' do
@@ -351,6 +400,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :create_remote_file ).and_return( true )
       allow( subject ).to receive( :stop_agent_on ).and_return( true )
       allow( subject ).to receive( :version_is_less ).with(anything, '3.2.0').exactly(hosts.length + 1).times.and_return( false )
+      allow( subject ).to receive( :version_is_less ).with(anything, '4.0').exactly(hosts.length + 1).times.and_return( true )
 
       expect( subject ).to receive( :on ).with( hosts[0], /puppet-enterprise-installer/ ).once
       expect( subject ).to receive( :create_remote_file ).with( hosts[0], /answers/, /q/ ).once


### PR DESCRIPTION
- check the pe_ver/version to see if aio pathing should be installed
  instead of foss/pe