### PR TITLE
(BKR-522) now creates new ec2 keys per run

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -92,6 +92,7 @@ module Beaker
     def cleanup
       # Provisioning should have set the host 'instance' values.
       kill_instances(@hosts.map{|h| h['instance']}.select{|x| !x.nil?})
+      delete_key_pair_all_regions()
       nil
     end
 
@@ -193,6 +194,7 @@ module Beaker
           end
         end
       end
+      delete_key_pair_all_regions(key_name_prefix)
 
       @logger.notify "#{key}: Killed #{kill_count} instance(s)"
     end
@@ -665,13 +667,23 @@ module Beaker
       File.read(key_file)
     end
 
+    # Generate a key prefix for key pair names
+    #
+    # @note This is the part of the key that will stay static between Beaker
+    #   runs on the same host.
+    #
+    # @return [String] Beaker key pair name based on sanitized hostname
+    def key_name_prefix
+      safe_hostname = Socket.gethostname.gsub('.', '-')
+      "Beaker-#{local_user}-#{safe_hostname}"
+    end
+
     # Generate a reusable key name from the local hosts hostname
     #
     # @return [String] safe key name for current host
     # @api private
     def key_name
-      safe_hostname = Socket.gethostname.gsub('.', '-')
-      "Beaker-#{local_user}-#{safe_hostname}"
+      "#{key_name_prefix}-#{@options[:timestamp].strftime("%F_%H_%M_%S")}"
     end
 
     # Returns the local user running this tool
@@ -682,22 +694,86 @@ module Beaker
       ENV['USER']
     end
 
-    # Returns the KeyPair for this host, creating it if needed
+    # Creates the KeyPair for this test run
     #
     # @param region [AWS::EC2::Region] region to create the key pair in
     # @return [AWS::EC2::KeyPair] created key_pair
     # @api private
     def ensure_key_pair(region)
-      @logger.notify("aws-sdk: Ensure key pair exists, create if not")
-      key_pairs = region.key_pairs
       pair_name = key_name()
-      kp = key_pairs[pair_name]
-      unless kp.exists?
-        ssh_string = public_key()
-        kp = key_pairs.import(pair_name, ssh_string)
-      end
+      delete_key_pair(region, pair_name)
+      create_new_key_pair(region, pair_name)
+    end
 
-      kp
+    # Deletes key pairs from all regions
+    #
+    # @param [String] keypair_name_filter if given, will get all keypairs that match
+    #   a simple {::String#start_with?} filter. If no filter is given, the basic key
+    #   name returned by {#key_name} will be used.
+    #
+    # @return nil
+    # @api private
+    def delete_key_pair_all_regions(keypair_name_filter=nil)
+      region_keypairs_hash = my_key_pairs(keypair_name_filter)
+      region_keypairs_hash.each_pair do |region, keypair_name_array|
+        keypair_name_array.each do |keypair_name|
+          delete_key_pair(region, keypair_name)
+        end
+      end
+    end
+
+    # Gets the Beaker user's keypairs by region
+    #
+    # @param [String] name_filter if given, will get all keypairs that match
+    #   a simple {::String#start_with?} filter. If no filter is given, the basic key
+    #   name returned by {#key_name} will be used.
+    #
+    # @return [Hash{AWS::EC2::Region=>Array[String]}] a hash of region instance to
+    #   an array of the keypair names that match for the filter
+    # @api private
+    def my_key_pairs(name_filter=nil)
+      keypairs_by_region = {}
+      keyname_default = key_name()
+      keyname_filtered = "#{name_filter}-*"
+      @ec2.regions.each do |region|
+        if name_filter
+          aws_name_filter = keyname_filtered
+        else
+          aws_name_filter = keyname_default
+        end
+        keypair_collection = region.key_pairs.filter('key-name', aws_name_filter)
+        keypair_collection.each do |keypair|
+          keypairs_by_region[region] ||= []
+          keypairs_by_region[region] << keypair.name
+        end
+      end
+      keypairs_by_region
+    end
+
+    # Deletes a given key pair
+    #
+    # @param [AWS::EC2::Region] region the region the key belongs to
+    # @param [String] pair_name the name of the key to be deleted
+    #
+    # @api private
+    def delete_key_pair(region, pair_name)
+      kp = region.key_pairs[pair_name]
+      if kp.exists?
+        @logger.debug("aws-sdk: delete key pair in region: #{region.name}")
+        kp.delete()
+      end
+    end
+
+    # Create a new key pair for a given Beaker run
+    #
+    # @param [AWS::EC2::Region] region the region the key pair will be imported into
+    # @param [String] pair_name the name of the key to be created
+    #
+    # @return [AWS::EC2::KeyPair] key pair created
+    def create_new_key_pair(region, pair_name)
+      @logger.debug("aws-sdk: generating new key pair: #{pair_name}")
+      ssh_string = public_key()
+      region.key_pairs.import(pair_name, ssh_string)
     end
 
     # Return a reproducable security group identifier based on input ports

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Beaker
   describe AwsSdk do
