### PR TITLE
(BKR-505) rescue `SkipTest` in `confine_block`

### DIFF
--- a/acceptance/tests/base/dsl/structure_test.rb
+++ b/acceptance/tests/base/dsl/structure_test.rb
@@ -1,0 +1,63 @@
+test_name "dsl::structure" do
+  step "#confine_block runs specified block on matching hosts" do
+    begin
+      @in_confine = 0
+      confine_block :to, :platform => default["platform"] do
+        @in_confine +=1
+      end
+
+      assert_equal 1, @in_confine, "#confine_block did not run the supplied block"
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      fail "#confine_block raised unexpected SkipTest exception: #{e}"
+    end
+  end
+
+  step "#confine_block leaves hosts array intact after running block on matching hosts" do
+    begin
+      previous_hosts = hosts.dup
+
+      @in_confine = 0
+      confine_block :to, :platform => default["platform"] do
+        @in_confine +=1
+      end
+
+      assert_equal 1, @in_confine, "#confine_block did not run the supplied block"
+      assert_equal hosts.dup, hosts, "#confine_block did not preserve the hosts array"
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      fail "#confine_block raised unexpected SkipTest exception: #{e}"
+    end
+  end
+
+  step "#confine_block will not run specified block on non-matching hosts" do
+    begin
+      @in_confine = 0
+      confine_block :except, :platform => default["platform"] do
+        @in_confine +=1
+      end
+
+      assert_equal 0, @in_confine, "#confine_block did not skip the supplied block"
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      fail "#confine_block raised unexpected SkipTest exception: #{e}"
+    end
+  end
+
+  step "#confine_block leaves hosts array intact after skipping block on non-matching hosts" do
+    begin
+      previous_hosts = hosts.dup
+
+      @in_confine = 0
+      confine_block :except, :platform => default["platform"] do
+        @in_confine +=1
+      end
+
+      assert_equal 0, @in_confine, "#confine_block did not skip the supplied block"
+      assert_equal hosts.dup, hosts, "#confine_block did not preserve the hosts array"
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      fail "#confine_block raised unexpected SkipTest exception: #{e}"
+    end
+  end
+end

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -208,16 +208,15 @@ module Beaker
       #
       # @see #confine
       def confine_block(type, criteria, host_array = nil, &block)
-        begin
-          host_array = Array( host_array || hosts )
-          original_hosts = self.hosts.dup
-          confine(type, criteria, host_array)
+        host_array = Array( host_array || hosts )
+        original_hosts = self.hosts.dup
+        confine(type, criteria, host_array)
 
-          yield
+        yield
 
-        ensure
-          self.hosts = original_hosts
-        end
+      rescue Beaker::DSL::Outcomes::SkipTest
+      ensure
+        self.hosts = original_hosts
       end
 
       # Sets tags on the current {Beaker::TestCase}, and skips testing


### PR DESCRIPTION
![](http://unspokenpictures.com/wp-content/uploads/funny-Beaker-Muppets-meme.jpg)

Prior to this, use of `confine_block` would result in all following code in the test case being skipped in situations where the host list had no matches for the confine_block.  The entire purpose of `confine_block` is to limit the scope of the confine to the passed block.

Also, `ensure` and `rescue` at the method level do not require an additional wrapping `begin..end` block.

This was tested locally against the acceptance test suite still in development (and currently partially blocked by this bug) at https://github.com/puppetlabs/beaker/pull/930

/cc @puppetlabs/beaker @justinstoller 