### PR TITLE
BRK-431: Find AWS credentials from environment variables

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -771,7 +771,7 @@ module Beaker
     # @param prefix [String] environment variable prefix
     # @return [Hash<Symbol, String>] ec2 credentials
     # @api private
-    def load_env_credentials(prefix='ENV')
+    def load_env_credentials(prefix='AWS')
       provider = AWS::Core::CredentialProviders::ENVProvider.new prefix
 
       if provider.set?

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -792,8 +792,8 @@ module Beaker
       fog = YAML.load_file( dot_fog )
       default = fog[:default]
 
-      raise "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:access_key]
-      raise "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:secret_key]
+      raise "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_access_key_id]
+      raise "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!" unless default[:aws_secret_access_key]
 
       {
         :access_key => default[:aws_access_key_id],

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -50,7 +50,7 @@ module Beaker
       @hosts[4][:user] = 'notroot'
 
       ENV['AWS_ACCESS_KEY'] = nil
-      ENV['AWS_ACCESS_KEY_ID'] = nil
+      ENV['AWS_SECRET_ACCESS_KEY'] = nil
     end
 
     context 'loading credentials' do
@@ -63,10 +63,10 @@ module Beaker
 
 
       it 'from environment variables' do
-        ENV['AWS_ACCESS_KEY'] = "IAMANACCESSKEY"
-        ENV['AWS_ACCESS_KEY_ID'] = "supersekritkey"
+        ENV['AWS_ACCESS_KEY_ID'] = "IMANACCESSKEY"
+        ENV['AWS_SECRET_ACCESS_KEY'] = "supersekritkey"
 
-        creds = aws.load_credentials
+        creds = aws.load_env_credentials
         expect( creds[:access_key] ).to eq("IMANACCESSKEY")
         expect( creds[:secret_key] ).to eq("supersekritkey")
       end

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -102,12 +102,12 @@ module Beaker
         instance_set = [ec2_instance, vpc_instance, nil_instance, unreal_instance]
         expect(aws.kill_instances(instance_set)).to be_nil
       end
-  
+
       it 'cleanly handles an empty instance list' do
         instance_set = []
         expect(aws.kill_instances(instance_set)).to be_nil
       end
-  
+
       context 'in general use' do
         let( :instance_set ) { [ec2_instance, vpc_instance] }
 
@@ -117,7 +117,7 @@ module Beaker
           end
           expect(kill_instances).to be_nil
         end
-  
+
         it 'verifies instances are not nil' do
           instance_set.each do |instance|
             expect(instance).to receive(:nil?)
@@ -125,7 +125,7 @@ module Beaker
           end
           expect(kill_instances).to be_nil
         end
-  
+
         it 'verifies instances exist in AWS' do
           instance_set.each do |instance|
             expect(instance).to receive(:exists?)
@@ -144,7 +144,7 @@ module Beaker
           end
           expect(kill_instances).to be_nil
         end
-  
+
         it 'verifies instance is not nil' do
           instance_set.each do |instance|
             expect(instance).to receive(:nil?)
@@ -152,7 +152,7 @@ module Beaker
           end
           expect(kill_instances).to be_nil
         end
-  
+
         it 'verifies instance exists in AWS' do
           instance_set.each do |instance|
             expect(instance).to receive(:exists?)
@@ -536,7 +536,7 @@ module Beaker
           @hosts.each {|host| expect(host).to receive(:exec).once}
           expect(set_hostnames).to eq(@hosts)
         end
-  
+
         it 'passes a Command instance to exec' do
           @hosts.each do |host|
             expect(host).to receive(:exec).with( instance_of(Beaker::Command) ).once
@@ -729,7 +729,7 @@ module Beaker
       subject(:load_fog_credentials) { aws.load_fog_credentials(dot_fog) }
 
       it 'returns loaded fog credentials' do
-        fog_hash = {:default => {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass'}} 
+        fog_hash = {:default => {:aws_access_key_id => 'awskey', :aws_secret_access_key => 'awspass'}}
         expect(aws).to receive(:load_fog_credentials).and_call_original
         expect(YAML).to receive(:load_file).and_return(fog_hash)
         expect(load_fog_credentials).to eq(creds)
@@ -737,16 +737,16 @@ module Beaker
 
       context 'raises errors' do
         it 'if missing access_key credential' do
-          fog_hash = {:default => {:aws_secret_access_key => 'awspass'}} 
+          fog_hash = {:default => {:aws_secret_access_key => 'awspass'}}
           err_text = "You must specify an aws_access_key_id in your .fog file (#{dot_fog}) for ec2 instances!"
           expect(aws).to receive(:load_fog_credentials).and_call_original
           expect(YAML).to receive(:load_file).and_return(fog_hash)
           expect { load_fog_credentials }.to raise_error(err_text)
         end
-  
+
         it 'if missing secret_key credential' do
           dot_fog = '.fog'
-          fog_hash = {:default => {:aws_access_key_id => 'awskey'}} 
+          fog_hash = {:default => {:aws_access_key_id => 'awskey'}}
           err_text = "You must specify an aws_secret_access_key in your .fog file (#{dot_fog}) for ec2 instances!"
           expect(aws).to receive(:load_fog_credentials).and_call_original
           expect(YAML).to receive(:load_file).and_return(fog_hash)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -7,8 +7,8 @@ module TestFileHelpers
   end
 
   def fog_file_contents
-    { :default => { :access_key => "IMANACCESSKEY",
-                    :secret_access => "supersekritkey",
+    { :default => { :aws_access_key_id => "IMANACCESSKEY",
+                    :aws_secret_access_key => "supersekritkey",
                     :aix_hypervisor_server => "aix_hypervisor.labs.net",
                     :aix_hypervisor_username => "aixer",
                     :aix_hypervisor_keyfile => "/Users/user/.ssh/id_rsa-acceptance",


### PR DESCRIPTION
Used the EnvCredentials class provided by the AWS SDK to fetch credentials. You can (optionally) set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables instead of populating ~/.fog. If they aren't both set, then we fall through to loading .fog, which behaves as it did before.

New tests added around the new load_credentials and load_env_credentials. Also added tests for load_fog_credentials which had been mocked out in the spec to return the entire .fog file fixture rather than just the credentials.