### PR TITLE
(BKR-535) Regression: confine_block does not skip tests...

### DIFF
--- a/acceptance/tests/base/dsl/structure_test.rb
+++ b/acceptance/tests/base/dsl/structure_test.rb
@@ -60,4 +60,20 @@ test_name "dsl::structure" do
       fail "#confine_block raised unexpected SkipTest exception: #{e}"
     end
   end
+
+  step "#confine_block allows blocks to raise skip_test" do
+    previous_hosts = hosts.dup
+
+    begin
+      @in_confine = 0
+      confine_block :to, :platform => default["platform"] do
+        @in_confine +=1
+        skip_test "this block raises a skip"
+      end
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      assert_match /this block raises a skip/, e.message, "#confine_block raised an unexpected skip_test"
+      assert_equal 1, @in_confine, "#confine_block did not execute supplied block"
+      assert_equal hosts.dup, hosts, "#confine_block did not preserve the hosts array"
+    end
+  end
 end

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -214,7 +214,13 @@ module Beaker
 
         yield
 
-      rescue Beaker::DSL::Outcomes::SkipTest
+      rescue Beaker::DSL::Outcomes::SkipTest => e
+        # I don't like this much, but adding options to confine is a breaking change
+        # to the DSL that would involve a major version bump
+        if e.message !~ /No suitable hosts found/
+          # a skip generated from the provided block, pass it up the chain
+          raise e
+        end
       ensure
         self.hosts = original_hosts
       end


### PR DESCRIPTION
...with beaker 2.24.0

- allow users to include skip_test in block parameter for confine_block
- added acceptance test to ensure correct behavior