### PR TITLE
(BKR-458) add beaker notouch hypervisor

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -56,7 +56,9 @@ module Beaker
           Beaker::Docker
         when /^openstack$/
           Beaker::OpenStack
-        when /^none$/
+        when /^noop$/
+          Beaker::Noop
+        when /^(default)|(none)$/
           Beaker::Hypervisor
         else
           # Custom hypervisor
@@ -133,6 +135,6 @@ module Beaker
   end
 end
 
-[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vmpooler', 'vcloud', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack' ].each do |lib|
+[ 'vsphere_helper', 'vagrant', 'vagrant_virtualbox', 'vagrant_parallels', 'vagrant_libvirt', 'vagrant_fusion', 'vagrant_workstation', 'fusion', 'aws_sdk', 'vsphere', 'vmpooler', 'vcloud', 'aixer', 'solaris', 'docker', 'google_compute', 'openstack', 'noop' ].each do |lib|
     require "beaker/hypervisor/#{lib}"
 end

--- a/lib/beaker/hypervisor/noop.rb
+++ b/lib/beaker/hypervisor/noop.rb
@@ -1,0 +1,31 @@
+module Beaker
+  class Noop < Beaker::Hypervisor
+
+    def initialize(new_hosts, options)
+      @options = options
+      @logger = options[:logger]
+      @hosts = new_hosts
+    end
+
+    def validate
+      # noop
+    end
+
+    def configure
+      # noop
+    end
+
+    def proxy_package_manager
+      # noop
+    end
+
+    def provision
+      # noop
+    end
+
+    def cleanup
+      # noop
+    end
+
+  end
+end


### PR DESCRIPTION
- support for a 'noop' hypervisor that does no
  configuration/validation/provision/cleanup/proxy-ing