### PR TITLE
(BKR-372) add support for ubuntu 15.04, Vivid, amd64 & i386

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -178,7 +178,6 @@ module Beaker
           :ssh                    => {
                                      :config                => false,
                                      :paranoid              => false,
-                                     :timeout               => 300,
                                      :auth_methods          => ["publickey"],
                                      :port                  => 22,
                                      :forward_agent         => true,


### PR DESCRIPTION
- not quite sure what is going on here, but removing the timeout and
  using the Net::SSH default allows ubuntu15.04 to reboot successfully
  (was stuck on a blocking call to Net::SSH.start)