### PR TITLE
(BKR-275) PowerShell Wrapper Does not Handle Quoting

### DIFF
--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -265,6 +265,25 @@ module Beaker
           end
         end
 
+        # Execute a powershell script from file, remote file created from provided string
+        # @note This method uses Tempfile in Ruby's STDLIB as well as {#create_remote_file}.
+        #
+        # @param [Host] hosts One or more hosts (or some object
+        #                                 that responds like
+        #                                 {Beaker::Host#do_scp_from}.
+        # @param [String] powershell_script A string describing a set of powershell actions
+        #
+        # @return [Result] Returns the result of the powershell command execution
+        def execute_powershell_script_on(hosts, powershell_script, opts = {})
+          block_on hosts do |host|
+            script_path = "beaker_powershell_script_#{Time.now.to_i}.ps1"
+            create_remote_file(host, script_path, powershell_script, opts)
+            native_path = script_path.gsub(/\//, "\\")
+            on host, powershell("", {"File" => native_path }), opts
+          end
+
+        end
+
         # Move a local script to a remote host and execute it
         # @note this relies on {#on} and {#scp_to}
         #

--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -1,3 +1,4 @@
+require 'base64'
 module Beaker
   module DSL
     # These are wrappers to equivalent {Beaker::Command} objects
@@ -107,13 +108,19 @@ module Beaker
       # Returns a {Beaker::Command} object for executing powershell commands on a host
       #
       # @param [String]   command   The powershell command to execute
-      # @param [Hash]     args      The commandline paramaeters to be passed to powershell
+      # @param [Hash]     args      The commandline parameters to be passed to powershell
       #
       # @example Setting the contents of a file
       #     powershell("Set-Content -path 'fu.txt' -value 'fu'")
       #
       # @example Using an alternative execution policy
       #     powershell("Set-Content -path 'fu.txt' -value 'fu'", {'ExecutionPolicy' => 'Unrestricted'})
+      #
+      # @example Using an EncodedCommand (defaults to non-encoded)
+      #     powershell("Set Content -path 'fu.txt', -value 'fu'", {'EncodedCommand => true})
+      #
+      # @example executing from a file
+      #     powershell("", {'-File' => '/path/to/file'})
       #
       # @return [Command]
       def powershell(command, args={})
@@ -124,19 +131,47 @@ module Beaker
           'NoProfile'       => '',
           'NonInteractive'  => ''
         }
+        encoded = false
         ps_opts.merge!(args)
         ps_args = []
         ps_opts.each do |k, v|
           if v.eql?('') or v.nil?
             ps_args << "-#{k}"
+          elsif k.eql?('EncodedCommand') && v
+            encoded = true
           else
             ps_args << "-#{k} #{v}"
           end
         end
-        ps_args << "-Command #{command}"
+
+        # may not have a command if executing a file
+        if command && !command.empty?
+          if encoded
+            ps_args << "-EncodedCommand #{encode_command(command)}"
+          else
+            ps_args << "-Command #{command}"
+          end
+        end
 
         Command.new("powershell.exe", ps_args)
       end
+
+      # Convert the provided command string to Base64
+      # @param [String] cmd The command to convert to Base64
+      # @return [String] The converted string
+      # @api private
+      def encode_command(cmd)
+        cmd = cmd.chars.to_a.join("\x00").chomp
+        cmd << "\x00" unless cmd[-1].eql? "\x00"
+        if(defined?(cmd.encode))
+          cmd = cmd.encode('ASCII-8BIT')
+          cmd = Base64.strict_encode64(cmd)
+        else
+          cmd = Base64.encode64(cmd).chomp
+        end
+        cmd
+      end
+
     end
   end
 end

--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -134,11 +134,17 @@ module Beaker
         encoded = false
         ps_opts.merge!(args)
         ps_args = []
+
+        # determine if the command should be encoded
+        if ps_opts.has_key?('EncodedCommand')
+          v = ps_opts.delete('EncodedCommand')
+          # encode the commend if v is true, nil or empty
+          encoded = v || v.eql?('') || v.nil?
+        end
+
         ps_opts.each do |k, v|
           if v.eql?('') or v.nil?
             ps_args << "-#{k}"
-          elsif k.eql?('EncodedCommand') && v
-            encoded = true
           else
             ps_args << "-#{k} #{v}"
           end
@@ -163,12 +169,8 @@ module Beaker
       def encode_command(cmd)
         cmd = cmd.chars.to_a.join("\x00").chomp
         cmd << "\x00" unless cmd[-1].eql? "\x00"
-        if(defined?(cmd.encode))
-          cmd = cmd.encode('ASCII-8BIT')
-          cmd = Base64.strict_encode64(cmd)
-        else
-          cmd = Base64.encode64(cmd).chomp
-        end
+        # use strict_encode because linefeeds are not correctly handled in our model
+        cmd = Base64.strict_encode64(cmd).chomp
         cmd
       end
 

--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -129,7 +129,7 @@ module PSWindows::Exec
     else
       val = val.split(/\n/)[0] # only take the first result
       if clean
-        val.gsub(/#{key}=/,'')
+        val.gsub(/#{key}=/i,'')
       else
         val
       end

--- a/spec/beaker/dsl/wrappers_spec.rb
+++ b/spec/beaker/dsl/wrappers_spec.rb
@@ -72,5 +72,54 @@ describe ClassMixedWithDSLWrappers do
       expect( command.args ).to be === ["-ExecutionPolicy Unrestricted", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command Set-Content -path 'fu.txt' -value 'fu'"]
       expect( command.options ).to be === {}
     end
+
+    it 'should use EncodedCommand when EncodedCommand => true' do
+      cmd = "Set-Content -path 'fu.txt' -value 'fu'"
+      cmd = subject.encode_command(cmd)
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'EncodedCommand' => true})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand #{cmd}"]
+      expect( command.options ).to be === {}
+    end
+
+    it 'should use EncodedCommand when EncodedCommand => ""' do
+      cmd = "Set-Content -path 'fu.txt' -value 'fu'"
+      cmd = subject.encode_command(cmd)
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'EncodedCommand' => ""})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand #{cmd}"]
+      expect( command.options ).to be === {}
+    end
+
+    it 'should use EncodedCommand when EncodedCommand => nil' do
+      cmd = "Set-Content -path 'fu.txt' -value 'fu'"
+      cmd = subject.encode_command(cmd)
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'EncodedCommand' => nil})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand #{cmd}"]
+      expect( command.options ).to be === {}
+    end
+
+    it 'should not use EncodedCommand when EncodedCommand => false' do
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {'EncodedCommand' => false})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command Set-Content -path 'fu.txt' -value 'fu'"]
+      expect( command.options ).to be === {}
+    end
+
+    it 'should not use EncodedCommand when EncodedCommand not present' do
+      command = subject.powershell("Set-Content -path 'fu.txt' -value 'fu'", {})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command Set-Content -path 'fu.txt' -value 'fu'"]
+      expect( command.options ).to be === {}
+    end
+
+    it 'has no -Command/-EncodedCommand when command is empty' do
+      command = subject.powershell("", {"File" => 'myfile.ps1'})
+      expect(command.command ).to be === 'powershell.exe'
+      expect( command.args).to be ===  ["-ExecutionPolicy Bypass", "-InputFormat None", "-NoLogo", "-NoProfile", "-NonInteractive", "-File myfile.ps1"]
+      expect( command.options ).to be === {}
+
+    end
   end
 end


### PR DESCRIPTION
- create new powershell dsl helper:
  execute_powershell_script
  * takes as input a string representing a powershell script
  * create a file on the host containing the script
  * executes the script using powershell -File