### PR TITLE
(BKR-447) Ubuntu PE puppet-agent urls not being generated correctly

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1203,7 +1203,7 @@ module Beaker
               if arch == 'x86_64'
                 arch = 'amd64'
               end
-              version = version[0,2] + '.' + version[2,2] if variant =~ /ubuntu/ && version =~ /\.{0}/
+              version = version[0,2] + '.' + version[2,2] if (variant =~ /ubuntu/ && !version.include?("."))
               release_file = "/repos/apt/#{codename}/pool/#{opts[:puppet_collection]}/p/puppet-agent/puppet-agent*#{arch}.deb"
               download_file = "puppet-agent-#{variant}-#{version}-#{arch}.tar.gz"
             when /^windows$/

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -912,9 +912,24 @@ describe ClassMixedWithDSLInstallUtils do
 
   describe '#install_puppet_agent_pe_promoted_repo_on' do
 
-    it 'splits the platform string version correctly to get ubuntu puppet-agent packages' do
+    it 'splits the platform string version correctly to get ubuntu puppet-agent packages (format 9999)' do
       platform = Object.new()
       allow(platform).to receive(:to_array) { ['ubuntu', '9999', 'x42']}
+      host = basic_hosts.first
+      host['platform'] = platform
+
+      expect(subject).to receive(:fetch_http_file).once.with(/\/puppet-agent\//, "puppet-agent-ubuntu-99.99-x42.tar.gz", /ubuntu/)
+      expect(subject).to receive(:scp_to).once.with(host, /-ubuntu-99.99-x42\./, "/root")
+      expect(subject).to receive(:on).ordered.with(host, /^tar.*-ubuntu-99.99-x42/)
+      expect(subject).to receive(:on).ordered.with(host, /dpkg\ -i\ --force-all/)
+      expect(subject).to receive(:on).ordered.with(host, /apt-get\ update/)
+
+      subject.install_puppet_agent_pe_promoted_repo_on( host, {} )
+    end
+
+    it 'doesn\'t split the platform string version correctly to get ubuntu puppet-agent packages when unnecessary (format 99.99)' do
+      platform = Object.new()
+      allow(platform).to receive(:to_array) { ['ubuntu', '99.99', 'x42']}
       host = basic_hosts.first
       host['platform'] = platform
 


### PR DESCRIPTION
- incorrectly adding additional '.' to ubuntu version strings that were
  already correct
- added spec test to ensure correct behavior
- passed local testing