### PR TITLE
(BKR-327) Add support for EL7 to epel_info_for and add_el_extras method

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -173,7 +173,7 @@ module Beaker
       url = "#{host[:epel_url] || opts[:epel_url]}/#{version}"
       if version == '7'
         if opts[:epel_7_arch] == 'i386'
-          raise "epel-7 does not provide packages for i386"
+          raise ArgumentError.new("epel-7 does not provide packages for i386")
         end
         pkg = host[:epel_pkg] || opts[:epel_7_pkg]
         arch = opts[:epel_7_arch] || 'x86_64'
@@ -184,7 +184,7 @@ module Beaker
         pkg = host[:epel_pkg] || opts[:epel_5_pkg]
         arch = host[:epel_arch] || opts[:epel_5_arch] || 'i386'
       else
-        raise "epel_info_for does not support el version #{version}, on #{host.name}"
+        raise ArgumentError.new("epel_info_for does not support el version #{version}, on #{host.name}")
       end
       return url, arch, pkg
     end

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -165,6 +165,7 @@ module Beaker
           :add_el_extras          => false,
           :epel_url               => "http://mirrors.kernel.org/fedora-epel",
           :epel_arch              => "i386",
+          :epel_7_pkg             => "epel-release-7-5.noarch.rpm",
           :epel_6_pkg             => "epel-release-6-8.noarch.rpm",
           :epel_5_pkg             => "epel-release-5-4.noarch.rpm",
           :consoleport            => 443,

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -154,6 +154,12 @@ describe Beaker do
   context "epel_info_for!" do
     subject { dummy_class.new }
 
+    it "can return the correct url for an el-7 host" do
+      host = make_host( 'testhost', { :platform => Beaker::Platform.new('el-7-platform') } )
+
+      expect( subject.epel_info_for( host, options )).to be === ["http://mirrors.kernel.org/fedora-epel/7", "x86_64", "epel-release-7-5.noarch.rpm"]
+    end
+
     it "can return the correct url for an el-6 host" do
       host = make_host( 'testhost', { :platform => Beaker::Platform.new('el-6-platform') } )
 

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -176,7 +176,7 @@ describe Beaker do
     it "raises an error on non el-5/6 host" do
       host = make_host( 'testhost', { :platform => Beaker::Platform.new('el-4-platform') } )
 
-      expect{ subject.epel_info_for( host, options )}.to raise_error(RuntimeError, /epel_info_for does not support el version/)
+      expect{ subject.epel_info_for( host, options )}.to raise_error(ArgumentError, /epel_info_for does not support el version/)
 
     end
 


### PR DESCRIPTION
Some new code to hopefully pass tests. Adds support for epel7 in epel_info_for and add_el_extras, as wel as adding a test for el7 url retrieval.