### PR TITLE
(QENG-2604) Add Host Tags

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -499,6 +499,9 @@ module Beaker
         @logger.notify("aws-sdk: Add tags for #{host.name}")
         instance.add_tag("jenkins_build_url", :value => @options[:jenkins_build_url])
         instance.add_tag("Name", :value => host.name)
+        instance.add_tag("department", :value => @options[:department])
+        instance.add_tag("project", :value => @options[:project])
+        instance.add_tag("created_by", :value => @options[:created_by])
 
         host[:host_tags].each do |name, val|
           instance.add_tag(name.to_s, :value => val)

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -499,9 +499,10 @@ module Beaker
         @logger.notify("aws-sdk: Add tags for #{host.name}")
         instance.add_tag("jenkins_build_url", :value => @options[:jenkins_build_url])
         instance.add_tag("Name", :value => host.name)
-        instance.add_tag("department", :value => @options[:department])
-        instance.add_tag("project", :value => @options[:project])
-        instance.add_tag("created_by", :value => @options[:created_by])
+
+        host[:host_tags].each do |name, val|
+          instance.add_tag(name.to_s, :value => val)
+        end
       end
 
       nil

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -145,7 +145,10 @@ module Beaker
 
       tags = {
         'beaker_version' => Beaker::Version::STRING,
-        'jenkins_build_url' => @options[:jenkins_build_url]
+        'jenkins_build_url' => @options[:jenkins_build_url],
+        'department' => @options[:department],
+        'project' => @options[:project],
+        'created_by' => @options[:created_by]
       }
 
       @hosts.each_with_index do |h, i|

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -145,10 +145,7 @@ module Beaker
 
       tags = {
         'beaker_version' => Beaker::Version::STRING,
-        'jenkins_build_url' => @options[:jenkins_build_url],
-        'department' => @options[:department],
-        'project' => @options[:project],
-        'created_by' => @options[:created_by]
+        'jenkins_build_url' => @options[:jenkins_build_url]
       }
 
       @hosts.each_with_index do |h, i|
@@ -158,7 +155,10 @@ module Beaker
           http = Net::HTTP.new(uri.host, uri.port)
           request = Net::HTTP::Put.new(uri.request_uri)
 
-          request.body = { 'tags' => tags }.to_json
+          # merge above tags with host-specific tags
+          host_tags = h[:host_tags].merge(tags)
+
+          request.body = { 'tags' => host_tags }.to_json
 
           response = http.request(request)
         rescue RuntimeError, Errno::EINVAL, Errno::ECONNRESET, EOFError,

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -73,6 +73,20 @@ module Beaker
       template_url
     end
 
+    # Override host tags with presets
+    # @param [Beaker::Host] host Beaker host
+    # @return [Hash] Tag hash
+    def add_tags(host)
+      host[:host_tags].merge(
+          {
+              'beaker_version'    => Beaker::Version::STRING,
+              'jenkins_build_url' => @options[:jenkins_build_url],
+              'department'        => @options[:department],
+              'project'           => @options[:project],
+              'created_by'        => @options[:created_by]
+          })
+    end
+
     def provision
       request_payload = {}
       start = Time.now
@@ -143,14 +157,6 @@ module Beaker
       start = Time.now
       @logger.notify 'Tagging vmpooler VMs'
 
-      tags = {
-        'beaker_version' => Beaker::Version::STRING,
-        'jenkins_build_url' => @options[:jenkins_build_url],
-        'department' => @options[:department],
-        'project' => @options[:project],
-        'created_by' => @options[:created_by]
-      }
-
       @hosts.each_with_index do |h, i|
         begin
           uri = URI.parse(@options[:pooling_api] + '/vm/' + h['vmhostname'].split('.')[0])
@@ -158,10 +164,8 @@ module Beaker
           http = Net::HTTP.new(uri.host, uri.port)
           request = Net::HTTP::Put.new(uri.request_uri)
 
-          # merge above tags with host-specific tags
-          host_tags = h[:host_tags].merge(tags)
-
-          request.body = { 'tags' => host_tags }.to_json
+          # merge pre-defined tags with host tags
+          request.body = { 'tags' => add_tags(h) }.to_json
 
           response = http.request(request)
         rescue RuntimeError, Errno::EINVAL, Errno::ECONNRESET, EOFError,

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -325,6 +325,14 @@ module Beaker
           if host[:platform] =~ /windows|el-4/
             test_host_roles(name, host)
           end
