### PR TITLE
(BKR-380) Fix '3389' (host port) is declared multiple times

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -36,7 +36,7 @@ module Beaker
         v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\", :mac => \"#{randmac}\"\n"
 
         if /windows/i.match(host['platform'])
-          v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389\n"
+          v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"
           v_file << "    v.vm.guest = :windows\n"
         end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -100,7 +100,7 @@ EOF
 
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
 
-      match = generated_file.match(/v.vm.network :forwarded_port, guest: 3389, host: 3389/)
+      match = generated_file.match(/v.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true/)
       expect( match ).to_not be_nil,'Should have proper port for RDP'
 
       match = generated_file.match(/v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true/)


### PR DESCRIPTION
(BKR-380) beaker vagrant windows box support issues

Without "auto_correct" we got error if source Vagrantfile of box already contains this port forwarding.

```
Error:
vm:
* Forwarded port '3389' (host port) is declared multiple times
with the protocol 'tcp'.
```

I think we need add this change as most part of Windows boxes in Vagrant Atlas already have this port forwarding:
- https://github.com/joefitzgerald/packer-windows/blob/master/vagrantfile-windows_2012_r2.template
- https://github.com/boxcutter/windows/blob/master/tpl/vagrantfile-eval-win2012r2-standard.tpl