### PR TITLE
(maint) Moves various VB options out of `disk_path` logic

### DIFF
--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -52,17 +52,22 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
       end
     end
 
+    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
+
+    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
+
+    provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
+
+    provider_section << "      [\"modifyvm\", :id, \"--cpuidset\", \"1\",\"000206a7\",\"02100800\",\"1fbae3bf\",\"bfebfbff\"\]" if /osx/i.match(host['platform'])
+
     if host['disk_path']
       unless File.exist?(host['disk_path'])
         host['disk_path'] = File.join(host['disk_path'], "#{host.name}.vmdk")
         provider_section << "      vb.customize ['createhd', '--filename', '#{host['disk_path']}', '--size', #{host['disk_size'] ||= 5 * 1024}, '--format', 'vmdk']\n"
       end
       provider_section << "      vb.customize ['storageattach', :id, '--storagectl', 'SATA Controller', '--port', 1, '--device', 0, '--type', 'hdd', '--medium','#{host['disk_path']}']\n"
-      provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
-      provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
-      provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
-      provider_section << "      [\"modifyvm\", :id, \"--cpuidset\", \"1\",\"000206a7\",\"02100800\",\"1fbae3bf\",\"bfebfbff\"\]" if /osx/i.match(host['platform'])
     end
+
     provider_section << "    end\n"
 
     provider_section


### PR DESCRIPTION
Looks like these got moved into the `if` logic for `disk_path` accidentally around v2.8. This means that you can no longer use these options without adding disk_path logic in later versions of Beaker. This moves them back into their own section.