### PR TITLE
(BKR-344) Support year.release versioning (e.g. 2015.2)

### DIFF
--- a/lib/beaker/answers.rb
+++ b/lib/beaker/answers.rb
@@ -49,7 +49,7 @@ module Beaker
     #   data.
     def self.create version, hosts, options
       case version
-      when /\A4\.0/
+      when /\A(4\.0|2015)/
         return Version40.new(version, hosts, options)
       when /\A3\.99/
         return Version40.new(version, hosts, options)

--- a/lib/beaker/shared/semvar.rb
+++ b/lib/beaker/shared/semvar.rb
@@ -14,9 +14,9 @@ module Beaker
         b_nums = b.split('-')[0].split('.')
         (0...a_nums.length).each do |i|
           if i < b_nums.length
-            if a_nums[i] < b_nums[i]
+            if a_nums[i].to_i < b_nums[i].to_i
               return true
-            elsif a_nums[i] > b_nums[i]
+            elsif a_nums[i].to_i > b_nums[i].to_i
               return false
             end
           else

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -258,14 +258,14 @@ describe ClassMixedWithDSLInstallUtils do
         subject.install_puppet
       end
       it 'installs specific version of puppet when passed :version' do
-        expect(hosts[0]).to receive(:install_package).with('puppet-3000')
-        subject.install_puppet( :version => '3000' )
+        expect(hosts[0]).to receive(:install_package).with('puppet-3')
+        subject.install_puppet( :version => '3' )
       end
       it 'can install specific versions of puppets dependencies' do
-        expect(hosts[0]).to receive(:install_package).with('puppet-3000')
+        expect(hosts[0]).to receive(:install_package).with('puppet-3')
         expect(hosts[0]).to receive(:install_package).with('hiera-2001')
         expect(hosts[0]).to receive(:install_package).with('facter-1999')
-        subject.install_puppet( :version => '3000', :facter_version => '1999', :hiera_version => '2001' )
+        subject.install_puppet( :version => '3', :facter_version => '1999', :hiera_version => '2001' )
       end
     end
     context 'on el-5' do
@@ -294,16 +294,16 @@ describe ClassMixedWithDSLInstallUtils do
         subject.install_puppet
       end
       it 'installs specific version of puppet when passed :version' do
-        expect(hosts[0]).to receive(:install_package).with('puppet=3000-1puppetlabs1')
-        expect(hosts[0]).to receive(:install_package).with('puppet-common=3000-1puppetlabs1')
-        subject.install_puppet( :version => '3000' )
+        expect(hosts[0]).to receive(:install_package).with('puppet=3-1puppetlabs1')
+        expect(hosts[0]).to receive(:install_package).with('puppet-common=3-1puppetlabs1')
+        subject.install_puppet( :version => '3' )
       end
       it 'can install specific versions of puppets dependencies' do
         expect(hosts[0]).to receive(:install_package).with('facter=1999-1puppetlabs1')
         expect(hosts[0]).to receive(:install_package).with('hiera=2001-1puppetlabs1')
-        expect(hosts[0]).to receive(:install_package).with('puppet-common=3000-1puppetlabs1')
-        expect(hosts[0]).to receive(:install_package).with('puppet=3000-1puppetlabs1')
-        subject.install_puppet( :version => '3000', :facter_version => '1999', :hiera_version => '2001' )
+        expect(hosts[0]).to receive(:install_package).with('puppet-common=3-1puppetlabs1')
+        expect(hosts[0]).to receive(:install_package).with('puppet=3-1puppetlabs1')
+        subject.install_puppet( :version => '3', :facter_version => '1999', :hiera_version => '2001' )
       end
     end
     context 'on windows' do
@@ -311,17 +311,17 @@ describe ClassMixedWithDSLInstallUtils do
       it 'installs specific version of puppet when passed :version' do
         allow(hosts[0]).to receive(:is_cygwin?).and_return(true)
         allow(subject).to receive(:link_exists?).and_return( true )
-        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://downloads.puppetlabs.com/windows/puppet-3000.msi')
+        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://downloads.puppetlabs.com/windows/puppet-3.msi')
         expect(subject).to receive(:on).with(hosts[0], " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
-        expect(subject).to receive(:on).with(hosts[0], 'cmd /C \'start /w msiexec.exe /qn /i puppet-3000.msi\'')
-        subject.install_puppet(:version => '3000')
+        expect(subject).to receive(:on).with(hosts[0], 'cmd /C \'start /w msiexec.exe /qn /i puppet-3.msi\'')
+        subject.install_puppet(:version => '3')
       end
       it 'installs from custom url when passed :win_download_url' do
         allow(hosts[0]).to receive(:is_cygwin?).and_return(true)
         allow(subject).to receive(:link_exists?).and_return( true )
-        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://nightlies.puppetlabs.com/puppet-latest/repos/windows/puppet-3000.msi')
-        expect(subject).to receive(:on).with(hosts[0], 'cmd /C \'start /w msiexec.exe /qn /i puppet-3000.msi\'')
-        subject.install_puppet( :version => '3000', :win_download_url => 'http://nightlies.puppetlabs.com/puppet-latest/repos/windows' )
+        expect(subject).to receive(:on).with(hosts[0], 'curl -O http://nightlies.puppetlabs.com/puppet-latest/repos/windows/puppet-3.msi')
+        expect(subject).to receive(:on).with(hosts[0], 'cmd /C \'start /w msiexec.exe /qn /i puppet-3.msi\'')
+        subject.install_puppet( :version => '3', :win_download_url => 'http://nightlies.puppetlabs.com/puppet-latest/repos/windows' )
       end
     end
     describe 'on unsupported platforms' do

--- a/spec/beaker/shared/semvar_spec.rb
+++ b/spec/beaker/shared/semvar_spec.rb
@@ -6,6 +6,18 @@ module Beaker
 
       describe 'version_is_less' do
 
+        it 'reports 2015.3.0-rc0-8-gf80879a is less than 2016' do
+          expect( subject.version_is_less( '2015.3.0-rc0-8-gf80879a', '2016' ) ).to be === true
+        end
+
+        it 'reports 2015.3.0-rc0-8-gf80879a is not less than 2015.3.0' do
+          expect( subject.version_is_less( '2015.3.0-rc0-8-gf80879a', '2015.3.0' ) ).to be === false
+        end
+
+        it 'reports 2015.3.0-rc0-8-gf80879a is not less than 3.0.0' do
+          expect( subject.version_is_less( '2015.3.0-rc0-8-gf80879a', '3.0.0' ) ).to be === false
+        end
+
         it 'reports 3.0.0-160-gac44cfb is not less than 3.0.0' do
           expect( subject.version_is_less( '3.0.0-160-gac44cfb', '3.0.0' ) ).to be === false
         end


### PR DESCRIPTION
- update semver matching to understand that 3.0.0 < 2015.3.0.0
- update answer file generation to provide 4.0 answers for version 2015+