+
+          #check to see if a custom user account has been provided, if so use it
+          if host[:ssh] && host[:ssh][:user]
+            host[:user] = host[:ssh][:user]
+          end
+
+          # merge host tags for this host with the global/preset host tags
+          host[:host_tags] = @options[:host_tags].merge(host[:host_tags] || {})
         end
 
         normalize_and_validate_tags()
@@ -332,14 +340,6 @@ module Beaker
 
         #set the default role
         set_default_host!(@options[:HOSTS])
-
-        #check to see if a custom user account has been provided, if so use it
-        @options[:HOSTS].each_key do |name|
-          host = @options[:HOSTS][name]
-          if host[:ssh] && host[:ssh][:user]
-            host[:user] = host[:ssh][:user]
-          end
-        end
 
       end
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -121,11 +121,7 @@ module Beaker
           :project                => 'Beaker',
           :department             => 'unknown',
           :created_by             => ENV['USER'] || ENV['USERNAME'] || 'unknown',
-          :host_tags              => {
-                                      :project    => 'Beaker',
-                                      :department => 'unknown',
-                                      :created_by => ENV['USER'] || ENV['USERNAME'] || 'unknown'
-          },
+          :host_tags              => {},
           :openstack_api_key      => ENV['OS_PASSWORD'],
           :openstack_username     => ENV['OS_USERNAME'],
           :openstack_auth_url     => "#{ENV['OS_AUTH_URL']}/tokens",

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -121,6 +121,11 @@ module Beaker
           :project                => 'Beaker',
           :department             => 'unknown',
           :created_by             => ENV['USER'] || ENV['USERNAME'] || 'unknown',
+          :host_tags              => {
+                                      :project    => 'Beaker',
+                                      :department => 'unknown',
+                                      :created_by => ENV['USER'] || ENV['USERNAME'] || 'unknown'
+          },
           :openstack_api_key      => ENV['OS_PASSWORD'],
           :openstack_username     => ENV['OS_USERNAME'],
           :openstack_auth_url     => "#{ENV['OS_AUTH_URL']}/tokens",

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -385,7 +385,14 @@ module Beaker
 
       context 'with multiple hosts' do
         before :each do
-          @hosts.each {|host| host['instance'] = aws_instance}
+          @hosts.each do |host|
+            host[:host_tags] = {
+                :department => 'my_department',
+                :project    => 'my_project',
+                :created_by => 'my_created_by'
+            }
+            host['instance'] = aws_instance
+          end
         end
 
         it 'adds tag for jenkins_build_url' do
@@ -400,19 +407,16 @@ module Beaker
         end
 
         it 'adds tag for department' do
-          aws.instance_eval('@options[:department] = "my_department"')
           expect(aws_instance).to receive(:add_tag).with('department', hash_including(:value => 'my_department')).at_least(:once)
           expect(add_tags).to be_nil
         end
 
         it 'adds tag for project' do
-          aws.instance_eval('@options[:project] = "my_project"')
           expect(aws_instance).to receive(:add_tag).with('project', hash_including(:value => 'my_project')).at_least(:once)
           expect(add_tags).to be_nil
         end
 
         it 'adds tag for created_by' do
-          aws.instance_eval('@options[:created_by] = "my_created_by"')
           expect(aws_instance).to receive(:add_tag).with('created_by', hash_including(:value => 'my_created_by')).at_least(:once)
           expect(add_tags).to be_nil
         end

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -385,14 +385,7 @@ module Beaker
 
       context 'with multiple hosts' do
         before :each do
-          @hosts.each do |host|
-            host[:host_tags] = {
-                :department => 'my_department',
-                :project    => 'my_project',
-                :created_by => 'my_created_by'
-            }
-            host['instance'] = aws_instance
-          end
+          @hosts.each {|host| host['instance'] = aws_instance}
         end
 
         it 'adds tag for jenkins_build_url' do
@@ -407,16 +400,19 @@ module Beaker
         end
 
         it 'adds tag for department' do
+          aws.instance_eval('@options[:department] = "my_department"')
           expect(aws_instance).to receive(:add_tag).with('department', hash_including(:value => 'my_department')).at_least(:once)
           expect(add_tags).to be_nil
         end
 
         it 'adds tag for project' do
+          aws.instance_eval('@options[:project] = "my_project"')
           expect(aws_instance).to receive(:add_tag).with('project', hash_including(:value => 'my_project')).at_least(:once)
           expect(add_tags).to be_nil
         end
 
         it 'adds tag for created_by' do
