### PR TITLE
[BKR-428] gracefully handle assert failure in teardown

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -33,7 +33,7 @@ module Beaker
     # an instance of {Beaker::Logger}.
     attr_accessor :logger
 
-    # Necessary for many methods in {Beaker::DSL::Helpers}.  Assumed to be 
+    # Necessary for many methods in {Beaker::DSL::Helpers}.  Assumed to be
     # a hash.
     attr_accessor :metadata
 
@@ -139,7 +139,7 @@ module Beaker
               @teardown_procs.each do |teardown|
                 begin
                   teardown.call
-                rescue StandardError, SignalException => e
+                rescue StandardError, SignalException, TEST_EXCEPTION_CLASS => e
                   log_and_fail_test(e)
                 end
               end

--- a/spec/beaker/test_case_spec.rb
+++ b/spec/beaker/test_case_spec.rb
@@ -94,6 +94,20 @@ module Beaker
         expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(Host::CommandFailure))
         testcase.run_test
       end
+
+      it 'records a test failure if an assertion fails in a teardown block' do
+        path = 'test.rb'
+        File.open(path, 'w') do |f|
+          f.write <<-EOF
+            teardown do
+              assert_equal(1, 2, 'Oh noes!')
+            end
+          EOF
+        end
+        @path = path
+        expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(Minitest::Assertion))
+        testcase.run_test
+      end
     end
 
     context 'metadata' do


### PR DESCRIPTION
![](http://thlog.com/wp-content/uploads/2012/09/Beaker-Meep-Vinyl-Decal.jpg)

Prior to this, if a teardown method ran code which contained assertions, and an assertion failed, the exception raised by the assertion failure was uncaught and beaker would crash.

This change treats the assertion failure as a test failure and allows beaker to continue running.

/cc @anodelman @kevpl @cowofevil 