### PR TITLE
(BKR-533) Beaker's `confine` overwrites the array of all hosts

### DIFF
--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -170,6 +170,12 @@ module Beaker
       # @example Confining from  an already defined subset of hosts
       #     confine :except, {}, agents
       #
+      # @example Confining to all ubuntu agents + all non-agents
+      #     confine :to, { :platform => 'ubuntu' }, agents
+      #
+      # @example Confining to any non-windows agents + all non-agents
+      #     confine :except, { :platform => 'windows' }, agents
+      #
       #
       # @return [Array<Host>] Returns an array of hosts that are still valid
       #   targets for this tests case.
@@ -177,17 +183,18 @@ module Beaker
       #   this test case after confinement.
       def confine(type, criteria, host_array = nil, &block)
         hosts_to_modify = Array( host_array || hosts )
+        hosts_not_modified = hosts - hosts_to_modify #we aren't examining these hosts
         case type
         when :except
           if criteria and ( not criteria.empty? )
-            hosts_to_modify = hosts_to_modify - select_hosts(criteria, hosts_to_modify, &block)
+            hosts_to_modify = hosts_to_modify - select_hosts(criteria, hosts_to_modify, &block) + hosts_not_modified
           else
             # confining to all hosts *except* provided array of hosts
-            hosts_to_modify = hosts - host_array
+            hosts_to_modify = hosts_not_modified
           end
         when :to
           if criteria and ( not criteria.empty? )
-            hosts_to_modify = select_hosts(criteria, hosts_to_modify, &block)
+            hosts_to_modify = select_hosts(criteria, hosts_to_modify, &block) + hosts_not_modified
           else
             # confining to only hosts in provided array of hosts
           end

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -131,6 +131,7 @@ describe ClassMixedWithDSLStructure do
     it ':to - uses a provided host subset when no criteria is provided' do
       subset = ['host1', 'host2']
       hosts = subset.dup << 'host3'
+      allow( subject ).to receive( :hosts ).and_return(hosts).twice
       expect( subject ).to receive( :hosts= ).with( subset )
       subject.confine :to, {}, subset
     end
@@ -138,13 +139,14 @@ describe ClassMixedWithDSLStructure do
     it ':except - excludes provided host subset when no criteria is provided' do
       subset = ['host1', 'host2']
       hosts = subset.dup << 'host3'
-      allow( subject ).to receive( :hosts ).and_return(hosts)
+      allow( subject ).to receive( :hosts ).and_return(hosts).twice
       expect( subject ).to receive( :hosts= ).with( hosts - subset )
       subject.confine :except, {}, subset
     end
 
     it 'raises when given mode is not :to or :except' do
-      allow( subject ).to receive( :hosts )
+      hosts = ['host1', 'host2']
+      allow( subject ).to receive( :hosts ).and_return(hosts)
       allow( subject ).to receive( :hosts= )
 
       expect {
@@ -155,7 +157,7 @@ describe ClassMixedWithDSLStructure do
     it 'rejects hosts that do not meet simple hash criteria' do
       hosts = [ {'thing' => 'foo'}, {'thing' => 'bar'} ]
 
-      expect( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :hosts ).and_return( hosts ).twice
       expect( subject ).to receive( :hosts= ).
         with( [ {'thing' => 'foo'} ] )
 
@@ -165,7 +167,7 @@ describe ClassMixedWithDSLStructure do
     it 'rejects hosts that match a list of criteria' do
       hosts = [ {'thing' => 'foo'}, {'thing' => 'bar'}, {'thing' => 'baz'} ]
 
-      expect( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :hosts ).and_return( hosts ).twice
       expect( subject ).to receive( :hosts= ).
         with( [ {'thing' => 'bar'} ] )
 
@@ -180,7 +182,7 @@ describe ClassMixedWithDSLStructure do
       ret2 = (Struct.new('Result2', :stdout)).new('a_zone')
       hosts = [ host1, host2, host3 ]
 
-      expect( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :hosts ).and_return( hosts ).twice
       expect( subject ).to receive( :on ).
         with( host1, '/sbin/zonename' ).
         and_return( ret1 )
@@ -193,6 +195,37 @@ describe ClassMixedWithDSLStructure do
       subject.confine :to, :platform => 'solaris' do |host|
         subject.on( host, '/sbin/zonename' ).stdout =~ /:global/
       end
+    end
+
+    it 'doesn\'t corrupt the global hosts hash when confining from a subset of hosts' do
+      host1 = {'platform' => 'solaris', :roles => ['master']}
+      host2 = {'platform' => 'solaris', :roles => ['agent']}
+      host3 = {'platform' => 'windows', :roles => ['agent']}
+      hosts = [ host1, host2, host3 ]
+      agents = [ host2, host3 ]
+
+      expect( subject ).to receive( :hosts ).and_return( hosts )
+      expect( subject ).to receive( :hosts= ).with( [  host2, host1 ] )
+      confined_hosts = subject.confine :except, {:platform => 'windows'}, agents
+      expect( confined_hosts ).to be === [ host2, host1 ]
+    end
+
+    it 'can apply multiple confines correctly' do
+      host1 = {'platform' => 'solaris', :roles => ['master']}
+      host2 = {'platform' => 'solaris', :roles => ['agent']}
+      host3 = {'platform' => 'windows', :roles => ['agent']}
+      host4 = {'platform' => 'fedora', :roles => ['agent']}
+      host5 = {'platform' => 'fedora', :roles => ['agent']}
+      hosts = [ host1, host2, host3, host4, host5 ]
+      agents = [ host2, host3, host4, host5 ]
+
+      expect( subject ).to receive( :hosts ).and_return( hosts ).exactly(3).times
+      expect( subject ).to receive( :hosts= ).with( [  host1, host2, host4, host5 ] )
+      hosts = subject.confine :except, {:platform => 'windows'}
+      expect( hosts ).to be === [ host1, host2, host4, host5  ]
+      expect( subject ).to receive( :hosts= ).with( [  host4, host5, host1 ] )
+      hosts = subject.confine :to, {:platform => 'fedora'}, agents
+      expect( hosts ).to be === [ host4, host5, host1 ]
     end
   end
 


### PR DESCRIPTION
- make it possible to confine to a subset of hosts + all hosts not in
  the subset.

  To confine to only windows agents + any non-agent hosts

    confine :to, { :platform => 'windows' }, agents

  To confine to non-windows agents + any non-agent hosts

    confine :except, { :platform => 'windows' }, agent

- Useful for cases where you want to use your master, but only operate
  on a subset of agents