### PR TITLE
(BKR-421) Refactor MSI installation

### DIFF
--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -66,8 +66,6 @@ module Beaker
         # @param [Host] host The host that PE is to be installed on
         #                    For UNIX machines using the full PE installer, the host object must have the 'pe_installer' field set correctly.
         # @param [Hash{Symbol=>String}] opts The options
-        # @option opts [String] :pe_ver_win Default PE version to install or upgrade to on Windows hosts
-        #                          (Othersie uses individual Windows hosts pe_ver)
         # @option opts [String]  :pe_ver Default PE version to install or upgrade to
         #                          (Otherwise uses individual hosts pe_ver)
         # @option opts [Boolean] :pe_debug (false) Should we run the installer in debug mode?

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -1,4 +1,4 @@
-[ 'aio_defaults', 'pe_defaults', 'puppet_utils' ].each do |lib|
+[ 'aio_defaults', 'pe_defaults', 'puppet_utils', 'windows_utils' ].each do |lib|
     require "beaker/dsl/install_utils/#{lib}"
 end
 require "beaker-answers"
@@ -19,6 +19,7 @@ module Beaker
         include AIODefaults
         include PEDefaults
         include PuppetUtils
+        include WindowsUtils
 
         # @!macro [new] common_opts
         #   @param [Hash{Symbol=>String}] opts Options to alter execution.
@@ -74,16 +75,9 @@ module Beaker
         # @api private
         def installer_cmd(host, opts)
           version = host['pe_ver'] || opts[:pe_ver]
-          if host['platform'] =~ /windows/
-            log_file = "#{File.basename(host['working_dir'])}.log"
-            # cat may not be available with strictly Windows environments
-            # Prefer `type` as an alternative to `cat` if non-cygwin
-            win_cat = host.is_cygwin? ? "cat" : "type"
-            pe_debug = host[:pe_debug] || opts[:pe_debug] ? " && #{win_cat} #{log_file}" : ''
-            "cd #{host['working_dir']} && cmd /C 'start /w msiexec.exe /qn /L*V #{log_file} /i #{host['dist']}.msi PUPPET_MASTER_SERVER=#{master} PUPPET_AGENT_CERTNAME=#{host}'#{pe_debug}"
           # Frictionless install didn't exist pre-3.2.0, so in that case we fall
           # through and do a regular install.
-          elsif host['roles'].include? 'frictionless' and ! version_is_less(version, '3.2.0')
+          if host['roles'].include? 'frictionless' and ! version_is_less(version, '3.2.0')
             # PE 3.4 introduced the ability to pass in config options to the bash script in the form
             # of <section>:<key>=<value>
             frictionless_install_opts = []
@@ -404,12 +398,11 @@ module Beaker
               acceptable_exit_codes << 2 if opts[:type] == :upgrade
               setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
             elsif host['platform'] =~ /windows/
-              on host, installer_cmd(host, opts)
+              msi_opts = { 'PUPPET_MASTER_SERVER' => master, 'PUPPET_AGENT_CERTNAME' => host }
+              opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
+              msi_path = "#{host['working_dir']}\\#{host['dist']}.msi"
+              install_msi_on(host, msi_path, msi_opts, opts)
               configure_type_defaults_on(host)
-              if not host.is_cygwin?
-                # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
-                host.close
-              end
             else
               # We only need answers if we're using the classic installer
               version = host['pe_ver'] || opts[:pe_ver]

--- a/lib/beaker/dsl/install_utils/pe_utils.rb
+++ b/lib/beaker/dsl/install_utils/pe_utils.rb
@@ -394,15 +394,18 @@ module Beaker
                                                                :puppet_agent_sha => host[:puppet_agent_sha] || opts[:puppet_agent_sha],
                                                                :pe_ver => host[:pe_ver] || opts[:pe_ver],
                                                                :puppet_collection => host[:puppet_collection] || opts[:puppet_collection] })
+              # 1 since no certificate found and waitforcert disabled
               acceptable_exit_codes = [0, 1]
               acceptable_exit_codes << 2 if opts[:type] == :upgrade
               setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
             elsif host['platform'] =~ /windows/
