### PR TITLE
(BKR-519) Beaker prints invisible messages in debug mode (black-on-bl…

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -18,7 +18,7 @@ module Beaker
     MAGENTA        = "\e[00;35m"
     CYAN           = "\e[00;36m"
     WHITE          = "\e[00;37m"
-    GREY           = "\e[01;30m"
+    GREY           = "\e[00;00m"  # Some terms can't handle grey, use normal
     BRIGHT_RED     = "\e[01;31m"
     BRIGHT_GREEN   = "\e[01;32m"
     BRIGHT_YELLOW  = "\e[01;33m"


### PR DESCRIPTION
Use normal colour instead of bold as some terminals (mac) can't handle the grey without additional configuration.

Ends up looking like this (green is my regular colour):
![screen shot 2015-09-15 at 08 56 36](https://cloud.githubusercontent.com/assets/3904115/9863916/b4013032-5b87-11e5-8b10-ebf6dfc5ee2f.png)

Tests seem to be passing:
```
bundle exec rake spec
...
Finished in 14.13 seconds (files took 1.79 seconds to load)
1045 examples, 0 failures
```
