### PR TITLE
(BKR-388) Beaker::Host::Mac#touch returns non-existent path

### DIFF
--- a/lib/beaker/host/mac.rb
+++ b/lib/beaker/host/mac.rb
@@ -5,10 +5,11 @@ end
 module Mac
     class Host < Unix::Host
 
-    [ 'user', 'group', 'pkg' ].each do |lib|
+    [ 'exec', 'user', 'group', 'pkg' ].each do |lib|
       require "beaker/host/mac/#{lib}"
     end
 
+    include Mac::Exec
     include Mac::User
     include Mac::Group
     include Mac::Pkg

--- a/lib/beaker/host/mac/exec.rb
+++ b/lib/beaker/host/mac/exec.rb
@@ -1,0 +1,8 @@
+module Mac::Exec
+  include Beaker::CommandFactory
+
+  def touch(file, abs=true)
+    (abs ? '/usr/bin/touch' : 'touch') + " #{file}"
+  end
+
+end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -364,6 +364,24 @@ module Beaker
 
       end
 
+    end
+
+    describe "#touch" do
+
+      it "generates the right absolute command for a windows host" do
+        @platform = 'windows'
+        expect( host.touch('touched_file') ).to be == "c:\\\\windows\\\\system32\\\\cmd.exe /c echo. 2> touched_file"
+      end
+
+      it "generates the right absolute command for a unix host" do
+        @platform = 'centos'
+        expect( host.touch('touched_file') ).to be == "/bin/touch touched_file"
+      end
+
+      it "generates the right absolute command for an osx host" do
+        @platform = 'osx'
+        expect( host.touch('touched_file') ).to be == "/usr/bin/touch touched_file"
+      end
 
     end
 


### PR DESCRIPTION
- ensure that you can run the host.touch command successfully on mac
- ride along: touch also broken on windows, fixed and operational
- added acceptance test to ensure that this works against all platforms