### PR TITLE
(BKR-576) scp_to does not handle dotfiles

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -2,6 +2,7 @@ require 'socket'
 require 'timeout'
 require 'benchmark'
 require 'rsync'
+require 'find'
 
 [ 'command', 'ssh_connection'].each do |lib|
   require "beaker/#{lib}"
@@ -363,8 +364,9 @@ module Beaker
           @logger.trace result.stdout
         end
       else # a directory with ignores
-        dir_source = Dir.glob("#{source}/**/*").reject do |f|
-          f.gsub(/\A#{Regexp.escape(source)}/, '') =~ ignore_re #only match against subdirs, not full path
+        dir_source = Find.find(source).reject do |f|
+          #only match against subdirs, not full path
+          File.directory?(f) or f.gsub(/\A#{Regexp.escape(source)}/, '') =~ ignore_re
         end
         @logger.trace "After rejecting ignored files/dirs, going to scp [#{dir_source.join(", ")}]"
 


### PR DESCRIPTION
Use find instead of shell glob to obtain a listing of the FILES within a directory structure.  We must exclude empty directories to prevent attempting to SCP them (this will also cause test failures).  This code now supports dotfiles and files within hidden dotfile directories, eg `.git`