### PR TITLE
(BKR-412) clarify 'types' in beaker

### DIFF
--- a/lib/beaker/dsl/install_utils/aio_defaults.rb
+++ b/lib/beaker/dsl/install_utils/aio_defaults.rb
@@ -36,7 +36,6 @@ module Beaker
           else
             host['group'] = 'puppet'
           end
-          host['type'] = 'aio'
         end
 
         # Add the appropriate aio defaults to an array of hosts
@@ -60,7 +59,6 @@ module Beaker
           AIO_DEFAULTS[platform].each_pair do |key, val|
             host.delete(key)
           end
-          host['type'] = nil
           host['group'] = nil
         end
 

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -19,26 +19,6 @@ module Beaker
         include PEDefaults
         include PuppetUtils
 
-        # Set defaults and PATH for these hosts to be either pe or aio, have host['type'] == aio for aio settings, defaults
-        # to pe.
-        #
-        # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
-        #                            or a role (String or Symbol) that identifies one or more hosts.
-        def configure_pe_defaults_on( hosts )
-          block_on hosts do |host|
-            if host[:pe_ver] && aio_version?(host) or (host['type'] && host['type'] =~ /aio/)
-              add_aio_defaults_on(host)
-              # provide a sane default here for puppetservice
-              host['puppetservice'] ||= 'pe-puppetserver'
-            else
-              add_pe_defaults_on(host)
-            end
-            # add pathing env
-            add_puppet_paths_on(host)
-          end
-        end
-
-
         # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
         #   @option opts [Boolean] :silent (false) Do not produce log output
@@ -426,7 +406,7 @@ module Beaker
               setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
             elsif host['platform'] =~ /windows/
               on host, installer_cmd(host, opts)
-              configure_pe_defaults_on(host)
+              configure_type_defaults_on(host)
               if not host.is_cygwin?
                 # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
                 host.close
@@ -441,7 +421,7 @@ module Beaker
                   deploy_frictionless_to_master(host)
                 end
                 on host, installer_cmd(host, opts)
-                configure_pe_defaults_on(host)
+                configure_type_defaults_on(host)
               elsif host['platform'] =~ /osx|eos/
                 # If we're not frictionless, we need to run the OSX special-case
                 on host, installer_cmd(host, opts)
@@ -451,7 +431,7 @@ module Beaker
                 answers = Beaker::Answers.create(opts[:pe_ver] || host['pe_ver'], hosts, opts)
                 create_remote_file host, "#{host['working_dir']}/answers", answers.answer_string(host)
                 on host, installer_cmd(host, opts)
-                configure_pe_defaults_on(host)
+                configure_type_defaults_on(host)
               end
             end
 
@@ -539,7 +519,7 @@ module Beaker
         # @return nil
         # @api private
         def setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes=nil)
-          configure_pe_defaults_on(host)
+          configure_type_defaults_on(host)
           #set the certname and master
           on host, puppet("config set server #{master}")
           on host, puppet("config set certname #{host}")

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -556,14 +556,7 @@ module Beaker
         end
         # REMOVE POST BEAKER 3: backwards compatability, do some setup based upon the global type
         # this is the worst and i hate it
-        if host[:type]
-          case host[:type]
-          when /git|foss|aio/
-            Class.new.extend(Beaker::DSL).configure_foss_defaults_on(host)
-          when /pe/
-            Class.new.extend(Beaker::DSL).configure_pe_defaults_on(host)
-          end
-        end
+        Class.new.extend(Beaker::DSL).configure_type_defaults_on(host)
 
         #close the host to re-establish the connection with the new sshd settings
         host.close

--- a/lib/beaker/options/options_hash.rb
+++ b/lib/beaker/options/options_hash.rb
@@ -66,8 +66,6 @@ module Beaker
           :pe
         when /foss/
           :foss
-        when /aio/
-          :aio
         else
           :foss
         end

--- a/spec/beaker/dsl/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/puppet_utils_spec.rb
@@ -70,4 +70,61 @@ describe ClassMixedWithDSLInstallUtils do
       subject.configure_defaults_on(hosts, 'foss')
     end
   end
