### PR TITLE
(BKR-401) fix race in OpenStack volume deletion

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -153,6 +153,7 @@ module Beaker
       vm.volumes.each do |vol|
         @logger.debug "Deleting volume #{vol.name} for OpenStack host #{vm.name}"
         vm.detach_volume(vol.id)
+        vol.wait_for { ready? }
         vol.destroy
       end
     end


### PR DESCRIPTION
There is a delay between a volume being detached from a virtual machine and
when it is ready to be deleted.  The code as it stands is likely to hit a 400
error as the volume is still in the 'detaching' state.  Add in a wait_for
statement to allow the volume to get back into the 'available' state before
deleting