### PR TITLE
(BKR-488) Add support for Windows 10 (x86, x64)

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -295,7 +295,7 @@ module Beaker
           if options[:expect_connection_failure] && result.exit_code
             # should have had a connection failure, but didn't
             # wait to see if the connection failure will be generation, otherwise raise error
-            if not connection.wait_for_connection_failure
+            if not connection.wait_for_connection_failure(options, output_callback)
               raise CommandFailure,  "Host '#{self}' should have resulted in a connection failure running:\n #{cmdline}\nLast #{@options[:trace_limit]} lines of output were:\n#{result.formatted_output(@options[:trace_limit])}"
             end
           end

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -2,7 +2,7 @@ module Windows::Exec
   include Beaker::CommandFactory
 
   def reboot
-    exec(Beaker::Command.new('shutdown /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :expect_connection_failure => true)
+    exec(Beaker::Command.new('shutdown /f /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :expect_connection_failure => true)
     # rebooting on windows is sloooooow
     # give it some breathing room before attempting a reconnect
     sleep(40)


### PR DESCRIPTION
- improve the 'wait_for_connection_failure' ssh connection method
  * increase the timeouts
  * send actual data down the pipe, seems to improve the function of
    the test
- add /f to the windows reboot call
  * forces closure of any open applications