### PR TITLE
(BKR-482) Add support for OSX 10.11 El Capitan (x86_64)

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -519,6 +519,10 @@ module Beaker
           else
             #nothing to do here
           end
+        when /osx-10\.*11/
+          host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /private/etc/ssh/sshd_config"))
+          host.exec(Command.new("launchctl unload /System/Library/LaunchDaemons/ssh.plist"))
+          host.exec(Command.new("launchctl load /System/Library/LaunchDaemons/ssh.plist"))
         when /osx/
           host.exec(Command.new("echo '\nPermitUserEnvironment yes' >> /etc/sshd_config"))
           host.exec(Command.new("launchctl unload /System/Library/LaunchDaemons/ssh.plist"))

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -21,7 +21,8 @@ module Beaker
                      "precise" => "1204",
                      "lucid"   => "1004",
                    },
-        :osx =>    { "yosemite"  => "1010",
+        :osx =>    { "elcapitan" => "1011",
+                     "yosemite"  => "1010",
                      "mavericks" => "109",
                    }
       }


### PR DESCRIPTION
- correctly turn on ssh user environment support
- update platform list