### PR TITLE
(BKR-387) environment not being preserved between ssh connections...

### DIFF
--- a/acceptance/tests/base/host.rb
+++ b/acceptance/tests/base/host.rb
@@ -42,6 +42,25 @@ hosts.each do |host|
   assert_match(/TEST=3(;|:)2(;|:)1$/, val, "add_env_var can correctly add env vars")
 end
 
+step "#add_env_var : can preserve an environment between ssh connections"
+hosts.each do |host|
+  host.clear_env_var("test")
+  logger.debug("add TEST=1")
+  host.add_env_var("TEST", "1")
+  logger.debug("add TEST=1 again (shouldn't create duplicate entry)")
+  host.add_env_var("test", "1")
+  logger.debug("add test=2")
+  host.add_env_var("test", "2")
+  logger.debug("ensure that TEST env var has correct setting")
+  logger.debug("add test=3")
+  host.add_env_var("test", "3")
+  logger.debug("close the connection")
+  host.close
+  logger.debug("ensure that TEST env var has correct setting")
+  val = host.get_env_var("test")
+  assert_match(/TEST=3(;|:)2(;|:)1$/, val, "can preserve an environment between ssh connections")
+end
+
 step "#delete_env_var : can delete an environment"
 hosts.each do |host|
   logger.debug("remove TEST=3")

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -70,10 +70,10 @@ module Unix::Exec
   end
 
   # Converts the provided environment file to a new shell script in /etc/profile.d, then sources that file.
-  # This is for sles based hosts.
+  # This is for sles and debian based hosts.
   # @param [String] env_file The ssh environment file to read from
   def mirror_env_to_profile_d env_file
-    if self[:platform] =~ /sles-/
+    if self[:platform] =~ /sles-|debian/
       @logger.debug("mirroring environment to /etc/profile.d on sles platform host")
       cur_env = exec(Beaker::Command.new("cat #{env_file}")).stdout
       shell_env = ''
@@ -88,7 +88,7 @@ module Unix::Exec
       exec(Beaker::Command.new("source #{self[:profile_d_env_file]}"))
     else
       #noop
-      @logger.debug("will not mirror environment to /etc/profile.d on non-sles platform host")
+      @logger.debug("will not mirror environment to /etc/profile.d on non-sles/debian platform host")
     end
   end
 


### PR DESCRIPTION
... on debian

- mirror the env to /etc/profile.d/beaker_env.sh
- add and acceptance test to ensure that environment variables are
  preserved between ssh connections for a SUT