### PR TITLE
(BKR-403) Use rpm on sles for pe puppet-agent

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1141,9 +1141,12 @@ module Beaker
             scp_to host, File.join(copy_dir_local, download_file), onhost_copy_base
 
             case variant
-            when /^(fedora|el|centos|sles)$/
+            when /^(fedora|el|centos)$/
               on host, "tar -zxvf #{onhost_copied_download} -C #{onhost_copy_base}"
               on host, "yum --nogpgcheck localinstall -y #{onhost_copied_file}"
+            when /^(sles)$/
+              on host, "tar -zxvf #{onhost_copied_download} -C #{onhost_copy_base}"
+              on host, "rpm -ihv #{onhost_copied_file}"
             when /^(debian|ubuntu|cumulus)$/
               on host, "tar -zxvf #{onhost_copied_download} -C #{onhost_copy_base}"
               on host, "dpkg -i --force-all #{onhost_copied_file}"


### PR DESCRIPTION
In BKR-397 we updated rpm using platforms to use yum instead of rpm in
the install_puppet_agent_pe_promoted_repo, however it wasn't noticed
that SLES was also an rpm using platform in the match that doesn't also
include yum.

This patch moves SLES platforms into their own branch of logic that uses
the old rpm installation method while retaining the yum based
installation for other platforms.