### PR TITLE
(maint) Allow PE puppet-agent installs on custom roles

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -509,8 +509,9 @@ module Beaker
         def create_agent_specified_arrays(hosts)
           hosts_agent_only = []
           hosts_not_agent_only = []
+          non_agent_only_roles = %w(master database dashboard console frictionless)
           hosts.each do |host|
-            if host['roles'] && host['roles'].length == 1 && host['roles'][0] == 'agent'
+            if host['roles'].none? {|role| non_agent_only_roles.include?(role) }
               hosts_agent_only << host
             else
               hosts_not_agent_only << host


### PR DESCRIPTION
Previously we installed puppet-agent on a host if there was the agent
role and no other role assigned to it. This prevents assigning a
puppet-agent node the "default" role to be used as the default test
target, or allow any other custom roles.

To allow assigning the "default" or custom roles to a puppet-agent node
we list the non-puppet-agnet roles we know how to generate installation answers
for and use that list to determine what nodes are puppet-agent or not.
