### PR TITLE
(BKR-402) Regression in Beaker 2.18.0 AIO testing for PuppetDB usage

### DIFF
--- a/lib/beaker/dsl/install_utils/aio_defaults.rb
+++ b/lib/beaker/dsl/install_utils/aio_defaults.rb
@@ -10,7 +10,6 @@ module Beaker
         #
         AIO_DEFAULTS = {
           'unix' => {
-            'puppetservice'         => 'pe-puppetserver',
             'puppetbindir'          => '/opt/puppetlabs/bin',
             'privatebindir'         => '/opt/puppetlabs/puppet/bin',
             'distmoduledir'         => '/etc/puppetlabs/code/modules',

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -39,6 +39,8 @@ module Beaker
               or (host['type'] && host['type'] =~ /aio/)
               # add aio defaults to host
               add_aio_defaults_on(host)
+              # provide a sane default here for puppetservice
+              host['puppetservice'] ||= 'puppetserver'
             else
               add_foss_defaults_on(host)
             end

--- a/lib/beaker/dsl/install_utils/pe_defaults.rb
+++ b/lib/beaker/dsl/install_utils/pe_defaults.rb
@@ -11,7 +11,7 @@ module Beaker
         PE_DEFAULTS = {
           'mac' => {
             'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
-            'puppetservice'    => 'pe-httpd',
+            'puppetservice'    => 'pe-puppetserver',
             'puppetpath'       => '/etc/puppetlabs/puppet',
             'puppetconfdir'    => '/etc/puppetlabs/puppet',
             'puppetcodedir'    => '/etc/puppetlabs/puppet',
@@ -26,7 +26,7 @@ module Beaker
           },
           'unix' => {
             'puppetserver-confdir' => '/etc/puppetlabs/puppetserver/conf.d',
-            'puppetservice'    => 'pe-httpd',
+            'puppetservice'    => 'pe-puppetserver',
             'puppetpath'       => '/etc/puppetlabs/puppet',
             'puppetconfdir'    => '/etc/puppetlabs/puppet',
             'puppetbin'        => '/opt/puppet/bin/puppet',
@@ -40,7 +40,7 @@ module Beaker
             'sitemoduledir'    => '/opt/puppet/share/puppet/modules',
           },
           'windows' => { #cygwin windows
-            'puppetservice' => 'pe-httpd',
+            'puppetservice' => 'pe-puppetserver',
             'puppetpath'    => '`cygpath -smF 35`/PuppetLabs/puppet/etc',
             'puppetconfdir' => '`cygpath -smF 35`/PuppetLabs/puppet/etc',
             'puppetcodedir' => '`cygpath -smF 35`/PuppetLabs/puppet/etc',
@@ -53,7 +53,7 @@ module Beaker
             'privatebindir' => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet Enterprise/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet Enterprise/sys/ruby/bin',
           },
           'pswindows' => { #windows windows
-            'puppetservice' => 'pe-httpd',
+            'puppetservice' => 'pe-puppetserver',
             'puppetpath'    => 'C:\\ProgramData\\PuppetLabs\\puppet\\etc',
             'puppetconfdir' => 'C:\\ProgramData\\PuppetLabs\\puppet\\etc',
             'puppetcodedir' => 'C:\\ProgramData\\PuppetLabs\\puppet\\etc',
@@ -79,10 +79,10 @@ module Beaker
             host['group'] = 'pe-puppet'
           end
           host['type'] = 'pe'
-          # newer pe requires a different puppetservice name, set it here on the master
+          # older pe requires a different puppetservice name, set it here on the master
           if host['roles'].include?('master')
-            if host['pe_ver'] and (not version_is_less(host['pe_ver'], '3.4'))
-              host['puppetservice'] = 'pe-puppetserver'
+            if host['pe_ver'] and (version_is_less(host['pe_ver'], '3.4'))
+              host['puppetservice'] = 'pe-httpd'
             end
           end
         end

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -28,6 +28,8 @@ module Beaker
           block_on hosts do |host|
             if host[:pe_ver] && aio_version?(host) or (host['type'] && host['type'] =~ /aio/)
               add_aio_defaults_on(host)
+              # provide a sane default here for puppetservice
+              host['puppetservice'] ||= 'pe-puppetserver'
             else
               add_pe_defaults_on(host)
             end


### PR DESCRIPTION
- provide a sane default for puppetservice for aio defaults, but allow
  override with a user setting