### PR TITLE
(BKR-411) Set host.ip for Fusion hypervisor

### DIFF
--- a/lib/beaker/hypervisor/fusion.rb
+++ b/lib/beaker/hypervisor/fusion.rb
@@ -54,6 +54,15 @@ module Beaker
         end
         time = Time.now - start
         @logger.notify "Spent %.2f seconds resuming VM" % time
+
+        @logger.notify "Obtaining IP information for #{host.name}"
+        ip = vm.network_info.data[vm.network_info.data.keys[0]]['ip_address']
+        if ip.empty?
+          @logger.notify "Unable to obtain IP information for #{host.name}. Continuing."
+        else
+          @logger.notify "Found IP address #{ip} for #{host.name}. Setting host.ip value"
+          host[:ip] = ip
+        end
       end
       end #revert_fusion
 

--- a/spec/beaker/hypervisor/fusion_spec.rb
+++ b/spec/beaker/hypervisor/fusion_spec.rb
@@ -6,13 +6,14 @@ module Beaker
 
     before :each do
      stub_const( "Fission::VM", true )
-      @hosts = make_hosts()
+      @hosts = make_hosts({:ip => nil})
       MockFission.presets( @hosts )
       allow_any_instance_of( Fusion ).to receive( :require ).with( 'fission' ).and_return( true )
-      fusion.instance_variable_set( :@fission, MockFission ) 
+      fusion.instance_variable_set( :@fission, MockFission )
     end
 
     it "can interoperate with the fission library to provision hosts"  do
+      allow( fusion ).to receive( :try_ssh_connection )
       fusion.provision
     end
 
@@ -34,6 +35,44 @@ module Beaker
     it 'host fails init with nil snapshot' do
       @hosts[0][:snapshot] = nil
       expect{ Beaker::Fusion.new( @hosts, make_opts) }.to raise_error(/specify a snapshot/)
+    end
+
+    context 'connection can be made by host.name' do
+      before :each do
+        allow( fusion ).to receive( :try_ssh_connection )
+      end
+
+      it 'does not set host[:ip] if a connection can be made my host.name' do
+        fusion.provision
+        @hosts.each do |host|
+          expect(host['ip']).to eql(nil)
+        end
+      end
+    end
+
+    context 'if connection cannot be made by host.name,' do
+      before :each do
+        allow( fusion ).to receive( :try_ssh_connection ).with(/^\d+\.\d+\.\d+\.\d+$/, anything, anything).and_return(true)
+        allow( fusion ).to receive( :try_ssh_connection ).with(/^[a-z]/, anything, anything).and_raise(SocketError)
+      end
+
+      it 'then intropects IP address and sets host[:ip]' do
+        fusion.provision
+        @hosts.each do |host|
+          expect(host['ip']).not_to eql(nil)
+          expect(host['ip']).to eql(MockFission.all.data.find{|h| h.name == host.name}.network_info.data.first[1]['ip_address'])
+        end
+      end
+
+      it 'then host fails init if ip cannot be introspected' do
+        allow_any_instance_of( MockFissionVM ).to receive( :network_info ).and_return( Response.new(0,'',{'eth0' => {'ip_address' => nil}}))
+        expect{ fusion.provision }.to raise_error(/ip address is unavailable/)
+      end
+
+      it 'then sets host dns_name to instance.dns_name' do
+        expect(fusion).to receive(:hack_etc_hosts).with(@hosts, anything).once
+        fusion.provision
+      end
     end
 
   end

--- a/spec/mock_fission.rb
+++ b/spec/mock_fission.rb
@@ -7,12 +7,13 @@ class Response
   end
 end
 
-class MockFissionVM 
+class MockFissionVM
   attr_accessor :name
   @@snaps = []
   def initialize name
     @name = name
     @running = true
+    @network_info = {'eth0' => {'ip_address' => '1.2.3.4'} }
   end
 
   def self.set_snapshots snaps
@@ -28,11 +29,11 @@ class MockFissionVM
   end
 
   def running?
-    Response.new(0, '', @running) 
+    Response.new(0, '', @running)
   end
 
   def start opt
-    @running = true 
+    @running = true
   end
 
   def exists?
@@ -40,11 +41,11 @@ class MockFissionVM
   end
 
   def network_info
-    Response.new(0, '', {'eth0' => {'ip_address' => '1.2.3.4'} })
+    Response.new(0, '', @network_info)
   end
 end
 
-class MockFission 
+class MockFission
   @@vms = []
   def self.presets hosts
     snaps = []

--- a/spec/mock_fission.rb
+++ b/spec/mock_fission.rb
@@ -38,6 +38,10 @@ class MockFissionVM
   def exists?
     true
   end
+
+  def network_info
+    Response.new(0, '', {'eth0' => {'ip_address' => '1.2.3.4'} })
+  end
 end
 
 class MockFission 


### PR DESCRIPTION
This commit updates the Fusion hypervisor to set the host[:ip]
value based on the IP address obtained from querying the VM data
using the fission gem.

This removes the need for the user to have setup dns resolution to
the `host.name` prior to running beaker.