### PR TITLE
(BKR-405) The "install_pe" DSL Method Fails to Install SG...

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -623,13 +623,15 @@ module Beaker
               end
             end
 
-            # The agent service is `pe-puppet` everywhere EXCEPT certain linux distros on PE 2.8
-            # In all the case that it is different, this init script will exist. So we can assume
-            # that if the script doesn't exist, we should just use `pe-puppet`
-            agent_service = 'pe-puppet-agent'
-            agent_service = 'pe-puppet' unless agent.file_exist?('/etc/init.d/pe-puppet-agent')
             # In 4.0 this was changed to just be `puppet`
-            agent_service = 'puppet' unless version_is_less(agent['pe_ver'], '4.0')
+            agent_service = 'puppet'
+            if !aio_version?(agent)
+              # The agent service is `pe-puppet` everywhere EXCEPT certain linux distros on PE 2.8
+              # In all the case that it is different, this init script will exist. So we can assume
+              # that if the script doesn't exist, we should just use `pe-puppet`
+              agent_service = 'pe-puppet-agent'
+              agent_service = 'pe-puppet' unless agent.file_exist?('/etc/init.d/pe-puppet-agent')
+            end
 
             # Under a number of stupid circumstances, we can't stop the
             # agent using puppet.  This is usually because of issues with

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1094,10 +1094,10 @@ module Beaker
         def install_puppet_agent_pe_promoted_repo_on( hosts, opts )
           opts[:puppet_agent_version] ||= 'latest'
           block_on hosts do |host|
-            pe_ver = host[:pe_ver] || opts[:pe_ver] || '4.0'
+            pe_ver = host[:pe_ver] || opts[:pe_ver] || '4.0.0-rc1'
             variant, version, arch, codename = host['platform'].to_array
             opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
-            opts[:download_url] = "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{ pe_ver }/#{ opts[:puppet_agent_version] }/repos/"
+            opts[:download_url] = "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{ pe_ver }/#{ opts[:puppet_agent_version] }/repos"
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
             opts[:copy_dir_external]  ||= File.join('/', 'root')
             opts[:puppet_collection] ||= 'PC1'
@@ -1126,7 +1126,7 @@ module Beaker
               # - we do not have install_32 set on host
               # - we do not have install_32 set globally
               arch_suffix = should_install_64bit ? '64' : '86'
-              release_path += "windows/"
+              release_path += "/windows/"
               release_file = "/puppet-agent-x#{arch_suffix}.msi"
               download_file = "puppet-agent-x#{arch_suffix}.msi"
             when /^osx$/

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -344,6 +344,7 @@ module Beaker
         # @option opts [Boolean] :fetch_local_then_push_to_host determines whether
         #                 you use Beaker as the middleman for this (true), or curl the
         #                 file from the host (false; default behavior)
+        # @option opts [Boolean] :masterless Are we performing a masterless installation?
         #
         # @example
         #  do_install(hosts, {:type => :upgrade, :pe_dir => path, :pe_ver => version, :pe_ver_win =>  version_win})
@@ -354,8 +355,7 @@ module Beaker
         # @api private
         #
         def do_install hosts, opts = {}
-          masterless = (defined? options) ? options[:masterless] : false
-          opts[:masterless] = masterless # has to pass masterless down for answer generation awareness
+          masterless = opts[:masterless]
           opts[:type] = opts[:type] || :install
           unless masterless
             pre30database = version_is_less(opts[:pe_ver] || database['pe_ver'], '3.0')
@@ -416,10 +416,10 @@ module Beaker
           install_hosts.each do |host|
             if agent_only_check_needed && hosts_agent_only.include?(host)
               host['type'] = 'aio'
-              install_puppet_agent_pe_promoted_repo_on(host, { :puppet_agent_version => opts[:puppet_agent_version],
-                                                               :puppet_agent_sha => opts[:puppet_agent_sha],
-                                                               :pe_ver => opts[:pe_ver],
-                                                               :puppet_collection => opts[:puppet_collection] })
+              install_puppet_agent_pe_promoted_repo_on(host, { :puppet_agent_version => host[:puppet_agent_version] || opts[:puppet_agent_version],
+                                                               :puppet_agent_sha => host[:puppet_agent_sha] || opts[:puppet_agent_sha],
+                                                               :pe_ver => host[:pe_ver] || opts[:pe_ver],
+                                                               :puppet_collection => host[:puppet_collection] || opts[:puppet_collection] })
               setup_defaults_and_config_helper_on(host, master, [0, 1])
             elsif host['platform'] =~ /windows/
               on host, installer_cmd(host, opts)
@@ -555,9 +555,10 @@ module Beaker
         # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
         #                            or a role (String or Symbol) that identifies one or more hosts.
         # @!macro common_opts
+        # @option opts [Boolean] :masterless Are we performing a masterless installation?
         # @option opts [String] :puppet_agent_version  Version of puppet-agent to install. Required for PE agent
         #                                 only hosts on 4.0+
