### PR TITLE
(BKR-397) Use yum for installing pe promoted puppet-agent

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1143,7 +1143,7 @@ module Beaker
             case variant
             when /^(fedora|el|centos|sles)$/
               on host, "tar -zxvf #{onhost_copied_download} -C #{onhost_copy_base}"
-              on host, "rpm -ivh #{onhost_copied_file}"
+              on host, "yum --nogpgcheck localinstall -y #{onhost_copied_file}"
             when /^(debian|ubuntu|cumulus)$/
               on host, "tar -zxvf #{onhost_copied_download} -C #{onhost_copy_base}"
               on host, "dpkg -i --force-all #{onhost_copied_file}"


### PR DESCRIPTION
Prior to this we used rpm, which means puppet-agent won't resolve its dependency on dmidecode for EL systems.

To ensure that it correctly resolves that dependency we need to use yum.