### PR TITLE
(BKR-339) Remove the target module directory on host during copy_module_to

### DIFF
--- a/lib/beaker/dsl/install_utils/module_utils.rb
+++ b/lib/beaker/dsl/install_utils/module_utils.rb
@@ -131,13 +131,7 @@ module Beaker
               scp_to host, source_path, target_module_dir, {:ignore => ignore_list}
               #rename to the selected module name, if not correct
               cur_path = File.join(target_module_dir, source_name)
-              if (cur_path != target_path)
-                if host.is_powershell?
-                  on host, "move /y #{cur_path} #{target_path}"
-                else
-                  on host, "mv #{cur_path} #{target_path}"
-                end
-              end
+              host.mv cur_path, target_path unless cur_path == target_path
             when 'rsync'
               logger.debug "Using rsync to transfer #{source_path} to #{target_path}"
               rsync_to host, source_path, target_path, {:ignore => ignore_list}

--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -21,6 +21,15 @@ module PSWindows::Exec
     execute("del /s /q #{path}")
   end
 
+  # Move the origin to destination. The destination is removed prior to moving.
+  # @param [String] orig The origin path
+  # @param [String] dest the destination path
+  # @param [Boolean] rm Remove the destination prior to move
+  def mv(orig, dest, rm=true)
+    rm_rf dest unless !rm
+    execute("move /y #{orig} #{dest}")
+  end
+
   def path
     'c:/windows/system32;c:/windows'
   end

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -41,7 +41,16 @@ module Unix::Exec
   # Recursively remove the path provided
   # @param [String] path The path to remove
   def rm_rf path
-    exec(Beaker::Command.new("rm -rf #{path}"))
+    execute("rm -rf #{path}")
+  end
+
+  # Move the origin to destination. The destination is removed prior to moving.
+  # @param [String] orig The origin path
+  # @param [String] dest the destination path
+  # @param [Boolean] rm Remove the destination prior to move
+  def mv orig, dest, rm=true
+    rm_rf dest unless !rm
+    execute("mv #{orig} #{dest}")
   end
 
   # Converts the provided environment file to a new shell script in /etc/profile.d, then sources that file.

--- a/spec/beaker/dsl/install_utils/module_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/module_utils_spec.rb
@@ -136,7 +136,7 @@ describe ClassMixedWithDSLInstallUtils do
         allow( File ).to receive(:directory?).with(any_args()).and_return(false)
 
         expect( subject ).to receive(:scp_to).with(host,source, File.dirname(target), {:ignore => ignore_list})
-        expect( subject ).to receive(:on).with(host, "mv #{File.join(File.dirname(target), File.basename(source))} #{target}")
+        expect( host ).to receive(:mv).with(File.join(File.dirname(target), File.basename(source)), target)
         if opts.nil?
           subject.copy_module_to(host)
         else
@@ -187,7 +187,7 @@ describe ClassMixedWithDSLInstallUtils do
         expect( subject ).to receive(:on).with(host, "echo C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules" ).and_return( result )
 
         expect( subject ).to receive(:scp_to).with(host, "/opt/testmodule2", "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules", {:ignore => ignore_list})
-        expect( subject ).to receive(:on).with(host, 'move /y C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule2 C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule')
+        expect( host ).to receive(:mv).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule2', 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule')
 
         subject.copy_module_to(host, {:module_name => 'testmodule', :source => '/opt/testmodule2'})
       end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Beaker
+  describe Unix::Exec do
+    class UnixExecTest
+      include Unix::Exec
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { UnixExecTest.new(opts, logger) }
+
+    context "rm" do
+
+      it "deletes" do
+        path = '/path/to/delete'
+        expect( instance ).to receive(:execute).with("rm -rf #{path}").and_return(0)
+        expect( instance.rm_rf(path) ).to be === 0
+      end
+    end
+
+    context 'mv' do
+      let(:origin)      { '/origin/path/of/content' }
+      let(:destination) { '/destination/path/of/content' }
+
+      it 'rm first' do
+        expect( instance ).to receive(:execute).with("rm -rf #{destination}").and_return(0)
+        expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
+        expect( instance.mv(origin, destination) ).to be === 0
+
+      end
+
+      it 'does not rm' do
+         expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
+         expect( instance.mv(origin, destination, false) ).to be === 0
+      end
+    end
+  end
+end

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Beaker
+  describe PSWindows::Exec do
+    class PSWindowsExecTest
+      include PSWindows::Exec
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { PSWindowsExecTest.new(opts, logger) }
+
+    context "rm" do
+
+      it "deletes" do
+        path = '/path/to/delete'
+        expect( instance ).to receive(:execute).with("del /s /q #{path}").and_return(0)
+        expect( instance.rm_rf(path) ).to be === 0
+      end
+    end
+
+    context 'mv' do
+      let(:origin)      { '/origin/path/of/content' }
+      let(:destination) { '/destination/path/of/content' }
+
+      it 'rm first' do
+        expect( instance ).to receive(:execute).with("del /s /q #{destination}").and_return(0)
+        expect( instance ).to receive(:execute).with("move /y #{origin} #{destination}").and_return(0)
+        expect( instance.mv(origin, destination) ).to be === 0
+
+      end
+
+      it 'does not rm' do
+         expect( instance ).to receive(:execute).with("move /y #{origin} #{destination}").and_return(0)
+         expect( instance.mv(origin, destination, false) ).to be === 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without this patch, the `copy_module_to` function will not work correctly to copy updated module files into the target directory on the hosts. Acceptance test spec files can be updated, but not module sources. Additionally the module copy will fail on the second non-provisioning run.

The patch simply executes a delete of the target directory on the host, ensuring it does not exist prior to the mv command.