-        # @option opts [String] :puppet_agent_sha The sha of puppet-agent to install, defaults to puppet-agent-version.
+        # @option opts [String] :puppet_agent_sha The sha of puppet-agent to install, defaults to puppet_agent_version.
         #                                 Required for PE agent only hosts on 4.0+
         # @option opts [String] :pe_ver   The version of PE (will also use host['pe_ver']), defaults to '4.0'
         # @option opts [String] :puppet_collection   The puppet collection for puppet-agent install.
@@ -572,14 +573,19 @@ module Beaker
         def install_pe_on(hosts, opts)
           #process the version files if necessary
           confine_block(:to, {}, hosts) do
-            hosts.each do |host|
+            sorted_hosts.each do |host|
               host['pe_dir'] ||= opts[:pe_dir]
               if host['platform'] =~ /windows/
-                host['pe_ver'] = host['pe_ver'] || opts['pe_ver'] ||
-                  Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || opts[:pe_dir], opts[:pe_version_file_win])
+                # we don't need the pe_version if:
+                # * master pe_ver > 4.0
+                if not (!opts[:masterless] && master[:pe_ver] && !version_is_less(master[:pe_ver], '3.99'))
+                  host['pe_ver'] ||= Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || opts[:pe_dir], opts[:pe_version_file_win])
+                else
+                  # inherit the master's version
+                  host['pe_ver'] ||= master[:pe_ver]
+                end
               else
-                host['pe_ver'] = host['pe_ver'] || opts['pe_ver'] ||
-                  Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || opts[:pe_dir], opts[:pe_version_file])
+                host['pe_ver'] ||= Beaker::Options::PEVersionScraper.load_pe_version(host[:pe_dir] || opts[:pe_dir], opts[:pe_version_file])
               end
             end
             do_install sorted_hosts, opts

--- a/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
@@ -394,7 +394,6 @@ describe ClassMixedWithDSLHelpers do
       allow( el_agent ).to receive( :puppet ).and_return( { 'vardir' => vardir } )
 
       expect( el_agent ).to receive( :file_exist? ).with("/var/state/agent_catalog_run.lock").and_return(false)
-      expect( el_agent ).to receive( :file_exist? ).with("/etc/init.d/pe-puppet-agent").and_return(true)
 
       expect( subject ).to receive( :puppet_resource ).with( "service", "puppet", "ensure=stopped").once
       expect( subject ).to receive( :on ).once

--- a/spec/beaker/dsl/install_utils/pe_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_utils_spec.rb
@@ -394,9 +394,9 @@ describe ClassMixedWithDSLInstallUtils do
         :pe_ver => '3.0',
         :roles => ['agent']
       }, 1)
+      opts[:masterless] = true
 
       allow( subject ).to receive( :hosts ).and_return( hosts )
-      allow( subject ).to receive( :options ).and_return({ :masterless => true })
       allow( subject ).to receive( :on ).and_return( Beaker::Result.new( {}, '' ) )
       allow( subject ).to receive( :fetch_pe ).and_return( true )
       allow( subject ).to receive( :create_remote_file ).and_return( true )
@@ -454,9 +454,9 @@ describe ClassMixedWithDSLInstallUtils do
       #run installer on all hosts
       expect( subject ).to receive( :on ).with( hosts[0], /puppet-enterprise-installer/ ).once
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with( hosts[1],
-                                                                                     {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>nil, :puppet_collection=>nil} ).once
+                                                                                     {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>hosts[1][:pe_ver], :puppet_collection=>nil} ).once
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with( hosts[2],
-                                                                                     {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>nil, :puppet_collection=>nil} ).once
+                                                                                     {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>hosts[2][:pe_ver], :puppet_collection=>nil} ).once
       hosts.each do |host|
         expect( subject ).to receive( :add_aio_defaults_on ).with( host ).once
         expect( subject ).to receive( :sign_certificate_for ).with( host ).once
@@ -510,7 +510,7 @@ describe ClassMixedWithDSLInstallUtils do
       #run installer on all hosts
       expect( subject ).to receive( :on ).with( hosts[0], /puppet-enterprise-installer/ ).once
       expect( subject ).to receive( :install_puppet_agent_pe_promoted_repo_on ).with( hosts[1],
-                                                                                      {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>nil, :puppet_collection=>nil} ).once
+                                                                                      {:puppet_agent_version=>nil, :puppet_agent_sha=>nil, :pe_ver=>hosts[1][:pe_ver], :puppet_collection=>nil} ).once
       expect( subject ).to receive( :on ).with( hosts[2], /puppet-enterprise-installer/ ).once
       hosts.each do |host|
         if subject.aio_version?(host)


### PR DESCRIPTION
...if "Latest-win" Version File is Missing

- do not attempt to determine windows pe_ver if master version is
  greater than 3.99, just inherit from the master (if it exists)
- there's probably more edge cases here, but I don't believe that
  install_pe can handle every combinations of platforms/versions