### PR TITLE
(BKR-366) merge-up install_from_git changes from deployer and puppet

### DIFF
--- a/acceptance/lib/beaker/acceptance/install_utils.rb
+++ b/acceptance/lib/beaker/acceptance/install_utils.rb
@@ -1,0 +1,58 @@
+module Beaker
+  module Acceptance
+    module InstallUtils
+
+      PLATFORM_PATTERNS = {
+        :redhat        => /fedora|el|centos/,
+        :debian        => /debian|ubuntu/,
+        :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
+        :solaris_10    => /solaris-10/,
+        :solaris_11    => /solaris-11/,
+        :windows       => /windows/,
+        :sles          => /sles/,
+      }.freeze
+
+      # Installs packages on the hosts.
+      #
+      # @param hosts [Array<Host>] Array of hosts to install packages to.
+      # @param package_hash [Hash{Symbol=>Array<String,Array<String,String>>}]
+      #   Keys should be a symbol for a platform in PLATFORM_PATTERNS.  Values
+      #   should be an array of package names to install, or of two element
+      #   arrays where a[0] is the command we expect to find on the platform
+      #   and a[1] is the package name (when they are different).
+      # @param options [Hash{Symbol=>Boolean}]
+      # @option options [Boolean] :check_if_exists First check to see if
+      #   command is present before installing package.  (Default false)
+      # @return true
+      def install_packages_on(hosts, package_hash, options = {})
+        return true if hosts == nil
+        check_if_exists = options[:check_if_exists]
+        hosts = [hosts] unless hosts.kind_of?(Array)
+        hosts.each do |host|
+          package_hash.each do |platform_key,package_list|
+            if pattern = PLATFORM_PATTERNS[platform_key]
+              if pattern.match(host['platform'])
+                package_list.each do |cmd_pkg|
+                  if cmd_pkg.kind_of?(Array)
+                    command, package = cmd_pkg
+                  else
+                    command = package = cmd_pkg
+                  end
+                  if !check_if_exists || !host.check_for_package(command)
+                    host.logger.notify("Installing #{package}")
+                    additional_switches = '--allow-unauthenticated' if platform_key == :debian
+                    host.install_package(package, additional_switches)
+                  end
+                end
+              end
+            else
+              raise("Unknown platform '#{platform_key}' in package_hash")
+            end
+          end
+        end
+        return true
+      end
+
+    end
+  end
+end

--- a/acceptance/tests/foss_utils/clone_git_repo_on.rb
+++ b/acceptance/tests/foss_utils/clone_git_repo_on.rb
@@ -1,0 +1,49 @@
+begin
+  require 'beaker/acceptance/install_utils'
+  extend Beaker::Acceptance::InstallUtils
+end
+test_name 'Clone from git'
+
+PACKAGES = {
+  :redhat => [
+    'git',
+  ],
+  :debian => [
+    ['git', 'git-core'],
+  ],
+  :solaris_11 => [
+    ['git', 'developer/versioning/git'],
+  ],
+  :solaris_10 => [
+    'coreutils',
+    'curl', # update curl to fix "CURLOPT_SSL_VERIFYHOST no longer supports 1 as value!" issue
+    'git',
+  ],
+  :windows => [
+    'git',
+  ],
+  :sles => [
+    'git-core',
+  ]
+}
+
+install_packages_on(hosts, PACKAGES, :check_if_exists => true)
+
+# build_giturl implicitly looks these up
+ENV['HIERA_FORK']='puppetlabs'
+ENV['FORK']='fail'
+
+# implicitly tests build_giturl() and lookup_in_env()
+hosts.each do |host|
+  on host, "echo #{GitHubSig} >> $HOME/.ssh/known_hosts"
+  testdir = create_tmpdir_on(host, File.basename(__FILE__))
+
+  step 'should find fork name from the correct environment variable'
+  results = clone_git_repo_on(host, "#{testdir}", extract_repo_info_from(build_git_url('puppet')))
+  assert_match( /github\.com:fail/, result.cmd, 'Did not find correct fork name')
+  assert_equal( 1, result.exit_code, 'Did not produce error exit_code of 1')
+
+  step 'should clone hiera from correct fork'
+  results = clone_git_repo_on(host, "#{testdir}", extract_repo_info_from(build_git_url('hiera')))
+  assert_match( /From github\.com:puppetlabs\/hiera/, result.output, 'Did not find clone')
+end

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -28,6 +28,40 @@ module Beaker
         # Github's ssh signature for cloning via ssh
         GitHubSig   = 'github.com,207.97.227.239 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
 
