### PR TITLE
(maint) Supply token (if exists) during VM cleanup

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -194,6 +194,10 @@ module Beaker
         http = Net::HTTP.new( uri.host, uri.port )
         request = Net::HTTP::Delete.new(uri.request_uri)
 
+        if @credentials[:vmpooler_token]
+          request['X-AUTH-TOKEN'] = @credentials[:vmpooler_token]
+        end
+
         begin
           response = http.request(request)
         rescue *SSH_EXCEPTIONS => e


### PR DESCRIPTION
Per QENG-1304 and https://github.com/puppetlabs/vmpooler/pull/118, vmpooler requires a token be used during the 'cleanup' phase if one was specified during the 'checkout' phase.