+
+  describe "#configure_type_defaults_on" do
+
+    it "can set foss defaults for foss type" do
+      hosts.each do |host|
+        host['type'] = 'foss'
+      end
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+    it "adds aio defaults to foss hosts when they have an aio foss puppet version" do
+      hosts.each do |host|
+        host['type'] = 'foss'
+        host['version'] = '4.0'
+      end
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+    it "adds aio defaults to foss hosts when they have type foss-aio" do
+      hosts.each do |host|
+        host['type'] = 'foss-aio'
+      end
+      expect(subject).to receive(:add_foss_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+    it "can set aio defaults for aio type (backwards compatability)" do
+      hosts.each do |host|
+        host['type'] = 'aio'
+      end
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+    it "can set pe defaults for pe type" do
+      hosts.each do |host|
+        host['type'] = 'pe'
+      end
+      expect(subject).to receive(:add_pe_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+    it "adds aio defaults to pe hosts when they an aio pe version" do
+      hosts.each do |host|
+        host['type'] = 'pe'
+        host['pe_ver'] = '4.0'
+      end
+      expect(subject).to receive(:add_pe_defaults_on).exactly(hosts.length).times
+      expect(subject).to receive(:add_aio_defaults_on).exactly(hosts.length).times
+      subject.configure_type_defaults_on(hosts)
+    end
+
+  end
 end

--- a/spec/beaker/dsl/roles_spec.rb
+++ b/spec/beaker/dsl/roles_spec.rb
@@ -116,20 +116,51 @@ describe ClassMixedWithDSLRoles do
     end
   end
   describe '#aio_version?' do
-    it 'returns true if the host doesn\'t have a :pe_ver' do
+    it 'returns false if the host doesn\'t have a :pe_ver or :version' do
       agent1[:pe_ver] = nil
-      expect( subject.aio_version?(agent1) ).to be === true
+      agent1[:version] = nil
+      expect( subject.aio_version?(agent1) ).to be === false
+    end
+    it 'returns false if :version < 4.0 and pe_ver is nil, type foss' do
+      agent1[:pe_ver] = nil
+      agent1[:version] = '3.8'
+      agent1[:type] = 'foss'
+      expect( subject.aio_version?(agent1) ).to be === false
     end
     it 'returns false if the host :pe_ver is set < 4.0' do
       agent1[:pe_ver] = '3.8'
+      expect( subject.aio_version?(agent1) ).to be === false
+    end
+    it 'returns false if the host :version is set < 4.0' do
+      agent1[:version] = '3.8'
       expect( subject.aio_version?(agent1) ).to be === false
     end
     it 'returns true if the host :pe_ver is 4.0' do
       agent1[:pe_ver] = '4.0'
       expect( subject.aio_version?(agent1) ).to be === true
     end
+    it 'returns true if the host :version is 4.0' do
+      agent1[:version] = '4.0'
+      expect( subject.aio_version?(agent1) ).to be === true
+    end
     it 'returns true if the host :pe_ver is 2015.5' do
       agent1[:pe_ver] = '2015.5'
+      expect( subject.aio_version?(agent1) ).to be === true
+    end
+    it 'returns true if the host has role aio' do
+      agent1[:roles] = agent1[:roles] | ['aio']
+      expect( subject.aio_version?(agent1) ).to be === true
+    end
+    it 'returns true if the host is type aio' do
+      agent1[:type] = 'aio'
+      expect( subject.aio_version?(agent1) ).to be === true
+    end
+    it 'returns true if the host is type aio-foss' do
+      agent1[:type] = 'aio-foss'
+      expect( subject.aio_version?(agent1) ).to be === true
+    end
+    it 'returns true if the host is type foss-aio' do
+      agent1[:type] = 'aio-foss'
       expect( subject.aio_version?(agent1) ).to be === true
     end
   end
@@ -172,13 +203,13 @@ describe ClassMixedWithDSLRoles do
   end
   describe '#add_role_def' do
     it 'raises an error on unsupported role format "1role"' do
-      expect { subject.add_role_def( "1role" ) }.to raise_error
+      expect { subject.add_role_def( "1role" ) }.to raise_error ArgumentError
     end
     it 'raises an error on unsupported role format "role_!a"' do
-      expect { subject.add_role_def( "role_!a" ) }.to raise_error
+      expect { subject.add_role_def( "role_!a" ) }.to raise_error ArgumentError
     end
     it 'raises an error on unsupported role format "role=="' do
-      expect { subject.add_role_def( "role==" ) }.to raise_error
+      expect { subject.add_role_def( "role==" ) }.to raise_error ArgumentError
     end
     it 'creates new method for role "role_correct!"' do
       test_role = "role_correct!"

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -97,7 +97,7 @@ describe Beaker do
 
       expect( Beaker::Command ).to receive( :new ).with("ntpdate -t 20 #{ntpserver}").exactly( 5 ).times
 
-      expect{ subject.timesync( hosts, options ) }.to raise_error
+      expect{ subject.timesync( hosts, options ) }.to raise_error(/NTP date was not successful after/)
     end
 
     it "can sync time on windows hosts" do
@@ -170,7 +170,7 @@ describe Beaker do
     it "raises an error on non el-5/6 host" do
       host = make_host( 'testhost', { :platform => Beaker::Platform.new('el-4-platform') } )
 
-      expect{ subject.epel_info_for( host, options )}.to raise_error
+      expect{ subject.epel_info_for( host, options )}.to raise_error(RuntimeError, /epel_info_for does not support el version/)
 
     end
 
@@ -572,6 +572,7 @@ describe Beaker do
       expect( Beaker::Command ).to receive( :new ).with( "mkdir -p #{Pathname.new(host[:ssh_env_file]).dirname}" ).once
       expect( Beaker::Command ).to receive( :new ).with( "chmod 0600 #{Pathname.new(host[:ssh_env_file]).dirname}" ).once
       expect( Beaker::Command ).to receive( :new ).with( "touch #{host[:ssh_env_file]}" ).once
+      expect_any_instance_of( Class ).to receive( :extend ).and_return( double( 'class' ).as_null_object )
       expect( Beaker::Command ).to receive( :new ).with( "cat #{host[:ssh_env_file]}" ).once
       expect( host ).to receive( :add_env_var ).with( 'PATH', '$PATH' ).once
       opts.each_pair do |key, value|

--- a/spec/beaker/options/options_hash_spec.rb
+++ b/spec/beaker/options/options_hash_spec.rb
@@ -58,11 +58,6 @@ module Beaker
           expect(newhash.get_type).to be === :foss
         end
 
-        it 'returns aio as expected in the normal case' do
-          newhash = options.merge({:type => 'aio'})
-          expect(newhash.get_type).to be === :aio
-        end
-
         it 'returns foss as the default' do
           newhash = options.merge({:type => 'git'})
           expect(newhash.get_type).to be === :foss

--- a/spec/mocks.rb
+++ b/spec/mocks.rb
@@ -77,12 +77,14 @@ module FakeHost
 
   def self.create(name = 'fakevm', platform = 'redhat-version-arch', options = {})
     options_hash = Beaker::Options::OptionsHash.new.merge(options)
+    options_hash[:logger] = RSpec::Mocks::Double.new('logger').as_null_object
     host = Beaker::Host.create(name, { 'platform' => Beaker::Platform.new(platform) } , options_hash)
     host.extend(MockedExec)
     host
   end
 
   module MockedExec
+
     def self.extended(other)
       other.instance_eval do
         send(:instance_variable_set, :@commands, [])


### PR DESCRIPTION
- having made 'aio' a type meant that we were losing pe/foss specific
  information (like the puppet service)
- make 'aio' a role that a host can have, meaning that the aio defaults
  will be installed overtop of any foss/pe defaults
- assume hosts with no pe/foss puppet version provided are aio