+        # lookup project-specific git environment variables
+        # PROJECT_VAR or VAR otherwise return the default
+        #
+        # @!visibility private
+        def lookup_in_env(env_variable_name, project_name=nil, default=nil)
+          env_variable_name     = "#{env_variable_name.upcase.gsub('-','_')}"
+          project_specific_name = "#{project_name.upcase.gsub('-','_')}_#{env_variable_name}" if project_name
+          project_name && ENV[project_specific_name] || ENV[env_variable_name] || default
+        end
+
+        # @param [String] project_name
+        # @param [String] git_fork     When not provided will use PROJECT_FORK environment variable
+        # @param [String] git_server   When not provided will use PROJECT_SERVER environment variable
+        # @param [String] git_protocol 'git','ssh','https'
+        #
+        # @return [String] Returns a git-usable url
+        #
+        # TODO: enable other protocols, clarify, http://git-scm.com/book/ch4-1.html
+        def build_git_url(project_name, git_fork = nil, git_server = nil, git_protocol='https')
+          git_fork   ||= lookup_in_env('FORK',   project_name, 'puppetlabs')
+          git_server ||= lookup_in_env('SERVER', project_name, 'github.com')
+
+          case git_protocol
+          when /(ssh|git)/
+            git_protocol = 'git@'
+          when /https/
+            git_protocol = 'https://'
+          end
+
+          repo = (git_server == 'github.com') ? "#{git_fork}/#{project_name}.git" : "#{git_fork}-#{project_name}.git"
+          return git_protocol == 'git@' ? "#{git_protocol}#{git_server}:#{repo}" : "#{git_protocol}#{git_server}/#{repo}"
+        end
+        alias_method :build_giturl, :build_git_url
+
         # @param [String] uri A uri in the format of <git uri>#<revision>
         #                     the `git://`, `http://`, `https://`, and ssh
         #                     (if cloning as the remote git user) protocols
@@ -100,9 +134,18 @@ module Beaker
           version
         end
 
+        # @param [Host] host An object implementing {Beaker::Hosts}'s
+        #                    interface.
+        # @param [String] path The path on the remote [host] to the repository
+        # @param [Hash{Symbol=>String}] repository A hash representing repo
+        #                                          info like that emitted by
+        #                                          {#extract_repo_info_from}
         #
-        # @see #find_git_repo_versions
-        def install_from_git host, path, repository
+        # @note This requires the helper methods:
+        #       * {Beaker::DSL::Helpers#on}
+        #
+        def clone_git_repo_on host, path, repository, opts = {}
+          opts = {:accept_all_exit_codes => true}.merge(opts)
           name          = repository[:name]
           repo          = repository[:path]
           rev           = repository[:rev]
@@ -121,33 +164,41 @@ module Beaker
 
           logger.notify("\n  * Clone #{repo} if needed")
 
-          on host, "test -d #{path} || mkdir -p #{path}"
-          on host, "test -d #{target} || #{clone_cmd}"
+          on host, "test -d #{path} || mkdir -p #{path}", opts
+          on host, "test -d #{target} || #{clone_cmd}", opts
 
           logger.notify("\n  * Update #{name} and check out revision #{rev}")
-
           commands = ["cd #{target}",
                       "remote rm origin",
                       "remote add origin #{repo}",
                       "fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/*",
                       "clean -fdx",
                       "checkout -f #{rev}"]
-          on host, commands.join(" && git ")
+          on host, commands.join(" && git "), opts
+        end
 
+        # @see #find_git_repo_versions
+        # @note This assumes the target repository application
+        #   can be installed via an install.rb ruby script.
+        def install_from_git_on host, path, repository, opts = {}
+          opts = {:accept_all_exit_codes => true}.merge(opts)
+          clone_git_repo_on host, path, repository, opts
+          name          = repository[:name]
           logger.notify("\n  * Install #{name} on the system")
           # The solaris ruby IPS package has bindir set to /usr/ruby/1.8/bin.
           # However, this is not the path to which we want to deliver our
           # binaries. So if we are using solaris, we have to pass the bin and
           # sbin directories to the install.rb
+          target        = "#{path}/#{name}"
           install_opts = ''
-          install_opts = '--bindir=/usr/bin --sbindir=/usr/sbin' if
-            host['platform'].include? 'solaris'
+          install_opts = '--bindir=/usr/bin --sbindir=/usr/sbin' if host['platform'].include? 'solaris'
 
-            on host,  "cd #{target} && " +
-                      "if [ -f install.rb ]; then " +
-                      "ruby ./install.rb #{install_opts}; " +
-                      "else true; fi"
+          on host,  "cd #{target} && " +
+                    "if [ -f install.rb ]; then " +
+                    "ruby ./install.rb #{install_opts}; " +
+                    "else true; fi", opts
         end
