### PR TITLE
(BKR-293) PowerShell Hangs on Windows 2008 R2 WMF 5.0 Beta

### DIFF
--- a/lib/beaker/dsl/install_utils/aio_defaults.rb
+++ b/lib/beaker/dsl/install_utils/aio_defaults.rb
@@ -21,6 +21,11 @@ module Beaker
             'distmoduledir'     => '`cygpath -smF 35`/PuppetLabs/code/modules',
             # sitemoduledir not included (check PUP-4049 for more info)
           },
+          'pwindows' => { #pure windows
+            'puppetbindir'      => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\bin"',
+            'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin"',
+            'distmoduledir'     => 'C:\\ProgramData\\PuppetLabs\\code\\environments\\production\\modules',
+          }
         }
 
         # Add the appropriate aio defaults to the host object so that they can be accessed using host[option], set host[:type] = aio
@@ -43,7 +48,9 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def add_aio_defaults_on(hosts)
           block_on hosts do | host |
-            if host['platform'] =~ /windows/
+            if host.is_powershell?
+              platform = 'pwindows'
+            elsif host['platform'] =~ /windows/
               platform = 'windows'
             else
               platform = 'unix'
@@ -67,7 +74,9 @@ module Beaker
         #                            or a role (String or Symbol) that identifies one or more hosts.
         def remove_aio_defaults_on(hosts)
           block_on hosts do | host |
-            if host['platform'] =~ /windows/
+            if host.is_powershell?
+              platform = 'pswindows'
+            elsif host['platform'] =~ /windows/
               platform = 'windows'
             else
               platform = 'unix'

--- a/lib/beaker/dsl/install_utils/module_utils.rb
+++ b/lib/beaker/dsl/install_utils/module_utils.rb
@@ -110,6 +110,7 @@ module Beaker
             opts = {:source => './',
                     :target_module_path => host['distmoduledir'],
                     :ignore_list => PUPPET_MODULE_INSTALL_IGNORE}.merge(opts)
+
             ignore_list = build_ignore_list(opts)
             target_module_dir = on( host, "echo #{opts[:target_module_path]}" ).stdout.chomp
             source_path = File.expand_path( opts[:source] )
@@ -122,6 +123,9 @@ module Beaker
             end
 
             target_path = File.join(target_module_dir, module_name)
+            if host.is_powershell? #make sure our slashes are correct
+              target_path = target_path.gsub(/\//,'\\')
+            end
 
             opts[:protocol] ||= 'scp'
             case opts[:protocol]

--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -20,6 +20,8 @@ module PSWindows::Exec
   end
 
   def rm_rf path
+    # ensure that we have the right slashes for windows
+    path = path.gsub(/\//, '\\')
     execute("del /s /q #{path}")
   end
 
@@ -28,6 +30,9 @@ module PSWindows::Exec
   # @param [String] dest the destination path
   # @param [Boolean] rm Remove the destination prior to move
   def mv(orig, dest, rm=true)
+    # ensure that we have the right slashes for windows
+    orig = orig.gsub(/\//,'\\')
+    dest = dest.gsub(/\//,'\\')
     rm_rf dest unless !rm
     execute("move /y #{orig} #{dest}")
   end
@@ -122,6 +127,7 @@ module PSWindows::Exec
     if val.empty?
       return ''
     else
+      val = val.split(/\n/)[0] # only take the first result
       if clean
         val.gsub(/#{key}=/,'')
       else

--- a/spec/beaker/dsl/install_utils/module_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/module_utils_spec.rb
@@ -187,7 +187,7 @@ describe ClassMixedWithDSLInstallUtils do
         expect( subject ).to receive(:on).with(host, "echo C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules" ).and_return( result )
 
         expect( subject ).to receive(:scp_to).with(host, "/opt/testmodule2", "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules", {:ignore => ignore_list})
-        expect( host ).to receive(:mv).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule2', 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule')
+        expect( host ).to receive(:mv).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule2', 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules\\testmodule')
 
         subject.copy_module_to(host, {:module_name => 'testmodule', :source => '/opt/testmodule2'})
       end

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -28,7 +28,8 @@ module Beaker
 
       it "deletes" do
         path = '/path/to/delete'
-        expect( instance ).to receive(:execute).with("del /s /q #{path}").and_return(0)
+        corrected_path = '\\path\\to\\delete'
+        expect( instance ).to receive(:execute).with("del /s /q #{corrected_path}").and_return(0)
         expect( instance.rm_rf(path) ).to be === 0
       end
     end
@@ -38,14 +39,14 @@ module Beaker
       let(:destination) { '/destination/path/of/content' }
 
       it 'rm first' do
-        expect( instance ).to receive(:execute).with("del /s /q #{destination}").and_return(0)
-        expect( instance ).to receive(:execute).with("move /y #{origin} #{destination}").and_return(0)
+        expect( instance ).to receive(:execute).with("del /s /q #{destination.gsub(/\//, '\\')}").and_return(0)
+        expect( instance ).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
         expect( instance.mv(origin, destination) ).to be === 0
 
       end
 
       it 'does not rm' do
-         expect( instance ).to receive(:execute).with("move /y #{origin} #{destination}").and_return(0)
+         expect( instance ).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
          expect( instance.mv(origin, destination, false) ).to be === 0
       end
     end


### PR DESCRIPTION
- beaker powershell regressions discovered while working on this bug,
  mostly around ensuring that we are using the correct path separator on
  pswindowns machines