-              msi_opts = { 'PUPPET_MASTER_SERVER' => master, 'PUPPET_AGENT_CERTNAME' => host }
               opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
               msi_path = "#{host['working_dir']}\\#{host['dist']}.msi"
-              install_msi_on(host, msi_path, msi_opts, opts)
-              configure_type_defaults_on(host)
+              install_msi_on(host, msi_path, {}, opts)
+
+              # 1 since no certificate found and waitforcert disabled
+              acceptable_exit_codes = 1
+              setup_defaults_and_config_helper_on(host, master, acceptable_exit_codes)
             else
               # We only need answers if we're using the classic installer
               version = host['pe_ver'] || opts[:pe_ver]

--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -1,0 +1,137 @@
+module Beaker
+  module DSL
+    module InstallUtils
+      #
+      # This module contains methods useful for Windows installs
+      #
+      module WindowsUtils
+
+        # Given a host, returns it's system TEMP path
+        # @param [Host] host An object implementing {Beaker::Hosts}'s interface.
+        def get_temp_path(host)
+          # under CYGWIN %TEMP% may not be set
+          tmp_path = on(host, Command.new('ECHO %SYSTEMROOT%', [], { :cmdexe => true }))
+          tmp_path.output.gsub(/\n/, '') + '\\TEMP'
+        end
+
+        # Generates commands to be inserted into a Windows batch file to launch an MSI install
+        # @param [String] msi_path The path of the MSI - can be a local Windows style file path like
+        #                   c:\temp\puppet.msi OR a url like https://download.com/puppet.msi or file://c:\temp\puppet.msi
+        # @param  [Hash{String=>String}] msi_opts MSI installer options
+        #                   See https://docs.puppetlabs.com/guides/install_puppet/install_windows.html#msi-properties
+        # @param [String] log_path The path to write the MSI log - must be a local Windows style file path
+        #
+        # @api private
+        def msi_install_script(msi_path, msi_opts, log_path)
+          # msiexec requires backslashes in file paths launched under cmd.exe start /w
+          url_pattern = /^(https?|file):\/\//
+          msi_path = msi_path.gsub(/\//, "\\") if msi_path !~ url_pattern
+
+          msi_params = msi_opts.map{|k, v| "#{k}=#{v}"}.join(' ')
+
+          # msiexec requires quotes around paths with backslashes - c:\ or file://c:\
+          # not strictly needed for http:// but it simplifies this code
+          batch_contents = <<-BATCH
+start /w msiexec.exe /i \"#{msi_path}\" /qn /L*V #{log_path} #{msi_params}
+exit /B %errorlevel%
+          BATCH
+        end
+
+        # Given a host, path to MSI and MSI options, will create a batch file
+        #   on the host, returning the path to the randomized batch file and
+        #   the randomized log file
+        # @param [Host] host An object implementing {Beaker::Hosts}'s interface.
+        # @param [String] msi_path The path of the MSI - can be a local Windows style file path like
+        #                   c:\temp\puppet.msi OR a url like https://download.com/puppet.msi or file://c:\temp\puppet.msi
+        # @param  [Hash{String=>String}] msi_opts MSI installer options
+        #                   See https://docs.puppetlabs.com/guides/install_puppet/install_windows.html#msi-properties
+        # @api private
+        def create_install_msi_batch_on(host, msi_path, msi_opts)
+          timestamp = Time.new.strftime('%Y-%m-%d_%H.%M.%S')
+          tmp_path = get_temp_path(host)
+
+          batch_name = "install-puppet-msi-#{timestamp}.bat"
+          batch_path = "#{tmp_path}\\#{batch_name}"
+
+          log_path = "#{tmp_path}\\install-puppet-#{timestamp}.log"
+
+          Tempfile.open(batch_name) do |tmp_file|
+            batch_contents = msi_install_script(msi_path, msi_opts, log_path)
+
+            File.open(tmp_file.path, 'w') { |file| file.puts(batch_contents) }
+            host.do_scp_to(tmp_file.path, batch_path, {})
+          end
+
+          return batch_path, log_path
+        end
+
+        # Given hosts construct a PATH that includes puppetbindir, facterbindir and hierabindir
+        # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
+        #                            or a role (String or Symbol) that identifies one or more hosts.
+        # @param [String] msi_path The path of the MSI - can be a local Windows style file path like
+        #                   c:\temp\puppet.msi OR a url like https://download.com/puppet.msi or file://c:\temp\puppet.msi
+        # @param  [Hash{String=>String}] msi_opts MSI installer options
+        #                   See https://docs.puppetlabs.com/guides/install_puppet/install_windows.html#msi-properties
+        # @option msi_opts [String] INSTALLIDIR Where Puppet and its dependencies should be installed.
+        #                  (Defaults vary based on operating system and intaller architecture)
+        #                  Requires Puppet 2.7.12 / PE 2.5.0
+        # @option msi_opts [String] PUPPET_MASTER_SERVER The hostname where the puppet master server can be reached.
+        #                  (Defaults to puppet)
+        #                  Requires Puppet 2.7.12 / PE 2.5.0
+        # @option msi_opts [String] PUPPET_CA_SERVER The hostname where the CA puppet master server can be reached, if you are using multiple masters and only one of them is acting as the CA.
+        #                  (Defaults the value of PUPPET_MASTER_SERVER)
+        #                  Requires Puppet 2.7.12 / PE 2.5.0
+        # @option msi_opts [String] PUPPET_AGENT_CERTNAME The node’s certificate name, and the name it uses when requesting catalogs. This will set a value for
+        #                  (Defaults to the node's fqdn as discovered by facter fqdn)
+        #                  Requires Puppet 2.7.12 / PE 2.5.0
+        # @option msi_opts [String] PUPPET_AGENT_ENVIRONMENT The node’s environment.
+        #                  (Defaults to production)
+        #                  Requires Puppet 3.3.1 / PE 3.1.0
+        # @option msi_opts [String] PUPPET_AGENT_STARTUP_MODE Whether the puppet agent service should run (or be allowed to run)
+        #                  (Defaults to Automatic - valid values are Automatic, Manual or Disabled)
+        #                  Requires Puppet 3.4.0 / PE 3.2.0
+        # @option msi_opts [String] PUPPET_AGENT_ACCOUNT_USER Whether the puppet agent service should run (or be allowed to run)
+        #                  (Defaults to LocalSystem)
+        #                  Requires Puppet 3.4.0 / PE 3.2.0
+        # @option msi_opts [String] PUPPET_AGENT_ACCOUNT_PASSWORD The password to use for puppet agent’s user account
+        #                  (No default)
+        #                  Requires Puppet 3.4.0 / PE 3.2.0
+        # @option msi_opts [String] PUPPET_AGENT_ACCOUNT_DOMAIN The domain of puppet agent’s user account.
+        #                  (Defaults to .)
+        #                  Requires Puppet 3.4.0 / PE 3.2.0
+        # @option opts [Boolean] :debug output the MSI installation log when set to true
+        #                 otherwise do not output log (false; default behavior)
+        #
+        # @example
+        #  install_msi_on(hosts, 'c:\puppet.msi', {:debug => true})
+        #
+        # @api private
+        def install_msi_on(hosts, msi_path, msi_opts = {}, opts = {})
+          block_on hosts do | host |
+            batch_path, log_file = create_install_msi_batch_on(host, msi_path, msi_opts)
+
+            # begin / rescue here so that we can reuse existing error msg propagation
+            begin
+              # 1641 = ERROR_SUCCESS_REBOOT_INITIATED
+              # 3010 = ERROR_SUCCESS_REBOOT_REQUIRED
+              on host, Command.new("\"#{batch_path}\"", [], { :cmdexe => true }), :acceptable_exit_codes => [0, 1641, 3010]
+            rescue
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+              raise
+            end
+
+            if opts[:debug]
+              on host, Command.new("type \"#{log_file}\"", [], { :cmdexe => true })
+            end
+
+            if !host.is_cygwin?
+              # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
+              host.close
+            end
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -88,7 +88,7 @@ exit /B %errorlevel%
         #                  (Defaults to production)
         #                  Requires Puppet 3.3.1 / PE 3.1.0
         # @option msi_opts [String] PUPPET_AGENT_STARTUP_MODE Whether the puppet agent service should run (or be allowed to run)
-        #                  (Defaults to Automatic - valid values are Automatic, Manual or Disabled)
+        #                  (Defaults to Manual - valid values are Automatic, Manual or Disabled)
         #                  Requires Puppet 3.4.0 / PE 3.2.0
         # @option msi_opts [String] PUPPET_AGENT_ACCOUNT_USER Whether the puppet agent service should run (or be allowed to run)
         #                  (Defaults to LocalSystem)
@@ -108,6 +108,7 @@ exit /B %errorlevel%
         # @api private
         def install_msi_on(hosts, msi_path, msi_opts = {}, opts = {})
           block_on hosts do | host |
+            msi_opts['PUPPET_AGENT_STARTUP_MODE'] ||= 'Manual'
             batch_path, log_file = create_install_msi_batch_on(host, msi_path, msi_opts)
 
             # begin / rescue here so that we can reuse existing error msg propagation

--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -128,6 +128,12 @@ exit /B %errorlevel%
               # HACK: for some reason, post install we need to refresh the connection to make puppet available for execution
               host.close
             end
+
+            # verify service status post install
+            # if puppet service exists, then pe-puppet is not queried
+            # if puppet service does not exist, pe-puppet is queried and that exit code is used
+            # therefore, this command will always exit 0 if either service is installed
+            on host, Command.new("sc query puppet || sc query pe-puppet", [], { :cmdexe => true })
           end
         end
 

--- a/spec/beaker/dsl/install_utils/pe_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/pe_utils_spec.rb
@@ -135,13 +135,6 @@ describe ClassMixedWithDSLInstallUtils do
 
   describe 'installer_cmd' do
 
-    it 'generates a windows PE install command for a windows host' do
-      winhost['dist'] = 'puppet-enterprise-3.0'
-      allow( subject ).to receive( :hosts ).and_return( [ hosts[1], hosts[0], hosts[2], winhost ] )
-      allow( winhost ).to receive( :is_cygwin?).and_return(true)
-      expect( subject.installer_cmd( winhost, {} ) ).to be === "cd /tmp && cmd /C 'start /w msiexec.exe /qn /L*V tmp.log /i puppet-enterprise-3.0.msi PUPPET_MASTER_SERVER=vm1 PUPPET_AGENT_CERTNAME=winhost'"
-    end
-
     it 'generates a unix PE install command for a unix host' do
       the_host = unixhost.dup
       the_host['pe_installer'] = 'puppet-enterprise-installer'
@@ -376,7 +369,9 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to receive( :create_remote_file ).with( hosts[0], /answers/, /q/ ).once
       #run installer on all hosts
       expect( subject ).to receive( :on ).with( hosts[0], /puppet-enterprise-installer/ ).once
-      expect( subject ).to receive( :on ).with( hosts[1], /msiexec.exe/ ).once
+      expect( subject ).to receive( :install_msi_on ).with ( any_args ) do | host, msi_path, msi_opts, opts |
+        expect( host ).to eq( hosts[1] )
+      end.once
       expect( subject ).to receive( :on ).with( hosts[2], / hdiutil attach puppet-enterprise-3.0-osx-10.9-x86_64.dmg && installer -pkg \/Volumes\/puppet-enterprise-3.0\/puppet-enterprise-installer-3.0.pkg -target \// ).once
       expect( subject ).to receive( :on ).with( hosts[3], /^Cli/ ).once
       #does extra mac/EOS specific commands

--- a/spec/beaker/dsl/install_utils/windows_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/windows_utils_spec.rb
@@ -57,10 +57,10 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :get_temp_path ).and_return( windows_temp )
     end
 
-    it "will not specify a PUPPET_AGENT_STARTUP_MODE by default" do
+    it "will specify a PUPPET_AGENT_STARTUP_MODE of Manual (disabling the service) by default" do
       expect_install_called
       expect_status_called
-      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log $/
+      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log PUPPET_AGENT_STARTUP_MODE=Manual$/
       expect_script_matches(hosts, expected_cmd)
       subject.install_msi_on(hosts, msi_path, {})
     end
@@ -77,7 +77,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect_install_called
       expect_status_called
       msi_path = 'c:/foo/puppet.msi'
-      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log $/
+      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log PUPPET_AGENT_STARTUP_MODE=Manual$/
       expect_script_matches(hosts, expected_cmd)
       subject.install_msi_on(hosts, msi_path)
     end
@@ -86,7 +86,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect_install_called
       expect_status_called
       msi_url = "https://downloads.puppetlabs.com/puppet.msi"
-      expected_cmd = /^start \/w msiexec\.exe \/i "https\:\/\/downloads\.puppetlabs\.com\/puppet\.msi" \/qn \/L\*V .*\.log $/
+      expected_cmd = /^start \/w msiexec\.exe \/i "https\:\/\/downloads\.puppetlabs\.com\/puppet\.msi" \/qn \/L\*V .*\.log PUPPET_AGENT_STARTUP_MODE=Manual$/
       expect_script_matches(hosts, expected_cmd)
       subject.install_msi_on(hosts, msi_url)
     end
@@ -95,7 +95,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect_install_called
       expect_status_called
       msi_url = "file://c:\\foo\\puppet.msi"
-      expected_cmd = /^start \/w msiexec\.exe \/i "file\:\/\/c:\\foo\\puppet\.msi" \/qn \/L\*V .*\.log $/
+      expected_cmd = /^start \/w msiexec\.exe \/i "file\:\/\/c:\\foo\\puppet\.msi" \/qn \/L\*V .*\.log PUPPET_AGENT_STARTUP_MODE=Manual$/
       expect_script_matches(hosts, expected_cmd)
       subject.install_msi_on(hosts, msi_url)
     end

--- a/spec/beaker/dsl/install_utils/windows_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/windows_utils_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLInstallUtils
+  include Beaker::DSL::Helpers
+  include Beaker::DSL::Patterns
+  include Beaker::DSL::InstallUtils
+
+  def logger
+    @logger ||= RSpec::Mocks::Double.new('logger').as_null_object
+  end
+end
+
+describe ClassMixedWithDSLInstallUtils do
+  let(:windows_temp)        { 'C:\\Windows\\Temp' }
+  let(:msi_path)            { 'c:\\foo\\puppet.msi' }
+  let(:winhost)             { make_host( 'winhost',
+                              { :platform => 'windows',
+                                :pe_ver => '3.0',
+                                :working_dir => '/tmp',
+                                :is_cygwin => true} ) }
+  let(:winhost_non_cygwin)  { make_host( 'winhost_non_cygwin',
+                              { :platform => 'windows',
+                                :pe_ver => '3.0',
+                                :working_dir => '/tmp',
+                                :is_cygwin => 'false' } ) }
+  let(:hosts)              { [ winhost, winhost_non_cygwin ] }
+
+  def expect_install_called(times = hosts.length)
+    result = expect( Beaker::Command ).to receive( :new )
+      .with( /^"#{Regexp.quote(windows_temp)}\\install-puppet-msi.*\.bat"$/, [], {:cmdexe => true})
+      .exactly( times ).times
+
+    yield result if block_given?
+  end
+
+  def expect_script_matches(hosts, contents)
+    hosts.each do |host|
+      expect( host )
+        .to receive( :do_scp_to ) do |local_path, remote_path|
+          expect(File.read(local_path)).to match(contents)
+        end
+        .and_return( true )
+    end
+  end
+
+  describe "#install_msi_on" do
+    before :each do
+      FakeFS::FileSystem.add(File.expand_path '/tmp')
+
+      allow( subject ).to receive( :on ).and_return( true )
+      allow( subject ).to receive( :get_temp_path ).and_return( windows_temp )
+    end
+
+    it "will not specify a PUPPET_AGENT_STARTUP_MODE by default" do
+      expect_install_called
+      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log $/
+      expect_script_matches(hosts, expected_cmd)
+      subject.install_msi_on(hosts, msi_path, {})
+    end
+
+    it "allows configuration of PUPPET_AGENT_STARTUP_MODE" do
+      expect_install_called
+      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log PUPPET_AGENT_STARTUP_MODE=Automatic$/
+      expect_script_matches(hosts, expected_cmd)
+      subject.install_msi_on(hosts, msi_path, {'PUPPET_AGENT_STARTUP_MODE' => 'Automatic'})
+    end
+
+    it "will generate an appropriate command with a MSI file path using non-Windows slashes" do
+      expect_install_called
+      msi_path = 'c:/foo/puppet.msi'
+      expected_cmd = /^start \/w msiexec\.exe \/i "c:\\foo\\puppet.msi" \/qn \/L\*V .*\.log $/
+      expect_script_matches(hosts, expected_cmd)
+      subject.install_msi_on(hosts, msi_path)
+    end
+
+    it "will generate an appropriate command with a MSI http(s) url" do
+      expect_install_called
+      msi_url = "https://downloads.puppetlabs.com/puppet.msi"
+      expected_cmd = /^start \/w msiexec\.exe \/i "https\:\/\/downloads\.puppetlabs\.com\/puppet\.msi" \/qn \/L\*V .*\.log $/
+      expect_script_matches(hosts, expected_cmd)
+      subject.install_msi_on(hosts, msi_url)
+    end
+
+    it "will generate an appropriate command with a MSI file url" do
+      expect_install_called
+      msi_url = "file://c:\\foo\\puppet.msi"
+      expected_cmd = /^start \/w msiexec\.exe \/i "file\:\/\/c:\\foo\\puppet\.msi" \/qn \/L\*V .*\.log $/
+      expect_script_matches(hosts, expected_cmd)
+      subject.install_msi_on(hosts, msi_url)
+    end
+
+    it "will not generate a command to emit a log file without the :debug option set" do
+      expect_install_called
+      hosts.each { |h| allow( h ).to receive( :do_scp_to ).and_return( true ) }
+      expect( Beaker::Command ).not_to receive( :new ).with( /^type .*\.log$/, [], {:cmdexe => true} )
+      subject.install_msi_on(hosts, msi_path)
+    end
+
+    it "will generate a command to emit a log file when the install script fails" do
+      # note a single failure aborts executing against remaining hosts
+      hosts_affected = 1
+
+      expect_install_called(hosts_affected) { |e| e.and_raise }
+      hosts.each { |h| allow( h ).to receive( :do_scp_to ).and_return( true ) }
+
+      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts_affected ).times
+      expect { subject.install_msi_on(hosts, msi_path) }.to raise_error(RuntimeError)
+    end
+
+    it "will generate a command to emit a log file with the :debug option set" do
+      expect_install_called
+      hosts.each { |h| allow( h ).to receive( :do_scp_to ).and_return( true ) }
+
+      expect( Beaker::Command ).to receive( :new ).with( /^type \".*\.log\"$/, [], {:cmdexe => true} ).exactly( hosts.length ).times
+      subject.install_msi_on(hosts, msi_path, {}, { :debug => true })
+    end
+  end
+end


### PR DESCRIPTION
 - Refactor the do_install portion of pe_utils so that it no longer uses
   the installer_cmd helper when on Windows.  Instead, extract out a new
   MSI installation helper to WindowsUtils called install_msi_on.

 - There are 4 separate points in the code where an MSI installation can
   be launched from, that all differ in foss_utils.  Unify all entry points to use the
   helper install_msi_on from WindowUtils.

   Simplify the logic in the foss_utils install_a_puppet_msi_on

 - install_msi_on expects 4 parameters
     hosts - to run the installer on
     msi_path - can be a local path on disk or uri
     msi_opts - options passed to the installer to configure behavior
     opts - additional options, currently only :debug to emit the log
        after installation

 - After completing an MSI install, verify the service status of the
   puppet service.