### PR TITLE
(BKR-384) & (BKR-385) support for dev puppet-agent installation on osx

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1020,6 +1020,11 @@ module Beaker
               # - we do not have install_32 set globally
               arch_suffix = should_install_64bit ? '64' : '86'
               release_file = "puppet-agent-x#{arch_suffix}.msi"
+            when /^osx$/
+              onhost_copy_base = File.join('/var', 'root')
+              mac_pkg_name = "puppet-agent-#{opts[:puppet_agent_version]}"
+              release_path << "/apple/#{opts[:puppet_collection]}"
+              release_file = "#{mac_pkg_name}-#{variant}-#{version}-x86_64.dmg"
             else
               raise "No repository installation step for #{variant} yet..."
             end
@@ -1038,6 +1043,8 @@ module Beaker
               result = on host, "echo #{onhost_copied_file}"
               onhost_copied_file = result.raw_output.chomp
               on host, Command.new("start /w #{onhost_copied_file}", [], { :cmdexe => true })
+            when /^osx$/
+              host.install_package("#{mac_pkg_name}*")
             end
             configure_foss_defaults_on( host )
           end
@@ -1111,7 +1118,7 @@ module Beaker
               release_file = "/repos/apple/#{opts[:puppet_collection]}/puppet-agent-*"
               download_file = "puppet-agent-#{variant}-#{version}.tar.gz"
             else
-              raise "No repository installation step for #{variant} yet..."
+              raise "No pe-promoted installation step for #{variant} yet..."
             end
 
             onhost_copied_download = File.join(onhost_copy_base, download_file)

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -21,6 +21,11 @@ module Beaker
                      "precise" => "1204",
                      "lucid"   => "1004",
                    },
+        :osx =>    { "yosemite"  => "10.10",
+                     "mavericks" => "10.9",
+                     "1010"      => "10.10",
+                     "109"       => "10.9"
+                   }
       }
 
     # A string with the name of the platform.


### PR DESCRIPTION
(BKR-384) install_puppet_agent_dev_repo needs to support osx
    - able to install dev puppet-agent on osx
    
    example:
    
    install_puppet_agent_dev_repo_on(host,
       { :puppet_agent_sha => 'c2946821d1bcd7e43a34bd1f9cd2f86160ca4fe0',
         :puppet_agent_version => '1.2.1.23.gc294682'    })

(BKR-385) beaker needs to be able to convert mac codename to version number
    
    - add support to the platform object to handle yosemite -> 10.10 and
      mavericks -> 10.9 conversions for osx variant