### PR TITLE
(BKR-448) Check for connection object during host.close

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -243,11 +243,13 @@ module Beaker
     end
 
     def close
-      @connection.close if @connection
-      # update connection information
-      @connection.ip = self['ip'] if self['ip']
-      @connection.vmhostname = self['vmhostname'] if self['vmhostname']
-      @connection.hostname = @name
+      if @connection
+        @connection.close
+        # update connection information
+        @connection.ip         = self['ip'] if self['ip']
+        @connection.vmhostname = self['vmhostname'] if self['vmhostname']
+        @connection.hostname   = @name
+      end
       @connection = nil
     end
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -649,5 +649,18 @@ module Beaker
       expect( "#{host}" ).to be === 'name'
     end
 
+    describe 'host close' do
+      context 'with a nil connection object' do
+        before do
+          conn = nil
+          host.instance_variable_set :@connection, conn
+          allow(host).to receive(:close).and_call_original
+        end
+        it 'does not raise an error' do
+          expect { host.close }.to_not raise_error
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The close method for hosts assumed the connection object existed when
trying to set the hostname; this fix checks to ensure the connection
object exists prior to calling any methods on it.