### PR TITLE
(BKR-459) update osx package name and directory to correspond...

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1125,8 +1125,18 @@ module Beaker
             when /^osx$/
               onhost_copy_base = File.join('/var', 'root')
               mac_pkg_name = "puppet-agent-#{opts[:puppet_agent_version]}"
-              release_path << "/apple/#{opts[:puppet_collection]}"
-              release_file = "#{mac_pkg_name}-#{variant}-#{version}-x86_64.dmg"
+              version = version[0,2] + '.' + version[2,2] if (variant =~ /osx/ && !version.include?("."))
+              path_chunk = ''
+              # new hotness
+              path_chunk = "apple/#{version}/#{opts[:puppet_collection]}/#{arch}"
+              release_path << path_chunk
+              release_file = "#{mac_pkg_name}-1.#{codename}.dmg"
+              if not link_exists?("#{release_path}/") # oops, try the old stuff
+                # the old school
+                release_path.chomp!(path_chunk) #remove chunk that didn't work
+                release_path << "apple/#{opts[:puppet_collection]}"
+                release_file = "#{mac_pkg_name}-#{variant}-#{version}-x86_64.dmg"
+              end
             else
               raise "No repository installation step for #{variant} yet..."
             end
@@ -1258,7 +1268,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-
 
         # This method will install a pem file certificate on a windows host
         #

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1088,12 +1088,17 @@ module Beaker
           if not opts[:puppet_agent_version]
             raise "must provide :puppet_agent_version (puppet-agent version) for install_puppet_agent_dev_repo_on"
           end
+
+          copy_base_external_defaults = Hash.new('/root').merge({
+            :windows => '`cygpath -smF 35`/',
+            :osx => '/var/root'
+          })
           block_on hosts do |host|
             variant, version, arch, codename = host['platform'].to_array
             opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
             opts[:download_url] = "#{opts[:dev_builds_url]}/puppet-agent/#{ opts[:puppet_agent_sha] || opts[:puppet_agent_version] }/repos/"
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
-            opts[:copy_dir_external]  ||= File.join('/', 'root')
+            opts[:copy_dir_external]  ||= copy_base_external_defaults[variant.to_sym]
             opts[:puppet_collection] ||= 'PC1'
             add_role(host, 'aio') #we are installing agent, so we want aio role
             release_path = opts[:download_url]
@@ -1114,7 +1119,6 @@ module Beaker
               release_file = "puppet-agent_#{opts[:puppet_agent_version]}-1#{codename}_#{arch}.deb"
             when /^windows$/
               release_path << 'windows'
-              onhost_copy_base = '`cygpath -smF 35`/'
               is_config_32 = host['ruby_arch'] == 'x86' || host['install_32'] || opts['install_32']
               should_install_64bit = host.is_x86_64? && !is_config_32
               # only install 64bit builds if
@@ -1123,7 +1127,6 @@ module Beaker
               arch_suffix = should_install_64bit ? '64' : '86'
               release_file = "puppet-agent-x#{arch_suffix}.msi"
             when /^osx$/
-              onhost_copy_base = File.join('/var', 'root')
               mac_pkg_name = "puppet-agent-#{opts[:puppet_agent_version]}"
               version = version[0,2] + '.' + version[2,2] if (variant =~ /osx/ && !version.include?("."))
               path_chunk = ''
@@ -1190,13 +1193,18 @@ module Beaker
         # @return nil
         def install_puppet_agent_pe_promoted_repo_on( hosts, opts )
           opts[:puppet_agent_version] ||= 'latest'
+
+          copy_base_external_defaults = Hash.new('/root').merge({
+            :windows => '`cygpath -smF 35`/',
+            :osx => '/var/root'
+          })
           block_on hosts do |host|
             pe_ver = host[:pe_ver] || opts[:pe_ver] || '4.0.0-rc1'
             variant, version, arch, codename = host['platform'].to_array
             opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
             opts[:download_url] = "#{opts[:pe_promoted_builds_url]}/puppet-agent/#{ pe_ver }/#{ opts[:puppet_agent_version] }/repos"
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
-            opts[:copy_dir_external]  ||= File.join('/', 'root')
+            opts[:copy_dir_external]  ||= copy_base_external_defaults[variant.to_sym]
             opts[:puppet_collection] ||= 'PC1'
             add_role(host, 'aio') #we are installing agent, so we want aio role
             release_path = opts[:download_url]
@@ -1217,7 +1225,6 @@ module Beaker
               release_file = "/repos/apt/#{codename}/pool/#{opts[:puppet_collection]}/p/puppet-agent/puppet-agent*#{arch}.deb"
               download_file = "puppet-agent-#{variant}-#{version}-#{arch}.tar.gz"
             when /^windows$/
-              onhost_copy_base = '`cygpath -smF 35`/'
               is_config_32 = host['ruby_arch'] == 'x86' || host['install_32'] || opts['install_32']
               should_install_64bit = host.is_x86_64? && !is_config_32
               # only install 64bit builds if
@@ -1228,7 +1235,6 @@ module Beaker
               release_file = "/puppet-agent-x#{arch_suffix}.msi"
               download_file = "puppet-agent-x#{arch_suffix}.msi"
             when /^osx$/
-              onhost_copy_base = File.join('/var', 'root')
               release_file = "/repos/apple/#{opts[:puppet_collection]}/puppet-agent-*"
               download_file = "puppet-agent-#{variant}-#{version}.tar.gz"
             else

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -21,10 +21,8 @@ module Beaker
                      "precise" => "1204",
                      "lucid"   => "1004",
                    },
