### PR TITLE
(BKR-410) `confine :except, {}, [host1,host2]` does not work as expected

### DIFF
--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -167,6 +167,10 @@ module Beaker
       # @example Confining to an already defined subset of hosts
       #     confine :to, {}, agents
       #
+      # @example Confining from  an already defined subset of hosts
+      #     confine :except, {}, agents
+      #
+      #
       # @return [Array<Host>] Returns an array of hosts that are still valid
       #   targets for this tests case.
       # @raise [SkipTest] Raises skip test if there are no valid hosts for
@@ -175,10 +179,17 @@ module Beaker
         hosts_to_modify = host_array || hosts
         case type
         when :except
-          hosts_to_modify = hosts_to_modify - select_hosts(criteria, hosts_to_modify, &block)
+          if criteria and ( not criteria.empty? )
+            hosts_to_modify = hosts_to_modify - select_hosts(criteria, hosts_to_modify, &block)
+          else
+            # confining to all hosts *except* provided array of hosts
+            hosts_to_modify = hosts - host_array
+          end
         when :to
           if criteria and ( not criteria.empty? )
             hosts_to_modify = select_hosts(criteria, hosts_to_modify, &block)
+          else
+            # confining to only hosts in provided array of hosts
           end
         else
           raise "Unknown option #{type}"

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -128,12 +128,19 @@ describe ClassMixedWithDSLStructure do
       subject.confine( :to, {} )
     end
 
-    it 'uses a provided host subset when no criteria is provided' do
-
+    it ':to - uses a provided host subset when no criteria is provided' do
       subset = ['host1', 'host2']
       hosts = subset.dup << 'host3'
       expect( subject ).to receive( :hosts= ).with( subset )
       subject.confine :to, {}, subset
+    end
+
+    it ':except - excludes provided host subset when no criteria is provided' do
+      subset = ['host1', 'host2']
+      hosts = subset.dup << 'host3'
+      allow( subject ).to receive( :hosts ).and_return(hosts)
+      expect( subject ).to receive( :hosts= ).with( hosts - subset )
+      subject.confine :except, {}, subset
     end
 
     it 'raises when given mode is not :to or :except' do


### PR DESCRIPTION
- add support to confine to all hosts *except* those in provided host
  array