### PR TITLE
(BKR-422) debian7 fails to reboot during smoketest

### DIFF
--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -3,6 +3,9 @@ module Windows::Exec
 
   def reboot
     exec(Beaker::Command.new('shutdown /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :expect_connection_failure => true)
+    # rebooting on windows is sloooooow
+    # give it some breathing room before attempting a reconnect
+    sleep(30)
   end
 
   ABS_CMD = 'c:\\\\windows\\\\system32\\\\cmd.exe'

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -243,6 +243,9 @@ module Beaker
         host.instance_variable_set :@logger, logger
         conn = double(:connection)
         allow( conn ).to receive(:execute).and_return(result)
+        allow( conn ).to receive(:ip).and_return(host['ip'])
+        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+        allow( conn ).to receive(:hostname).and_return(host.name)
         host.instance_variable_set :@connection, conn
       end
 
@@ -399,6 +402,9 @@ module Beaker
 
         expect( logger ).to receive(:trace)
         expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
+        allow( conn ).to receive(:ip).and_return(host['ip'])
+        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+        allow( conn ).to receive(:hostname).and_return(host.name)
 
         host.do_scp_to *args
       end
@@ -466,6 +472,9 @@ module Beaker
               expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
           end
+          allow( conn ).to receive(:ip).and_return(host['ip'])
+          allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+          allow( conn ).to receive(:hostname).and_return(host.name)
 
           host.do_scp_to *args
         end
@@ -527,6 +536,9 @@ module Beaker
               expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
           end
+          allow( conn ).to receive(:ip).and_return(host['ip'])
+          allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+          allow( conn ).to receive(:hostname).and_return(host.name)
 
           host.do_scp_to *args
         end
@@ -555,6 +567,9 @@ module Beaker
             expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
           end
 
+          allow( conn ).to receive(:ip).and_return(host['ip'])
+          allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+          allow( conn ).to receive(:hostname).and_return(host.name)
           host.do_scp_to *args
         end
       end
@@ -572,6 +587,9 @@ module Beaker
         expect( logger ).to receive(:debug)
         expect( conn ).to receive(:scp_from).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
 
+        allow( conn ).to receive(:ip).and_return(host['ip'])
+        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+        allow( conn ).to receive(:hostname).and_return(host.name)
         host.do_scp_from *args
       end
     end

--- a/spec/beaker/hypervisor/aixer_spec.rb
+++ b/spec/beaker/hypervisor/aixer_spec.rb
@@ -16,7 +16,7 @@ module Beaker
         expect( Command ).to receive( :new ).with( "cd pe-aix && rake restore:#{host.name}" ).once
 
       end
-
+      allow_any_instance_of(Host).to receive(:close)
       aixer.provision
 
     end

--- a/spec/beaker/hypervisor/solaris_spec.rb
+++ b/spec/beaker/hypervisor/solaris_spec.rb
@@ -22,6 +22,7 @@ module Beaker
         expect( Command ).to receive( :new ).with("sudo /sbin/zfs rollback -Rf #{vmpath}/#{vm_name}/#{spath}@#{snapshot}").once
         expect( Command ).to receive( :new ).with("sudo /sbin/zoneadm -z #{vm_name} boot").once
       end
+      allow_any_instance_of(Host).to receive(:close)
 
       solaris.provision
     end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -86,6 +86,7 @@ module HostHelpers
     host = Beaker::Host.create( name, host_hash, make_opts)
 
     allow(host).to receive( :exec ).and_return( generate_result( name, host_hash ) )
+    allow(host).to receive( :close )
     host
   end
 


### PR DESCRIPTION
- to fix current smoketest redness change how we connect to beaker boxes
- do three separate connection attempts (with retries)
  * first with ip
  * then the virtual hostname (vmhostname)
  * then the name of the box provided by the user (hostname)
- Only when all three fail do we fail out
- decrease the Net::SSH timeout so that we can move through the various
  attempts in a reasonable amount of time
- add a sleep post windows reboot, getting reds here because windows
  takes so long to come back up