### PR TITLE
(BKR-367) create beaker ec2 smoketest

### DIFF
--- a/acceptance/tests/hypervisor/communication.rb
+++ b/acceptance/tests/hypervisor/communication.rb
@@ -1,0 +1,7 @@
+# hosts should be able to talk to each other by name
+step "hosts can ping each other"
+hosts.each do |one|
+  hosts.each do |two|
+    assert_equal(one.ping(two), true)
+  end
+end

--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -45,6 +45,22 @@ module PSWindows::Exec
     ip
   end
 
+  # Attempt to ping the provided target hostname
+  # @param [String] target The hostname to ping
+  # @param [Integer] attempts Amount of times to attempt ping before giving up
+  # @return [Boolean] true of ping successful, overwise false
+  def ping target, attempts=5
+    try = 0
+    while try < attempts do
+      result = exec(Beaker::Command.new("ping -n 1 #{target}"), :accept_all_exit_codes => true)
+      if result.exit_code == 0
+        return true
+      end
+      try+=1
+    end
+    result.exit_code == 0
+  end
+
   # Create the provided directory structure on the host
   # @param [String] dir The directory structure to create on the host
   # @return [Boolean] True, if directory construction succeeded, otherwise False

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -53,6 +53,22 @@ module Unix::Exec
     execute("mv #{orig} #{dest}")
   end
 
+  # Attempt to ping the provided target hostname
+  # @param [String] target The hostname to ping
+  # @param [Integer] attempts Amount of times to attempt ping before giving up
+  # @return [Boolean] true of ping successful, overwise false
+  def ping target, attempts=5
+    try = 0
+    while try < attempts do
+      result = exec(Beaker::Command.new("ping -c 1 #{target}"), :accept_all_exit_codes => true)
+      if result.exit_code == 0
+        return true
+      end
+      try+=1
+    end
+    result.exit_code == 0
+  end
+
   # Converts the provided environment file to a new shell script in /etc/profile.d, then sources that file.
   # This is for sles based hosts.
   # @param [String] env_file The ssh environment file to read from

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -30,4 +30,21 @@ module Windows::Exec
     end
     ip
   end
+
+  # Attempt to ping the provided target hostname
+  # @param [String] target The hostname to ping
+  # @param [Integer] attempts Amount of times to attempt ping before giving up
+  # @return [Boolean] true of ping successful, overwise false
+  def ping target, attempts=5
+    try = 0
+    while try < attempts do
+      result = exec(Beaker::Command.new("ping -n 1 #{target}"), :accept_all_exit_codes => true)
+      if result.exit_code == 0
+        return true
+      end
+      try+=1
+    end
+    result.exit_code == 0
+  end
+
 end

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -11,6 +11,7 @@ module Beaker
   # vendor API.
   class AwsSdk < Beaker::Hypervisor
     ZOMBIE = 3 #anything older than 3 hours is considered a zombie
+    PING_SECURITY_GROUP_NAME = 'beaker-ping'
 
     # Initialize AwsSdk hypervisor driver
     #
@@ -287,6 +288,8 @@ module Beaker
       end
 
       security_group = ensure_group(vpc || region, Beaker::EC2Helper.amiports(host))
+      #check if ping is enabled
+      ping_security_group = ensure_ping_group(vpc || region)
 
       msg = "aws-sdk: launching %p on %p using %p/%p%s" %
             [host.name, amitype, amisize, image_type,
@@ -297,7 +300,7 @@ module Beaker
         :image_id => image_id,
         :monitoring_enabled => true,
         :key_pair => ensure_key_pair(region),
-        :security_groups => [security_group],
+        :security_groups => [security_group, ping_security_group],
         :instance_type => amisize,
         :disable_api_termination => false,
         :instance_initiated_shutdown_behavior => "terminate",
@@ -634,6 +637,25 @@ module Beaker
     # Accepts a VPC as input for checking & creation.
     #
     # @param vpc [AWS::EC2::VPC] the AWS vpc control object
+    # @return [AWS::EC2::SecurityGroup] created security group
+    # @api private
+    def ensure_ping_group(vpc)
+      @logger.notify("aws-sdk: Ensure security group exists that enables ping, create if not")
+
+      group = vpc.security_groups.filter('group-name', PING_SECURITY_GROUP_NAME).first
+
+      if group.nil?
+        group = create_ping_group(vpc)
+      end
+
+      group
+    end
+
+    # Return an existing group, or create new one
+    #
+    # Accepts a VPC as input for checking & creation.
+    #
+    # @param vpc [AWS::EC2::VPC] the AWS vpc control object
     # @param ports [Array<Number>] an array of port numbers
     # @return [AWS::EC2::SecurityGroup] created security group
     # @api private
@@ -646,6 +668,23 @@ module Beaker
       if group.nil?
         group = create_group(vpc, ports)
       end
+
+      group
+    end
+
+    # Create a new ping enabled security group
+    #
+    # Accepts a region or VPC for group creation.
+    #
+    # @param rv [AWS::EC2::Region, AWS::EC2::VPC] the AWS region or vpc control object
+    # @return [AWS::EC2::SecurityGroup] created security group
+    # @api private
+    def create_ping_group(rv)
+      @logger.notify("aws-sdk: Creating group #{PING_SECURITY_GROUP_NAME}")
+      group = rv.security_groups.create(PING_SECURITY_GROUP_NAME,
+                                        :description => "Custom Beaker security group to enable ping")
+
+      group.allow_ping
 
       group
     end


### PR DESCRIPTION
- add acceptance/tests/hypervisor/communication.rb, checks to ensure
  that hosts can ping each other
- enable ping for aws ec2 instances created by beaker
- create host.ping method to ping from host to a second host, return
  'true' when ping is successful, 'false' otherwise