### PR TITLE
(BKR-420) Allow easily installing latest puppet-agent

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -295,9 +295,6 @@ module Beaker
           opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
           opts[:puppet_collection] ||= 'pc1' #hi!  i'm case sensitive!  be careful!
           opts[:puppet_agent_version] ||= opts[:version] #backwards compatability with old parameter name
-          if not opts[:puppet_agent_version]
-            raise "must provide :puppet_agent_version (puppet-agent version) for install_puppet_agent_on"
-          end
 
           block_on hosts do |host|
             host[:type] = 'aio' #we are installing agent, so we want aio type


### PR DESCRIPTION
Prior to this we were over eagerly failing if there was no puppet-agent
version explicitly set.  Having install_puppet_agent install the latest
released version of puppet-agent is a desired and common workflow.

This patch removes the aggressive failing on non-specified puppet-agent
versions in `install_puppet_agent_on`