### PR TITLE
(maint) Add Package Acceptance Tests

### DIFF
--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-lucid.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-lucid.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/lucid lucid PC1

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-precise.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-precise.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/precise precise PC1

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-squeeze.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-squeeze.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/squeeze squeeze PC1

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-trusty.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-trusty.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/trusty trusty PC1

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-vivid.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-vivid.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/vivid vivid PC1

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-wheezy.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-wheezy.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/wheezy wheezy PC1

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-6-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-6-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/el/6/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-6-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-6-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/el/6/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-7-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-7-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/el/7/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-7-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-el-7-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/el/7/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-20-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-20-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f20/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-20-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-20-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f20/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-21-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-21-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f21/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-21-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-21-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f21/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-22-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-22-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f22/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-22-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-22-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f22/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/tests/base/packages.rb
+++ b/acceptance/tests/base/packages.rb
@@ -27,7 +27,7 @@ end
 step '#check_for_command : can determine where a command exists'
 hosts.each do |host|
   logger.debug "echo package should be installed on #{host}"
-  assert_equal(true, host.check_for_command('echo'), "'echo' should be a command")
+  assert(host.check_for_command('echo'), "'echo' should be a command")
   logger.debug("doesnotexist package should not be installed on #{host}")
   assert_equal(false, host.check_for_command('doesnotexist'), '"doesnotexist" should not be a command')
 end
@@ -37,7 +37,7 @@ hosts.each do |host|
   package = get_host_pkg(host)[0]
 
   logger.debug "#{package} package should be installed on #{host}"
-  assert_equal(true, host.check_for_package(package), "'#{package}' should be installed")
+  assert(host.check_for_package(package), "'#{package}' should be installed")
   logger.debug("doesnotexist package should not be installed on #{host}")
   assert_equal(false, host.check_for_package('doesnotexist'), '"doesnotexist" should not be installed')
 end
@@ -48,16 +48,26 @@ hosts.each do |host|
   # a lot of dependencies.
   package = 'zsh'
 
-  assert_equal(false, host.check_for_package(package), "'#{package}' should be installed")
+  if host['platform'] =~ /solaris/
+    logger.debug("#{package} should be uninstalled on #{host}")
+    host.uninstall_package(package)
+    assert_equal(false, host.check_for_package(package), "'#{package}' should not be installed")
+  end
+
+  assert_equal(false, host.check_for_package(package), "'#{package}' not should be installed")
   logger.debug("#{package} should be installed on #{host}")
   host.install_package(package)
-  assert_equal(true, host.check_for_package(package), "'#{package}' should be installed")
+  assert(host.check_for_package(package), "'#{package}' should be installed")
 
   # windows does not support uninstall_package
   unless host['platform'] =~ /windows/
     logger.debug("#{package} should be uninstalled on #{host}")
     host.uninstall_package(package)
-    assert_equal(false, host.check_for_package(package), "'#{package}' should be installed")
+    if host['platform'] =~ /debian/
+      assert_equal(false, host.check_for_command(package), "'#{package}' should not be installed or available")
+    else
+      assert_equal(false, host.check_for_package(package), "'#{package}' should not be installed")
+    end
   end
 
 end

--- a/acceptance/tests/base/packages.rb
+++ b/acceptance/tests/base/packages.rb
@@ -1,4 +1,5 @@
 test_name 'confirm packages on hosts behave correctly'
+confine :except, :platform => %w(osx)
 
 def get_host_pkg(host)
   case

--- a/acceptance/tests/base/packages.rb
+++ b/acceptance/tests/base/packages.rb
@@ -1,0 +1,63 @@
+test_name 'confirm packages on hosts behave correctly'
+
+def get_host_pkg(host)
+  case
+    when host['platform'] =~ /sles-10/
+      Beaker::HostPrebuiltSteps::SLES10_PACKAGES
+    when host['platform'] =~ /sles-/
+      Beaker::HostPrebuiltSteps::SLES_PACKAGES
+    when host['platform'] =~ /debian/
+      Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES
+    when host['platform'] =~ /cumulus/
+      Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES
+    when (host['platform'] =~ /windows/ and host.is_cygwin?)
+      Beaker::HostPrebuiltSteps::WINDOWS_PACKAGES
+    when (host['platform'] =~ /windows/ and not host.is_cygwin?)
+      Beaker::HostPrebuiltSteps::PSWINDOWS_PACKAGES
+    when host['platform'] =~ /freebsd/
+      Beaker::HostPrebuiltSteps::FREEBSD_PACKAGES
+    when host['platform'] =~ /openbsd/
+      Beaker::HostPrebuiltSteps::OPENBSD_PACKAGES
+    else
+      Beaker::HostPrebuiltSteps::UNIX_PACKAGES
+  end
+
+end
+
+step '#check_for_command : can determine where a command exists'
+hosts.each do |host|
+  logger.debug "echo package should be installed on #{host}"
+  assert_equal(true, host.check_for_command('echo'), "'echo' should be a command")
+  logger.debug("doesnotexist package should not be installed on #{host}")
+  assert_equal(false, host.check_for_command('doesnotexist'), '"doesnotexist" should not be a command')
+end
+
+step '#check_for_package : can determine if a package is installed'
+hosts.each do |host|
+  package = get_host_pkg(host)[0]
+
+  logger.debug "#{package} package should be installed on #{host}"
+  assert_equal(true, host.check_for_package(package), "'#{package}' should be installed")
+  logger.debug("doesnotexist package should not be installed on #{host}")
+  assert_equal(false, host.check_for_package('doesnotexist'), '"doesnotexist" should not be installed')
+end
+
+step '#install_package and #uninstall_package : remove and install a package successfully'
+hosts.each do |host|
+  # this works on Windows as well, althought it pulls in
+  # a lot of dependencies.
+  package = 'zsh'
+
+  assert_equal(false, host.check_for_package(package), "'#{package}' should be installed")
+  logger.debug("#{package} should be installed on #{host}")
+  host.install_package(package)
+  assert_equal(true, host.check_for_package(package), "'#{package}' should be installed")
+
+  # windows does not support uninstall_package
+  unless host['platform'] =~ /windows/
+    logger.debug("#{package} should be uninstalled on #{host}")
+    host.uninstall_package(package)
+    assert_equal(false, host.check_for_package(package), "'#{package}' should be installed")
+  end
+
+end