+          aws.instance_eval('@options[:created_by] = "my_created_by"')
           expect(aws_instance).to receive(:add_tag).with('created_by', hash_including(:value => 'my_created_by')).at_least(:once)
           expect(add_tags).to be_nil
         end

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -388,6 +388,15 @@ module Beaker
           @hosts.each {|host| host['instance'] = aws_instance}
         end
 
+        it 'handles host_tags hash on host object' do
+          # set :host_tags on first host
+          aws.instance_eval {
+            @hosts[0][:host_tags] =  {'test_tag' => 'test_value'}
+          }
+          expect(aws_instance).to receive(:add_tag).with('test_tag', hash_including(:value => 'test_value')).at_least(:once)
+          expect(add_tags).to be_nil
+        end
+
         it 'adds tag for jenkins_build_url' do
           aws.instance_eval('@options[:jenkins_build_url] = "my_build_url"')
           expect(aws_instance).to receive(:add_tag).with('jenkins_build_url', hash_including(:value => 'my_build_url')).at_least(:once)

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -42,6 +42,23 @@ module Beaker
       end
     end
 
+    describe '#add_tags' do
+      let(:vmpooler) { Beaker::Vmpooler.new(make_hosts({:host_tags => {'test_tag' => 'test_value'}}), make_opts) }
+
+      it 'merges tags correctly' do
+        host          = vmpooler.instance_variable_get(:@hosts)[0]
+        merged_tags   = vmpooler.add_tags(host)
+        expected_hash = {
+            test_tag:          'test_value',
+            beaker_version:    Beaker::Version::STRING,
+            project:           'Beaker',
+            jenkins_build_url: nil,
+            created_by:        be_a(String)
+        }
+        expect(merged_tags).to include(expected_hash)
+      end
+    end
+
     describe "#provision" do
 
       it 'provisions hosts from the pool' do

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -46,15 +46,15 @@ module Beaker
       let(:vmpooler) { Beaker::Vmpooler.new(make_hosts({:host_tags => {'test_tag' => 'test_value'}}), make_opts) }
 
       it 'merges tags correctly' do
+        vmpooler.instance_eval {
+          @options = @options.merge({:project => 'vmpooler-spec'})
+        }
         host          = vmpooler.instance_variable_get(:@hosts)[0]
         merged_tags   = vmpooler.add_tags(host)
-        presets       = Beaker::Options::Presets.new.presets
         expected_hash = {
-            test_tag:          'test_value',
-            beaker_version:    Beaker::Version::STRING,
-            project:           presets[:project],
-            jenkins_build_url: presets[:jenkins_build_url],
-            created_by:        presets[:created_by]
+            test_tag:       'test_value',
+            beaker_version: Beaker::Version::STRING,
+            project:        'vmpooler-spec'
         }
         expect(merged_tags).to include(expected_hash)
       end

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -48,12 +48,13 @@ module Beaker
       it 'merges tags correctly' do
         host          = vmpooler.instance_variable_get(:@hosts)[0]
         merged_tags   = vmpooler.add_tags(host)
+        presets       = Beaker::Options::Presets.new.presets
         expected_hash = {
             test_tag:          'test_value',
             beaker_version:    Beaker::Version::STRING,
-            project:           'Beaker',
-            jenkins_build_url: nil,
-            created_by:        be_a(String)
+            project:           presets[:project],
+            jenkins_build_url: presets[:jenkins_build_url],
+            created_by:        presets[:created_by]
         }
         expect(merged_tags).to include(expected_hash)
       end

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -292,6 +292,7 @@ module Beaker
             },
             'fail_mode' => 'slow',
             'preserve_hosts' => 'always',
+            'host_tags' => {}
           })
         end
 

--- a/spec/beaker/options/presets_spec.rb
+++ b/spec/beaker/options/presets_spec.rb
@@ -27,6 +27,11 @@ module Beaker
         expect(presets.presets).to be_instance_of(Beaker::Options::OptionsHash)
       end
 
+      it 'has empty host_tags' do
+        expect(presets.presets.has_key?(:host_tags)).to be_truthy
+        expect(presets.presets[:host_tags]).to eq({})
+      end
+
     end
   end
 end


### PR DESCRIPTION
This commit adds the ability to specify arbitrary tags and have them applied to AWS or vmpooler instances. The configuration parameter is called "host_tags" to avoid confusion with test tagging. Host tags can be specified at the host or CONFIG level.

The presets have been modified to pre-populate "host_tags" with: project, department, and created_by.

Example:
```
HOSTS:
  'agent1':
    roles:
      - agent
    host_tags:
      created_by: 'me'
      some_key: 'yes it is'
CONFIG:
    host_tags:
      project: 'beaker'
```