### PR TITLE
(BKR-314) Ensure install_puppetlabs_release_repo is idempotent for EL

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -725,7 +725,7 @@ module Beaker
             rpm = "puppetlabs-release%s-%s-%s.noarch.rpm" % [repo_name, variant, version]
             remote = URI.join( options[:release_yum_repo_url], rpm )
 
-            on host, "rpm -ivh #{remote}"
+            on host, "rpm --replacepkgs -ivh #{remote}"
 
           when /^(debian|ubuntu|cumulus)$/
             deb = "puppetlabs-release%s-%s.deb" % [repo_name, codename]

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -387,7 +387,7 @@ describe ClassMixedWithDSLInstallUtils do
       let( :platform ) { Beaker::Platform.new('el-7-i386') }
 
       it "installs an rpm" do
-        expect(subject).to receive(:on).with( host, /rpm .*/ ).ordered
+        expect(subject).to receive(:on).with( host, /^(rpm --replacepkgs -ivh).*/ ).ordered
         subject.install_puppetlabs_release_repo host
       end
 


### PR DESCRIPTION
- As per suggestion in [BKR-314](https://tickets.puppetlabs.com/browse/BKR-314?focusedCommentId=182682&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-182682) by @MikaelSmith, add `--replacepkgs` to rpm install
- Update tests accordingly