### PR TITLE
(BKR-523) Beaker prints error message on exit when using docker containers

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -137,6 +137,8 @@ module Beaker
             image.delete
           rescue Excon::Errors::ClientError => e
             @logger.warn("deletion of image #{image.id} failed: #{e.response.body}")
+          rescue ::Docker::Error::DockerError => e
+            @logger.warn("deletion of image #{image.id} caused internal Docker error: #{e.message}")
           end
         end
       end


### PR DESCRIPTION
Capture the strange error message from docker (and all other internal docker errors) and display the message as a logged warning instead of a stack trace.  This will preven the message from causing a CI test failure as the exit status is now zero.

Doesn't address the root-cause of this warning message but handles it in a more graceful way