### PR TITLE
(BKR-514) increase polling timeout when requesting vpool instances

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -127,8 +127,9 @@ module Beaker
           raise "Vmpooler.provision - requested host set not available"
         end
       rescue JSON::ParserError, RuntimeError, *SSH_EXCEPTIONS => e
+        @logger.debug "Failed vmpooler provision: #{e.class} : #{e.message}"
         if waited <= @options[:timeout].to_i
-          @logger.debug("Retrying provision for vmpooler host after waiting #{wait} second(s) (failed with #{e.class})")
+          @logger.debug("Retrying provision for vmpooler host after waiting #{wait} second(s)")
           sleep wait
           waited += wait
           last_wait, wait = wait, last_wait + wait

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -151,7 +151,7 @@ module Beaker
           :dry_run                => false,
           :tag_includes           => '',
           :tag_excludes           => '',
-          :timeout                => 300,
+          :timeout                => 900, # 15 minutes
           :fail_mode              => 'slow',
           :accept_all_exit_codes  => false,
           :timesync               => false,


### PR DESCRIPTION
- increase timeout to 15 minutes
- write out failure message to get more information about why the pool
  request failed