### PR TITLE
(BKR-564) beaker no longer works on ruby 1.9.3

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'google-api-client', '~> 0.8'
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
+  s.add_runtime_dependency 'fog-google', '~> 0.0.9' # dropped ruby 1.9 support in 0.1
   s.add_runtime_dependency 'fog', '~> 1.25'
 
   # So fog doesn't always complain of unmet AWS dependencies


### PR DESCRIPTION
- pin fog-google to 0.0.9, 0.1 release removed ruby 1.9 support