### PR TITLE
(BKR-390) Scooter pipeline is using pe-httpd instead of pe-puppetserver

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -35,8 +35,9 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def configure_foss_defaults_on( hosts )
           block_on hosts do |host|
-            if (host[:version] && (not version_is_less(host[:version], '4.0'))) or host['type'] && host['type'] =~ /aio/
-              # add foss defaults to host
+            if (not_controller(host) && host[:version] && (not version_is_less(host[:version], '4.0'))) \
+              or (host['type'] && host['type'] =~ /aio/)
+              # add aio defaults to host
               add_aio_defaults_on(host)
             else
               add_foss_defaults_on(host)

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -26,7 +26,8 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def configure_pe_defaults_on( hosts )
           block_on hosts do |host|
-            if (host[:pe_ver] && (not version_is_less(host[:pe_ver], '4.0'))) or (host['type'] && host['type'] =~ /aio/)
+            if (not_controller(host) && host[:pe_ver] && (not version_is_less(host[:pe_ver], '4.0'))) \
+              or (host['type'] && host['type'] =~ /aio/)
               # add pe defaults to host
               add_aio_defaults_on(host)
             else

--- a/lib/beaker/dsl/roles.rb
+++ b/lib/beaker/dsl/roles.rb
@@ -89,6 +89,35 @@ module Beaker
         find_host_with_role :default
       end
 
+      # Determine if host is not a controller, does not have roles 'master',
+      # 'dashboard' or 'database'.
+      #
+      # @return [Boolean]      True if agent-only, false otherwise
+      #
+      # @example Basic usage
+      #     if not_controller(host)
+      #       puts "this host isn't in charge!"
+      #     end
+      #
+      def not_controller(host)
+        controllers = ['dashboard', 'database', 'master', 'console']
+        matched_roles = host['roles'].select { |v| controllers.include?(v) }
+        matched_roles.length == 0
+      end
+
+      # Determine if this host is exclusively an agent (only has a single role 'agent')
+      #
+      #
+      # @return [Boolean]      True if agent-only, false otherwise
+      #
+      # @example Basic usage
+      #     if agent_only(host)
+      #       puts "this host is ONLY an agent!"
+      #     end
+      def agent_only(host)
+        host['roles'].length == 1 && host['roles'].include?('agent')
+      end
+
       #Create a new role method for a given arbitrary role name.  Makes it possible to be able to run
       #commands without having to refer to role by String or Symbol.  Will not add a new method 
       #definition if the name is already in use.

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -75,11 +75,19 @@ describe ClassMixedWithDSLInstallUtils do
       subject.configure_foss_defaults_on( hosts )
     end
 
-    it 'uses aio paths for hosts of version >= 4.0' do
+    it 'uses aio paths for hosts of version >= 4.0, except for master/database/dashboard' do
+      agents = []
+      not_agents = []
       hosts.each do |host|
         host[:version] = '4.0'
+        if subject.agent_only(host)
+          agents << host
+        else
+          not_agents << host
+        end
       end
-      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_aio_defaults_on).exactly(agents.length).times
+      expect(subject).to receive(:add_foss_defaults_on).exactly(not_agents.length).times
       expect(subject).to receive(:add_puppet_paths_on).exactly(hosts.length).times
 
       subject.configure_foss_defaults_on( hosts )

--- a/spec/beaker/dsl/roles_spec.rb
+++ b/spec/beaker/dsl/roles_spec.rb
@@ -96,6 +96,25 @@ describe ClassMixedWithDSLRoles do
       expect( subject.database ).to be_nil
     end
   end
+  describe '#not_controller' do
+    it 'returns true when a host does not have the roles master/database/dashboard' do
+      expect( subject.not_controller(agent1) ).to be == true
+    end
+    it 'returns false when a host has one of the roles master/database/dashboard' do
+      expect( subject.not_controller(a_and_dash) ).to be == false
+    end
+  end
+  describe '#agent_only' do
+    it 'returns true when a host has the single role agent' do
+      expect( subject.agent_only(agent1) ).to be == true
+    end
+    it 'returns false when a host has more than a single role' do
+      expect( subject.agent_only(a_and_dash) ).to be == false
+    end
+    it 'returns false when a host has the role master' do
+      expect( subject.agent_only(master) ).to be == false
+    end
+  end
   describe '#default' do
     it 'returns the default host when one is specified' do
       @hosts = [ db, agent1, agent2, default, master]


### PR DESCRIPTION
- only use aio defaults on agents that are not master, database or
  dashboard (was previously using aio defaults/paths on all hosts
  identified as being >= 4.0)