### PR TITLE
(maint) Always wait for Windows agent installs

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -95,7 +95,10 @@ module Beaker
           version = host['pe_ver'] || opts[:pe_ver]
           if host['platform'] =~ /windows/
             log_file = "#{File.basename(host['working_dir'])}.log"
-            pe_debug = host[:pe_debug] || opts[:pe_debug] ? " && cat #{log_file}" : ''
+            # cat may not be available with strictly Windows environments
+            # Prefer `type` as an alternative to `cat` if non-cygwin
+            win_cat = host.is_cygwin? ? "cat" : "type"
+            pe_debug = host[:pe_debug] || opts[:pe_debug] ? " && #{win_cat} #{log_file}" : ''
             "cd #{host['working_dir']} && cmd /C 'start /w msiexec.exe /qn /L*V #{log_file} /i #{host['dist']}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'#{pe_debug}"
           # Frictionless install didn't exist pre-3.2.0, so in that case we fall
           # through and do a regular install.

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -96,11 +96,7 @@ module Beaker
           if host['platform'] =~ /windows/
             log_file = "#{File.basename(host['working_dir'])}.log"
             pe_debug = host[:pe_debug] || opts[:pe_debug] ? " && cat #{log_file}" : ''
-            if host.is_cygwin?
-              "cd #{host['working_dir']} && cmd /C 'start /w msiexec.exe /qn /L*V #{log_file} /i #{host['dist']}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'#{pe_debug}"
-            else
-              "cd #{host['working_dir']} &&  msiexec.exe /qn /L*V #{log_file} /i #{host['dist']}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}#{pe_debug}"
-            end
+            "cd #{host['working_dir']} && cmd /C 'start /w msiexec.exe /qn /L*V #{log_file} /i #{host['dist']}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'#{pe_debug}"
           # Frictionless install didn't exist pre-3.2.0, so in that case we fall
           # through and do a regular install.
           elsif host['roles'].include? 'frictionless' and ! version_is_less(version, '3.2.0')


### PR DESCRIPTION
When installing Windows agents with cygwin or any other means, always
prefer `start /w` over just calling msiexec.

This adds to what was first introduced in 9c32cac.

Also adds using `type` over `cat` in pure Windows
 - If the host is not a cygwin environment, prefer `type` to produce the
   contents of the log file over `cat`. `type` is built-in, where `cat` is
   only available if someone has put *nix tools on the path, whether
   through a git install (MinGW tools), installing GnuWin utils or some
   other method.