### PR TITLE
(BKR-378) RHEL4 runs fail due to the absence of yum

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -61,6 +61,8 @@ module Unix::Pkg
     case self['platform']
       when /sles-/
         execute("zypper --non-interactive in #{name}", opts)
+      when /el-4/
+        @logger.debug("Package installation not supported on rhel4")
       when /cisco|fedora|centos|eos|el-/
         if version
           name = "#{name}-#{version}"


### PR DESCRIPTION
- accidentally changed as a ride along to puppet-agent installation
  work, return to correct state