### PR TITLE
(BKR-348) AWS: Adding instance storage support

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -267,23 +267,27 @@ module Beaker
         raise RuntimeError, "Image not found: #{image_id}"
       end
 
+      @logger.notify("Image Storage Type: #{image.root_device_type}")
+
       # Transform the images block_device_mappings output into a format
       # ready for a create.
-      orig_bdm = image.block_device_mappings()
-      @logger.notify("aws-sdk: Image block_device_mappings: #{orig_bdm.to_hash}")
       block_device_mappings = []
-      orig_bdm.each do |device_name, rest|
-        block_device_mappings << {
-          :device_name => device_name,
-          :ebs => {
-            # Change the default size of the root volume.
-            :volume_size => host['volume_size'] || rest[:volume_size],
-            # This is required to override the images default for
-            # delete_on_termination, forcing all volumes to be deleted once the
-            # instance is terminated.
-            :delete_on_termination => true,
+      if image.root_device_type == :ebs
+        orig_bdm = image.block_device_mappings()
+        @logger.notify("aws-sdk: Image block_device_mappings: #{orig_bdm.to_hash}")
+        orig_bdm.each do |device_name, rest|
+          block_device_mappings << {
+            :device_name => device_name,
+            :ebs => {
+              # Change the default size of the root volume.
+              :volume_size => host['volume_size'] || rest[:volume_size],
+              # This is required to override the images default for
+              # delete_on_termination, forcing all volumes to be deleted once the
+              # instance is terminated.
+              :delete_on_termination => true,
+            }
           }
-        }
+        end
       end
 
       security_group = ensure_group(vpc || region, Beaker::EC2Helper.amiports(host))
@@ -301,9 +305,9 @@ module Beaker
         :instance_type => amisize,
         :disable_api_termination => false,
         :instance_initiated_shutdown_behavior => "terminate",
-        :block_device_mappings => block_device_mappings,
         :subnet => subnet_id,
       }
+      config[:block_device_mappings] = block_device_mappings if image.root_device_type == :ebs
       region.instances.create(config)
     end
 


### PR DESCRIPTION
AMIs using the instance storage root device type are now supported
allowing users who don't want/need EBS backed AMIs to add nodesets
more easily.

Tests aren't easily done for this chunk of the AWS hypervisor currently. A
separate ticket (BKR-349) has been added to wrap in testing for this method
along with a number of other currently untouched AWS methods.

All existing tests pass currently and everything is (for now) rebased up to master.