### PR TITLE
(BKR-449) beaker acceptance base smoketest intermittant failure...

### DIFF
--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -4,6 +4,8 @@ module PSWindows::Exec
 
   def reboot
     exec(Beaker::Command.new("shutdown /r /t 0"), :expect_connection_failure => true)
+    # rebooting on windows is slooooow
+    sleep(40)
   end
 
   ABS_CMD = 'c:\\\\windows\\\\system32\\\\cmd.exe'

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -7,6 +7,7 @@ module Unix::Exec
     else
       exec(Beaker::Command.new("/sbin/shutdown -r now"), :expect_connection_failure => true)
     end
+    sleep(10) #if we attempt a reconnect too quickly we end up blocking ¯\_(ツ)_/¯
   end
 
   def echo(msg, abs=true)

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -5,7 +5,7 @@ module Windows::Exec
     exec(Beaker::Command.new('shutdown /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :expect_connection_failure => true)
     # rebooting on windows is sloooooow
     # give it some breathing room before attempting a reconnect
-    sleep(30)
+    sleep(40)
   end
 
   ABS_CMD = 'c:\\\\windows\\\\system32\\\\cmd.exe'


### PR DESCRIPTION
...on ubuntu 1504

- when attempting to reconnect post reboot we are getting into a
  blocking state, most likely an issue with the Net::SSH gem
- just give some breathing room before moving on from a reboot and
  everything is okay