### PR TITLE
(BKR-573) Add remove_puppet_on

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1389,6 +1389,55 @@ NOASK
           create_remote_file(host, "C:\\Windows\\Temp\\#{cert_name}.pem", cert)
           on host, "certutil -v -addstore Root C:\\Windows\\Temp\\#{cert_name}.pem"
         end
+
+        # Ensures Puppet and dependencies are no longer installed on host(s).
+        #
+        # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
+        #                            or a role (String or Symbol) that identifies one or more hosts.
+        #
+        # @return nil
+        # @api public
+        def remove_puppet_on( hosts )
+          block_on hosts do |host|
+            cmdline_args = ''
+            # query packages
+            case host[:platform]
+            when /aix/
+              pkgs = on(host, "rpm -qa  | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
+              pkgs.concat on(host, "rpm -q tar", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
+            when /solaris-10/
+              cmdline_args = '-a noask'
+              pkgs = on(host, "pkginfo | egrep '(^pe-|puppet)' | cut -f2 -d ' '", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
+            when /solaris-11/
+              pkgs = on(host, "pkg list | egrep '(^pe-|puppet)' | awk '{print $1}'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
+            else
+              raise "remove_puppet_on() called for unsupported " +
+                    "platform '#{host['platform']}' on '#{host.name}'"
+            end
+
+            # uninstall packages
+            host.uninstall_package(pkgs.join(' '), cmdline_args) if pkgs.length > 0
+
+            # delete any residual files
+            on(host, 'find / -name "*puppet*" -print | xargs rm -rf')
+
+            if host[:platform] =~ /solaris-11/ then
+              # FIXME: This leaves things in a state where Puppet Enterprise (3.x) cannot be cleanly installed
+              #        but is required to put things in a state that puppet-agent can be installed
+              # extra magic for expunging left over publisher
+              if on(host, "pkg publisher puppetlabs.com", :acceptable_exit_codes => [0,1]).exit_code == 0 then
+                # First, try to remove the publisher altogether
+                if on(host, "pkg unset-publisher puppetlabs.com", :acceptable_exit_codes => [0,1]).exit_code == 1 then
+                  # If that doesn't work, we're in a non-global zone and the
+                  # publisher is from a global zone. As such, just remove any
+                  # references to the non-global zone uri.
+                  on(host, "pkg set-publisher -G '*' puppetlabs.com", :acceptable_exit_codes => [0,1])
+                end
+              end
+            end
+
+          end
+        end
       end
     end
   end

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -135,7 +135,9 @@ module Unix::Pkg
       when /solaris-11/
         execute("pkg #{cmdline_args} uninstall #{name}", opts)
       when /solaris-10/
-        execute("pkgutil -r -y #{cmdline_args} #{name}", opts)
+        execute("pkgrm -n #{cmdline_args} #{name}", opts)
+      when /aix/
+        execute("rpm #{cmdline_args} -e #{name}", opts)
       else
         raise "Package #{name} cannot be installed on #{self}"
     end

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -1179,4 +1179,61 @@ describe ClassMixedWithDSLInstallUtils do
     end
 
   end
+
+  describe '#remove_puppet_on' do
+    let(:aixhost) { make_host('aix', :platform => 'aix-53-power') }
+    let(:sol10host) { make_host('sol10', :platform => 'solaris-10-x86_64') }
+    let(:sol11host) { make_host('sol11', :platform => 'solaris-11-x86_64') }
+    let(:el6host) { make_host('el6', :platform => 'el-6-x64') }
+
+    pkg_list = 'foo bar'
+
+    it 'uninstalls packages on aix, including tar' do
+      aix_depend_list = 'tar'
+      result = Beaker::Result.new(aixhost,'')
+      result.stdout = pkg_list
+      result2 = Beaker::Result.new(aixhost,'')
+      result2.stdout = aix_depend_list
+
+      expected_list = pkg_list + " " + aix_depend_list
+      cmd_args = ''
+
+      expect( subject ).to receive(:on).exactly(3).times.and_return(result, result2, result)
+      expect( aixhost ).to receive(:uninstall_package).with(expected_list, cmd_args)
+
+      subject.remove_puppet_on( aixhost )
+    end
+
+    it 'uninstalls packages on solaris 10' do
+      result = Beaker::Result.new(sol10host,'')
+      result.stdout = pkg_list
+
+      expected_list = pkg_list
+      cmd_args = '-a noask'
+
+      expect( subject ).to receive(:on).exactly(2).times.and_return(result, result)
+      expect( sol10host ).to receive(:uninstall_package).with(expected_list, cmd_args)
+
+      subject.remove_puppet_on( sol10host  )
+    end
+
+    it 'uninstalls packages on solaris 11' do
+      result = Beaker::Result.new(sol11host,'')
+      result.stdout='foo bar'
+
+      expected_list = pkg_list
+      cmd_args = ''
+
+      expect( subject ).to receive(:on).exactly(3).times.and_return(result, result, result)
+      expect( sol11host ).to receive(:uninstall_package).with(expected_list, cmd_args)
+
+      subject.remove_puppet_on( sol11host  )
+    end
+
+    it 'raises error on other platforms' do
+      expect { subject.remove_puppet_on( el6host ) }.to raise_error(RuntimeError, /unsupported platform/)
+    end
+
+  end
+
 end


### PR DESCRIPTION
This commit adds a `remove_puppet_on` method that can be used to
ensure that puppet packages have been expunged from hosts.

This method is intended to be used in a pre-suite. It is currently
limited to the AIX and Solaris platforms.