--- a/acceptance/tests/base/packages_unix.rb
+++ b/acceptance/tests/base/packages_unix.rb
@@ -24,7 +24,7 @@ hosts.each do |host|
 
     clean_file(host, pkg_file)
     host.deploy_apt_repo(pkg_fixtures, 'puppetserver', 'latest')
-    assert_equal(true, host.file_exist?(pkg_file), 'apt file should exist')
+    assert(host.file_exist?(pkg_file), 'apt file should exist')
     clean_file(host, pkg_file)
   end
 
@@ -38,7 +38,7 @@ hosts.each do |host|
 
     clean_file(host, pkg_file)
     host.deploy_yum_repo(pkg_fixtures, pkg_name, 'latest')
-    assert_equal(true, host.file_exist?(pkg_file), 'yum file should exist')
+    assert(host.file_exist?(pkg_file), 'yum file should exist')
     clean_file(host, pkg_file)
   end
 

--- a/acceptance/tests/base/packages_unix.rb
+++ b/acceptance/tests/base/packages_unix.rb
@@ -1,5 +1,5 @@
 test_name 'confirm unix-specific package methods work'
-confine :except, :platform => %w(windows solaris)
+confine :except, :platform => %w(windows solaris osx)
 
 current_dir  = File.dirname(__FILE__)
 pkg_fixtures = File.expand_path(File.join(current_dir, '../../fixtures/package'))

--- a/acceptance/tests/base/packages_unix.rb
+++ b/acceptance/tests/base/packages_unix.rb
@@ -1,0 +1,50 @@
+test_name 'confirm unix-specific package methods work'
+confine :except, :platform => %w(windows solaris)
+
+current_dir  = File.dirname(__FILE__)
+pkg_fixtures = File.expand_path(File.join(current_dir, '../../fixtures/package'))
+pkg_name     = 'puppetserver'
+
+def clean_file(host, file)
+  if host.file_exist?(file)
+    on(host, "rm -rf #{file}")
+  end
+end
+
+step '#update_apt_if_needed : can execute without raising an error'
+hosts.each do |host|
+  host.update_apt_if_needed
+end
+
+step '#deploy_apt_repo : deploy puppet-server nightly repo'
+hosts.each do |host|
+
+  if host['platform'] =~ /debian|ubuntu/
+    pkg_file = "/etc/apt/sources.list.d/#{pkg_name}.list"
+
+    clean_file(host, pkg_file)
+    host.deploy_apt_repo(pkg_fixtures, 'puppetserver', 'latest')
+    assert_equal(true, host.file_exist?(pkg_file), 'apt file should exist')
+    clean_file(host, pkg_file)
+  end
+
+end
+
+step '#deploy_yum_repo : deploy puppet-server nightly repo'
+hosts.each do |host|
+
+  if host['platform'] =~ /el/
+    pkg_file = "/etc/yum.repos.d/#{pkg_name}.repo"
+
+    clean_file(host, pkg_file)
+    host.deploy_yum_repo(pkg_fixtures, pkg_name, 'latest')
+    assert_equal(true, host.file_exist?(pkg_file), 'yum file should exist')
+    clean_file(host, pkg_file)
+  end
+
+end
+
+step '#deploy_package_repo : deploy puppet-server nightly repo'
+hosts.each do |host|
+  host.deploy_package_repo(pkg_fixtures, 'puppetserver', 'latest')
+end


### PR DESCRIPTION
Add acceptance tests that exercise the host packages functionality. There are two test files: one for all hosts and one targeting unix hosts specifically.

This includes fixtures for supporting the deploy_*_repo methods.