### PR TITLE
(BKR-515) add config option host_name_prefix

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -16,6 +16,7 @@ module Beaker
     #                     blimpy, vcloud or vagrant
     #@param [Array<Host>] hosts_to_provision The hosts to be provisioned with the selected hypervisor
     #@param [Hash] options options Options to alter execution
+    #@option options [String] :host_name_prefix (nil) Prefix host name if set
     def self.create(type, hosts_to_provision, options)
       @logger = options[:logger]
       @logger.notify("Beaker::Hypervisor, found some #{type} boxes to create")
@@ -128,8 +129,13 @@ module Beaker
     end
 
     #Generate a random string composted of letter and numbers
+    #prefixed with value of {Beaker::Hypervisor::create} option :host_name_prefix
     def generate_host_name
-      CHARMAP[rand(25)] + (0...14).map{CHARMAP[rand(CHARMAP.length)]}.join
+      n = CHARMAP[rand(25)] + (0...14).map{CHARMAP[rand(CHARMAP.length)]}.join
+      if @options[:host_name_prefix]
+        return @options[:host_name_prefix] + n
+      end
+      n
     end
 
   end

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -169,6 +169,7 @@ module Beaker
           :pe_version_file        => 'LATEST',
           :pe_version_file_win    => 'LATEST-win',
           :host_env               => {},
+          :host_name_prefix       => nil,
           :ssh_env_file           => '~/.ssh/environment',
           :profile_d_env_file     => '/etc/profile.d/beaker_env.sh',
           :dot_fog                => File.join(ENV['HOME'], '.fog'),

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -96,11 +96,13 @@ module Beaker
           options[:root_keys]         = true
           options[:add_el_extras]     = true
           options[:disable_iptables]  = true
+          options[:host_name_prefix]  = "test-"
           expect( hypervisor ).to_not receive( :timesync )
           expect( hypervisor ).to_not receive( :sync_root_keys )
           expect( hypervisor ).to_not receive( :add_el_extras )
           expect( hypervisor ).to_not receive( :disable_iptables )
           expect( hypervisor ).to_not receive( :set_env )
+          expect( hypervisor ).to_not receive( :host_name_prefix )
           hypervisor.configure
         end
       end
@@ -110,6 +112,15 @@ module Beaker
           options[:configure] = true
           expect( hypervisor ).to receive( :set_env ).once
           hypervisor.configure
+        end
+      end
+
+      context 'if :host_name_prefix is set' do
+        it "generates hostname with prefix" do
+          prefix = "testing-prefix-to-test-"
+          options[:host_name_prefix] = prefix
+	  expect( hypervisor.generate_host_name().start_with?(prefix) ).to be true
+	  expect( hypervisor.generate_host_name().length - prefix.length >= 15 ).to be true
         end
       end
 


### PR DESCRIPTION
This helps to identify hosts if you do not destroy them.

If defined, hostname is prefixed.