### PR TITLE
(BKR-504) Update Solaris package name for release version

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1148,8 +1148,11 @@ module Beaker
                 # Solaris 10 uses / as the root user directory. Solaris 11 uses /root.
                 onhost_copy_base = '/'
               end
-              release_path << "/solaris/#{version}/#{opts[:puppet_collection]}"
-              release_file = "puppet-agent-#{opts[:puppet_agent_version]}.#{arch}.pkg.gz"
+              release_path << "solaris/#{version}/#{opts[:puppet_collection]}"
+              release_file = "puppet-agent-#{opts[:puppet_agent_version]}-1.#{arch}.pkg.gz"
+              if not link_exists?("#{release_path}/#{release_file}")
+                release_file = "puppet-agent-#{opts[:puppet_agent_version]}.#{arch}.pkg.gz"
+              end
             else
               raise "No repository installation step for #{variant} yet..."
             end

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -1080,6 +1080,15 @@ describe ClassMixedWithDSLInstallUtils do
       end
 
       it "copies package to the root directory and installs it" do
+        expect( subject ).to receive( :link_exists? ).with(/puppet-agent-1\.0\.0-1\.i386\.pkg\.gz/).and_return( true )
+        expect( subject ).to receive( :scp_to ).with( host, /\/puppet-agent-1\.0\.0\-1.i386\.pkg\.gz/, '/' )
+        expect( subject ).to receive( :create_remote_file ).with( host, '/noask', /noask file/m )
+        expect( subject ).to receive( :on ).with( host, 'gunzip -c puppet-agent-1.0.0-1.i386.pkg.gz | pkgadd -d /dev/stdin -a noask -n all' )
+        test_fetch_http_file
+      end
+
+      it "copies old package to the root directory and installs it" do
+        expect( subject ).to receive( :link_exists? ).with(/puppet-agent-1\.0\.0-1\.i386\.pkg\.gz/).and_return( false )
         expect( subject ).to receive( :scp_to ).with( host, /\/puppet-agent-1\.0\.0\.i386\.pkg\.gz/, '/' )
         expect( subject ).to receive( :create_remote_file ).with( host, '/noask', /noask file/m )
         expect( subject ).to receive( :on ).with( host, 'gunzip -c puppet-agent-1.0.0.i386.pkg.gz | pkgadd -d /dev/stdin -a noask -n all' )
@@ -1093,6 +1102,15 @@ describe ClassMixedWithDSLInstallUtils do
       end
 
       it "copies package to the root user directory and installs it" do
+        expect( subject ).to receive( :link_exists? ).with(/puppet-agent-1\.0\.0-1\.i386\.pkg\.gz/).and_return( true )
+        expect( subject ).to receive( :scp_to ).with( host, /\/puppet-agent-1\.0\.0-1\.i386\.pkg\.gz/, '/root' )
+        expect( subject ).to receive( :create_remote_file ).with( host, '/root/noask', /noask file/m )
+        expect( subject ).to receive( :on ).with( host, 'gunzip -c puppet-agent-1.0.0-1.i386.pkg.gz | pkgadd -d /dev/stdin -a noask -n all' )
+        test_fetch_http_file
+      end
+
+      it "copies old package to the root directory and installs it" do
+        expect( subject ).to receive( :link_exists? ).with(/puppet-agent-1\.0\.0-1\.i386\.pkg\.gz/).and_return( false )
         expect( subject ).to receive( :scp_to ).with( host, /\/puppet-agent-1\.0\.0\.i386\.pkg\.gz/, '/root' )
         expect( subject ).to receive( :create_remote_file ).with( host, '/root/noask', /noask file/m )
         expect( subject ).to receive( :on ).with( host, 'gunzip -c puppet-agent-1.0.0.i386.pkg.gz | pkgadd -d /dev/stdin -a noask -n all' )


### PR DESCRIPTION
The planned Solaris package names for the puppet-agent package were
changed to incorporate a release version, as already handled for other
platforms. Update the Solaris package name to include the hard-coded
release `1` naming.