-        :osx =>    { "yosemite"  => "10.10",
-                     "mavericks" => "10.9",
-                     "1010"      => "10.10",
-                     "109"       => "10.9"
+        :osx =>    { "yosemite"  => "1010",
+                     "mavericks" => "109",
                    }
       }
 

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -812,7 +812,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
-  describe '#install_puppetagent_dev_repo' do
+  describe '#install_puppet_agent_dev_repo_on' do
 
     it 'raises an exception when host platform is unsupported' do
       platform = Object.new()
@@ -823,7 +823,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :options ).and_return( {} )
 
       expect{
-        subject.install_puppetagent_dev_repo( host, opts )
+        subject.install_puppet_agent_dev_repo_on( host, opts )
       }.to raise_error(RuntimeError, /No repository installation step for/)
     end
 
@@ -839,7 +839,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:scp_to).once.with(host, /-agent-/, "/root")
       expect(subject).to receive(:on).once.with(host, /rpm\ -ivh/)
 
-      subject.install_puppetagent_dev_repo( host, opts )
+      subject.install_puppet_agent_dev_repo_on( host, opts )
     end
 
     it 'runs the correct install for debian-based platforms' do
@@ -855,7 +855,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:on).ordered.with(host, /dpkg\ -i\ --force-all/)
       expect(subject).to receive(:on).ordered.with(host, /apt-get\ update/)
 
-      subject.install_puppetagent_dev_repo( host, opts )
+      subject.install_puppet_agent_dev_repo_on( host, opts )
     end
 
     it 'runs the correct install for windows platforms' do
@@ -874,7 +874,48 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:install_msi_on).with(host, copied_path, {}, {:debug => nil}).once
       expect(subject).to receive(:on).ordered.with(host, /echo/).and_return(mock_echo)
 
-      subject.install_puppetagent_dev_repo( host, opts )
+      subject.install_puppet_agent_dev_repo_on( host, opts )
+    end
+
+    it 'runs the correct install for osx platforms (new link format)' do
+      platform = Object.new()
+      allow(platform).to receive(:to_array) { ['osx', '10.9', 'x86_64', 'mavericks']}
+      host = basic_hosts.first
+      host['platform'] = platform
+      opts = { :version => '0.1.0' }
+      allow( subject ).to receive( :options ).and_return( {} )
+      copied_path = "#{win_temp}\\puppet-agent-x64.msi"
+      mock_echo = Object.new()
+      allow( mock_echo ).to receive( :raw_output ).and_return( copied_path )
+
+      expect(subject).to receive(:link_exists?).with(/\/puppet-agent\/0.1.0\/repos\/apple\/10.9\/PC1\/x86_64\//).and_return(true)
+      expect(subject).to receive(:fetch_http_file).once.with(/\/apple\/10.9\/PC1\/x86_64$/, 'puppet-agent-0.1.0-1.mavericks.dmg', /\/osx$/)
+      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-0.1.0-1.mavericks.dmg$/, /var\/root/)
+      expect(host).to receive( :install_package ).with(/puppet-agent-0.1.0\*/)
+
+      subject.install_puppet_agent_dev_repo_on( host, opts )
+
+    end
+
+    it 'runs the correct install for osx platforms (old link format)' do
+      platform = Object.new()
+      allow(platform).to receive(:to_array) { ['osx', '10.9', 'x86_64', 'mavericks']}
+      host = basic_hosts.first
+      host['platform'] = platform
+      opts = { :version => '0.1.0' }
+      allow( subject ).to receive( :options ).and_return( {} )
+      copied_path = "#{win_temp}\\puppet-agent-x64.msi"
+      mock_echo = Object.new()
+      allow( mock_echo ).to receive( :raw_output ).and_return( copied_path )
+
+      expect(subject).to receive(:link_exists?).with(/\/puppet-agent\/0.1.0\/repos\/apple\/10.9\/PC1\/x86_64\//).and_return(false)
+      expect(subject).to receive(:fetch_http_file).once.with(/\/puppet-agent\/0.1.0\/repos\/apple\/PC1$/, 'puppet-agent-0.1.0-osx-10.9-x86_64.dmg', /\/osx$/)
+      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-0.1.0-osx-10.9-x86_64.dmg$/, /var\/root/)
+      expect(host).to receive( :install_package ).with(/puppet-agent-0.1.0\*/)
+
+      subject.install_puppet_agent_dev_repo_on( host, opts )
+
+
     end
 
     it 'allows you to override the local copy directory' do
@@ -890,7 +931,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:on).ordered.with(host, /dpkg\ -i\ --force-all/)
       expect(subject).to receive(:on).ordered.with(host, /apt-get\ update/)
 
-      subject.install_puppetagent_dev_repo( host, opts )
+      subject.install_puppet_agent_dev_repo_on( host, opts )
     end
 
     it 'allows you to override the external copy directory' do
@@ -906,7 +947,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:on).ordered.with(host, /dpkg\ -i\ --force-all/)
       expect(subject).to receive(:on).ordered.with(host, /apt-get\ update/)
 
-      subject.install_puppetagent_dev_repo( host, opts )
+      subject.install_puppet_agent_dev_repo_on( host, opts )
     end
   end
 


### PR DESCRIPTION
    
    ... to RE changes
    
    - updated install_puppet_agent_dev_repo_on to handle new directory
      structure and name change
    - backwards compatible, handles both old and new
    - fixed up a small bug about overriding passed in options