+        alias_method :install_from_git, :install_from_git_on
 
         # @deprecated Use {#install_puppet_on} instead.
         def install_puppet(opts = {})

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -135,6 +135,54 @@ describe ClassMixedWithDSLInstallUtils do
 
   end
 
+  context 'lookup_in_env' do
+    it 'returns a default properly' do
+      env_var = subject.lookup_in_env('noway', 'nonesuch', 'returnme')
+      expect(env_var).to be == 'returnme'
+      env_var = subject.lookup_in_env('noway', nil, 'returnme')
+      expect(env_var).to be == 'returnme'
+    end
+    it 'finds correct env variable' do
+      allow(ENV).to receive(:[]).with(nil).and_return(nil)
+      allow(ENV).to receive(:[]).with('REALLYNONE').and_return(nil)
+      allow(ENV).to receive(:[]).with('NONESUCH').and_return('present')
+      allow(ENV).to receive(:[]).with('NOWAY_PROJ_NONESUCH').and_return('exists')
+      env_var = subject.lookup_in_env('nonesuch', 'noway-proj', 'fail')
+      expect(env_var).to be == 'exists'
+      env_var = subject.lookup_in_env('nonesuch')
+      expect(env_var).to be == 'present'
+      env_var = subject.lookup_in_env('reallynone')
+      expect(env_var).to be == nil
+      env_var = subject.lookup_in_env('reallynone',nil,'default')
+      expect(env_var).to be == 'default'
+    end
+  end
+
+  context 'build_giturl' do
+    it 'returns urls properly' do
+      allow(ENV).to receive(:[]).with('SERVER').and_return(nil)
+      allow(ENV).to receive(:[]).with('FORK').and_return(nil)
+      allow(ENV).to receive(:[]).with('PUPPET_FORK').and_return(nil)
+      allow(ENV).to receive(:[]).with('PUPPET_SERVER').and_return(nil)
+      url = subject.build_giturl('puppet')
+      expect(url).to be == 'https://github.com/puppetlabs/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck')
+      expect(url).to be == 'https://github.com/er0ck/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'bitbucket.com')
+      expect(url).to be == 'https://bitbucket.com/er0ck-puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https://')
+      expect(url).to be == 'https://github.com/er0ck/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https')
+      expect(url).to be == 'https://github.com/er0ck/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git@')
+      expect(url).to be == 'git@github.com:er0ck/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git')
+      expect(url).to be == 'git@github.com:er0ck/puppet.git'
+      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'ssh')
+      expect(url).to be == 'git@github.com:er0ck/puppet.git'
+    end
+  end
+
   context 'extract_repo_info_from' do
     [{ :protocol => 'git', :path => 'git://github.com/puppetlabs/project.git' },
      { :protocol => 'ssh', :path => 'git@github.com:puppetlabs/project.git' },
@@ -225,6 +273,71 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
+  context 'clone_git_repo_on' do
+    it 'does a ton of stuff it probably shouldnt' do
+      repo = { :name => 'puppet',
+               :path => 'git://my.server.net/puppet.git',
+               :rev => 'master' }
+      path = '/path/to/repos'
+      host = { 'platform' => 'debian' }
+      logger = double.as_null_object
+
+      allow( subject ).to receive( :metadata ).and_return( metadata )
+      allow( subject ).to receive( :configure_foss_defaults_on ).and_return( true )
+
+      expect( subject ).to receive( :logger ).exactly( 2 ).times.and_return( logger )
+      expect( subject ).to receive( :on ).exactly( 3 ).times
+
+      subject.instance_variable_set( :@metadata, {} )
+      subject.clone_git_repo_on( host, path, repo )
+    end
+
+    it 'allows a checkout depth of 1' do
+      repo   = { :name => 'puppet',
+                 :path => 'git://my.server.net/puppet.git',
+                 :rev => 'master',
+                 :depth => 1 }
+
+      path   = '/path/to/repos'
+      cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:rev]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
+      host   = { 'platform' => 'debian' }
+      logger = double.as_null_object
+      allow( subject ).to receive( :metadata ).and_return( metadata )
+      allow( subject ).to receive( :configure_foss_defaults_on ).and_return( true )
+      expect( subject ).to receive( :logger ).exactly( 2 ).times.and_return( logger )
+      expect( subject ).to receive( :on ).with( host, "test -d #{path} || mkdir -p #{path}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      # this is the the command we want to test
+      expect( subject ).to receive( :on ).with( host, cmd, {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/* && git clean -fdx && git checkout -f #{repo[:rev]}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+
+      subject.instance_variable_set( :@metadata, {} )
+      subject.clone_git_repo_on( host, path, repo )
+    end
+
+    it 'allows a checkout depth with a rev from a specific branch' do
+      repo   = { :name => 'puppet',
+                 :path => 'git://my.server.net/puppet.git',
+                 :rev => 'a2340acddadfeafd234230faf',
+                 :depth => 50,
+                 :depth_branch => 'master' }
+
+      path   = '/path/to/repos'
+      cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:depth_branch]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
+      host   = { 'platform' => 'debian' }
+      allow( subject ).to receive( :configure_foss_defaults_on ).and_return( true )
+      logger = double.as_null_object
+      allow( subject ).to receive( :metadata ).and_return( metadata )
+      expect( subject ).to receive( :logger ).exactly( 2 ).times.and_return( logger )
+      expect( subject ).to receive( :on ).with( host, "test -d #{path} || mkdir -p #{path}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      # this is the the command we want to test
+      expect( subject ).to receive( :on ).with( host, cmd, {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/* && git clean -fdx && git checkout -f #{repo[:rev]}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+
+      subject.instance_variable_set( :@metadata, {} )
+      subject.clone_git_repo_on( host, path, repo )
+    end
+  end
+
   context 'install_from_git' do
     it 'does a ton of stuff it probably shouldnt' do
       repo = { :name => 'puppet',
@@ -244,7 +357,7 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_from_git( host, path, repo )
     end
 
-    it 'allows a checkout depth of 1' do
+    it 'should attempt to install ruby code' do
       repo   = { :name => 'puppet',
                  :path => 'git://my.server.net/puppet.git',
                  :rev => 'master',
@@ -257,38 +370,13 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :metadata ).and_return( metadata )
       allow( subject ).to receive( :configure_foss_defaults_on ).and_return( true )
       expect( subject ).to receive( :logger ).exactly( 3 ).times.and_return( logger )
-      expect( subject ).to receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
-      # this is the the command we want to test
-      expect( subject ).to receive( :on ).with( host, cmd ).exactly( 1 ).times
-      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/* && git clean -fdx && git checkout -f #{repo[:rev]}" ).exactly( 1 ).times
-      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi" ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, "test -d #{path} || mkdir -p #{path}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, cmd, {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/* && git clean -fdx && git checkout -f #{repo[:rev]}", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
+      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi", {:accept_all_exit_codes=>true} ).exactly( 1 ).times
 
       subject.instance_variable_set( :@metadata, {} )
-      subject.install_from_git( host, path, repo )
-    end
-
-    it 'allows a checkout depth with a rev from a specific branch' do
-      repo   = { :name => 'puppet',
-                 :path => 'git://my.server.net/puppet.git',
-                 :rev => 'a2340acddadfeafd234230faf',
-                 :depth => 50,
-                 :depth_branch => 'master' }
-
-      path   = '/path/to/repos'
-      cmd    = "test -d #{path}/#{repo[:name]} || git clone --branch #{repo[:depth_branch]} --depth #{repo[:depth]} #{repo[:path]} #{path}/#{repo[:name]}"
-      host   = { 'platform' => 'debian' }
-      allow( subject ).to receive( :configure_foss_defaults_on ).and_return( true )
-      logger = double.as_null_object
-      allow( subject ).to receive( :metadata ).and_return( metadata )
-      expect( subject ).to receive( :logger ).exactly( 3 ).times.and_return( logger )
-      expect( subject ).to receive( :on ).with( host,"test -d #{path} || mkdir -p #{path}").exactly( 1 ).times
-      # this is the the command we want to test
-      expect( subject ).to receive( :on ).with( host, cmd ).exactly( 1 ).times
-      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && git remote rm origin && git remote add origin #{repo[:path]} && git fetch origin +refs/pull/*:refs/remotes/origin/pr/* +refs/heads/*:refs/remotes/origin/* && git clean -fdx && git checkout -f #{repo[:rev]}" ).exactly( 1 ).times
-      expect( subject ).to receive( :on ).with( host, "cd #{path}/#{repo[:name]} && if [ -f install.rb ]; then ruby ./install.rb ; else true; fi" ).exactly( 1 ).times
-
-      subject.instance_variable_set( :@metadata, {} )
-      subject.install_from_git( host, path, repo )
+      subject.install_from_git_on( host, path, repo )
     end
    end
 


### PR DESCRIPTION
This change merges changes to install_from_git that were overloaded into
puppet and other repos' acceptance libraries.
We also split the cloning portion of install_from_git into its own
method, added options that are passed through to on() and moved a method
to beaker's acceptance library that needs to be shared across tests
(install_packages_on).
This addition of an acceptance library for beaker *may require changes* to
the jenkins CI configuration, to add the library to the test-runner's
load-path.
The merge-up also brought in helpers for install_from_git,
build_git_url() and lookup_in_env().