-    let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
+    let( :options ) { make_opts.merge({ 'logger' => double().as_null_object, 'timestamp' => Time.now }) }
     let(:aws) {
       # Mock out the call to load_fog_credentials
       allow_any_instance_of( Beaker::AwsSdk ).
@@ -211,6 +211,7 @@ module Beaker
       context 'with a list of hosts' do
         before :each do
           @hosts.each {|host| host['instance'] = ec2_instance}
+          expect(aws).to receive( :delete_key_pair_all_regions )
         end
 
         it { is_expected.to be_nil }
@@ -224,6 +225,7 @@ module Beaker
       context 'with an empty host list' do
         before :each do
           @hosts = []
+          expect(aws).to receive( :delete_key_pair_all_regions )
         end
 
         it { is_expected.to be_nil }
@@ -268,7 +270,16 @@ module Beaker
       it { is_expected.to be_instance_of(AWS::EC2::SecurityGroupCollection) }
     end
 
-    describe '#kill_zombies', :wip do
+    describe '#kill_zombies' do
+      it 'calls delete_key_pair_all_regions' do
+        ec2_mock = Object.new
+        allow(ec2_mock).to receive( :regions ).and_return( {} )
+        aws.instance_variable_set( :@ec2, ec2_mock )
+
+        expect( aws ).to receive( :delete_key_pair_all_regions ).once
+
+        aws.kill_zombies()
+      end
     end
 
     describe '#kill_zombie_volumes', :wip do
@@ -634,8 +645,11 @@ module Beaker
         expect( Socket ).to receive(:gethostname) { "foobar" }
         expect( aws ).to receive(:local_user) { "bob" }
 
+        options[:timestamp] = Time.now
+        date_part = options[:timestamp].strftime("%F_%H_%M_%S")
+
         # Should match the expected composite key name
-        expect(aws.key_name).to eq("Beaker-bob-foobar")
+        expect(aws.key_name).to eq("Beaker-bob-foobar-#{date_part}")
       end
     end
 
@@ -647,18 +661,36 @@ module Beaker
     end
 
     describe '#ensure_key_pair' do
-      let( :region ) { double('region') }
+      let( :region ) { double('region', :name => 'test_region_name') }
       subject(:ensure_key_pair) { aws.ensure_key_pair(region) }
 
       context 'when a beaker keypair already exists' do
         it 'returns the keypair if available' do
           stub_const('ENV', ENV.to_hash.merge('USER' => 'rspec'))
-          key_pair = double(:exists? => true, :secret => 'supersekritkey')
+          key_pair = double(:exists? => true, :secret => 'supersekritkey', :delete => true)
+          allow( aws ).to receive( :key_name ).and_return( "Beaker-rspec-SUT" )
           key_pairs = { "Beaker-rspec-SUT" => key_pair }
 
-          expect( region ).to receive(:key_pairs).and_return(key_pairs).once
-          expect( Socket ).to receive(:gethostname).and_return("SUT")
+          expect( region ).to receive(:key_pairs).and_return(key_pairs).twice
+          expect( aws ).to receive( :public_key ).and_return('test_ssh_string')
+          expect( key_pairs ).to receive( :import ).and_return(key_pair)
           expect(ensure_key_pair).to eq(key_pair)
+        end
+
+        it 'generates a new keypair if :generate_new_keypair set' do
+          stub_const('ENV', ENV.to_hash.merge('USER' => 'rspec'))
+          key_pair = double(:exists? => true, :secret => 'keyOfSekritz', :delete => true)
+          allow( aws ).to receive( :key_name ).and_return( "Beaker-rspec-SUT" )
+          key_pairs = { "Beaker-rspec-SUT" => key_pair }
+          options[:keypair_generate_new] = true
+
+          answer = 'You get a keypair!  You get a keypair!  And you get a keypair too!'
+          expect( region ).to receive(:key_pairs).and_return(key_pairs).twice
+          expect( aws ).to receive( :public_key ).and_return('test_ssh_string')
+          expect( key_pairs ).to receive( :import ).and_return(answer)
+          returned_keypair = ensure_key_pair
+          expect(returned_keypair).not_to eq(key_pair)
+          expect(returned_keypair).to eq(answer)
         end
       end
 
@@ -670,8 +702,8 @@ module Beaker
 
         before :each do
           stub_const('ENV', ENV.to_hash.merge('USER' => 'rspec'))
-          expect( region ).to receive(:key_pairs).and_return(key_pairs).once
-          expect( Socket ).to receive(:gethostname).and_return("SUT")
+          expect( region ).to receive(:key_pairs).and_return(key_pairs).twice
+          allow( aws ).to receive( :key_name ).and_return(key_name)
         end
 
         it 'imports a new key based on user pubkey' do
@@ -685,6 +717,114 @@ module Beaker
           expect( key_pairs ).to receive(:import).and_return(key_pair).once
           expect(ensure_key_pair).to eq(key_pair)
         end
+      end
+    end
+
+    describe '#delete_key_pair_all_regions' do
+      it 'calls delete_key_pair over all regions' do
+        key_name = 'kname_test1538'
+        allow(aws).to receive( :key_name ).and_return(key_name)
+        regions = []
+        regions << double('region', :key_pairs => 'pair1', :name => 'name1')
+        regions << double('region', :key_pairs => 'pair2', :name => 'name2')
+        ec2_mock = Object.new
+        allow(ec2_mock).to receive( :regions ).and_return(regions)
+        aws.instance_variable_set( :@ec2, ec2_mock )
+        region_keypairs_hash_mock = {}
+        region_keypairs_hash_mock[double('region')] = ['key1', 'key2', 'key3']
+        region_keypairs_hash_mock[double('region')] = ['key4', 'key5', 'key6']
+        allow( aws ).to receive( :my_key_pairs ).and_return( region_keypairs_hash_mock )
+
+        region_keypairs_hash_mock.each_pair do |region, keyname_array|
+          keyname_array.each do |keyname|
+            expect( aws ).to receive( :delete_key_pair ).with( region, keyname )
+          end
+        end
+        aws.delete_key_pair_all_regions
+      end
+    end
+
+    describe '#my_key_pairs' do
+      let( :region ) { double('region', :name => 'test_region_name') }
+
+      it 'uses the default keyname if no filter is given' do
+        default_keyname_answer = 'test_pair_6193'
+        allow( aws ).to receive( :key_name ).and_return( default_keyname_answer )
+
+        kp_mock_1 = double('keypair')
+        kp_mock_2 = double('keypair')
+        regions = []
+        regions << double('region', :key_pairs => kp_mock_1, :name => 'name1')
+        regions << double('region', :key_pairs => kp_mock_2, :name => 'name2')
+        ec2_mock = Object.new
+        allow( ec2_mock ).to receive( :regions ).and_return( regions )
+        aws.instance_variable_set( :@ec2, ec2_mock )
+
+        kp_mock = double('keypair')
+        allow( region ).to receive( :key_pairs ).and_return( kp_mock )
+        expect( kp_mock_1 ).to receive( :filter ).with( 'key-name', default_keyname_answer ).and_return( [] )
+        expect( kp_mock_2 ).to receive( :filter ).with( 'key-name', default_keyname_answer ).and_return( [] )
+
+        aws.my_key_pairs()
+      end
+
+      it 'uses the filter passed if given' do
+        default_keyname_answer = 'test_pair_6194'
+        allow( aws ).to receive( :key_name ).and_return( default_keyname_answer )
+        name_filter = 'filter_pair_1597'
+        filter_star = "#{name_filter}-*"
+
+        kp_mock_1 = double('keypair')
+        kp_mock_2 = double('keypair')
+        regions = []
+        regions << double('region', :key_pairs => kp_mock_1, :name => 'name1')
+        regions << double('region', :key_pairs => kp_mock_2, :name => 'name2')
+        ec2_mock = Object.new
+        allow( ec2_mock ).to receive( :regions ).and_return( regions )
+        aws.instance_variable_set( :@ec2, ec2_mock )
+
+        kp_mock = double('keypair')
+        allow( region ).to receive( :key_pairs ).and_return( kp_mock )
+        expect( kp_mock_1 ).to receive( :filter ).with( 'key-name', filter_star ).and_return( [] )
+        expect( kp_mock_2 ).to receive( :filter ).with( 'key-name', filter_star ).and_return( [] )
+
+        aws.my_key_pairs(name_filter)
+      end
+    end
+
+    describe '#delete_key_pair' do
+      let( :region ) { double('region', :name => 'test_region_name') }
+
+      it 'calls delete on a keypair if it exists' do
+        pair_name = 'pair1'
+        kp_mock = double('keypair', :exists? => true)
+        expect( kp_mock ).to receive( :delete ).once
+        pairs = { pair_name => kp_mock }
+        allow( region ).to receive( :key_pairs ).and_return( pairs )
+        aws.delete_key_pair(region, pair_name)
+      end
+
+      it 'skips delete on a keypair if it does not exist' do
+        pair_name = 'pair1'
+        kp_mock = double('keypair', :exists? => false)
+        expect( kp_mock ).to receive( :delete ).never
+        pairs = { pair_name => kp_mock }
+        allow( region ).to receive( :key_pairs ).and_return( pairs )
+        aws.delete_key_pair(region, pair_name)
+      end
+    end
+
+    describe '#create_new_key_pair' do
+      let( :region ) { double('region', :name => 'test_region_name') }
+
+      it 'imports the key given from public_key' do
+        ssh_string = 'ssh_string_test_0867'
+        allow( aws ).to receive( :public_key ).and_return( ssh_string )
+        pairs = double('keypairs')
+        pair_name = 'pair_name_1555432'
+        expect( pairs ).to receive( :import ).with( pair_name, ssh_string )
+        expect( region ).to receive(:key_pairs).and_return(pairs).once
+        aws.create_new_key_pair( region, pair_name )
       end
     end
 


### PR DESCRIPTION
Before, ec2 keys would only be created if this was the first run for
a particular user/coordinator. This is a problem for F5 testing, in
which F5 hosts needed to be created with a particular key. We were
using cached keys, which weren't the ones being used in ec2.

The original solution was to delete the keys in ec2, so that they'd
be recreated as if this was the first run by a user. @justinstoller
brought up the good point that if this were to happen, certain
Beaker runs would have their keys deleted from a new F5 run. The
solution became that each Beaker run would generate its own key,
deleting it on cleanup.

/cc @LuvCurves 