### PR TITLE
(BKR-326) Fixes FreeBSD install to use ports

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -244,6 +244,8 @@ module Beaker
                 install_puppet_from_dmg_on(host, opts)
               elsif host['platform'] =~ /openbsd/
                 install_puppet_from_openbsd_packages_on(host, opts)
+              elsif host['platform'] =~ /freebsd/
+                install_puppet_from_freebsd_ports_on(host, opts)
               else
                 if opts[:default_action] == 'gem_install'
                   opts[:version] ||= '~> 3.x'
@@ -590,6 +592,31 @@ module Beaker
             end
           end
         end
+
+        # Installs Puppet and dependencies from FreeBSD ports
+        #
+        # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
+        #                            or a role (String or Symbol) that identifies one or more hosts.
+        # @param [Hash{Symbol=>String}] opts An options hash
+        # @option opts [String] :version The version of Puppet to install (shows warning)
+        #
+        # @return nil
+        # @api private
+        def install_puppet_from_freebsd_ports_on( hosts, opts )
+          if (opts[:version])
+            logger.warn "If you wish to choose a specific Puppet version, use `install_puppet_from_gem_on('~> 3.*')`"
+          end
+
+          block_on hosts do |host|
+            if host['platform'] =~ /freebsd-9/
+              host.install_package("puppet")
+            else
+              host.install_package("sysutils/puppet")
+            end
+          end
+
+        end
+        alias_method :install_puppet_from_freebsd_ports, :install_puppet_from_freebsd_ports_on
 
         # Installs Puppet and dependencies from dmg on provided host(s).
         #

--- a/lib/beaker/host/freebsd.rb
+++ b/lib/beaker/host/freebsd.rb
@@ -7,11 +7,13 @@ module FreeBSD
 
     [
       'exec',
+      'pkg',
     ].each do |lib|
         require "beaker/host/freebsd/#{lib}"
     end
 
     include FreeBSD::Exec
+    include FreeBSD::Pkg
 
     def platform_defaults
       h = Beaker::Options::OptionsHash.new

--- a/lib/beaker/host/freebsd/pkg.rb
+++ b/lib/beaker/host/freebsd/pkg.rb
@@ -1,0 +1,18 @@
+module FreeBSD::Pkg
+  include Beaker::CommandFactory
+
+  def install_package(name, cmdline_args = nil, opts = {})
+    case self['platform']
+    when /freebsd-9/
+      cmdline_args ||= '-rF'
+      result = execute("pkg_add #{cmdline_args} #{name}", opts) { |result| result }
+    when /freebsd-10/
+      cmdline_args ||= '-y'
+      result = execute("pkg install #{cmdline_args} #{name}", opts) { |result| result }
+    else
+      raise "Package #{name} could not be installed on #{self}"
+    end
+    result.exit_code == 0
+  end
+
+end

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -37,6 +37,12 @@ describe ClassMixedWithDSLInstallUtils do
   let(:machost)       { make_host( 'machost', { :platform => 'osx-10.9-x86_64',
                                                 :pe_ver => '3.0',
                                                 :working_dir => '/tmp' } ) }
+  let(:freebsdhost9)   { make_host( 'freebsdhost9', { :platform => 'freebsd-9-x64',
+                                                :pe_ver => '3.0',
+                                                :working_dir => '/tmp' } ) }
+  let(:freebsdhost10)   { make_host( 'freebsdhost10', { :platform => 'freebsd-10-x64',
+                                                :pe_ver => '3.0',
+                                                :working_dir => '/tmp' } ) }
   let(:unixhost)      { make_host( 'unixhost', { :platform => 'linux',
                                                  :pe_ver => '3.0',
                                                  :working_dir => '/tmp',
@@ -151,6 +157,20 @@ describe ClassMixedWithDSLInstallUtils do
       version = subject.find_git_repo_versions( host, path, repository )
 
       expect( version ).to be == { 'name' => '2' }
+    end
+  end
+
+  context 'install_puppet_from_freebsd_ports_on' do
+    it 'installs puppet on FreeBSD 9' do
+      expect(freebsdhost9).to receive(:install_package).with('puppet')
+
+      subject.install_puppet_from_freebsd_ports_on( freebsdhost9, {}  )
+    end
+
+    it 'installs puppet on FreeBSD 10' do
+      expect(freebsdhost10).to receive(:install_package).with('sysutils/puppet')
+
+      subject.install_puppet_from_freebsd_ports_on( freebsdhost10, {}  )
     end
   end
 


### PR DESCRIPTION
Refactored to use native method and allow installing on an array of hosts