### PR TITLE
(BKR-571) updated documentation on return types

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -382,6 +382,8 @@ module Beaker
         #                      by the caller; this can be used for additional
         #                      validation, etc.
         #
+        # @return [Array<Result>, Result] An array of results, or a result object.
+        #   Check {#run_block_on} for more details on this.
         def apply_manifest_on(host, manifest, opts = {}, &block)
           block_on host do | host |
             on_options = {}

--- a/lib/beaker/dsl/patterns.rb
+++ b/lib/beaker/dsl/patterns.rb
@@ -11,13 +11,16 @@ module Beaker
     #
     module Patterns
 
-      #Execute a block selecting the hosts that match with the provided criteria
-      #@param [Array<Host>, Host, String, Symbol] hosts_or_filter A host role as a String or Symbol that can be
+      # Execute a block selecting the hosts that match with the provided criteria
+      # @param [Array<Host>, Host, String, Symbol] hosts_or_filter A host role as a String or Symbol that can be
       #                                                used to search for a set of Hosts,  a host name
       #                                                as a String that can be used to search for
       #                                                a set of Hosts, or a {Host}
       #                                                or Array<{Host}> to run the block against
-      #@param [Block] block This method will yield to a block of code passed by the caller
+      # @param [Block] block This method will yield to a block of code passed by the caller
+      #
+      # @return [Array<Result>, Result] An array of results, or a result object.
+      #   Check {#run_block_on} for more details on this.
       def block_on hosts_or_filter, &block
         block_hosts = nil
         if defined? hosts

--- a/lib/beaker/shared/host_manager.rb
+++ b/lib/beaker/shared/host_manager.rb
@@ -68,10 +68,17 @@ module Beaker
         host_with_role
       end
 
-      #Execute a block selecting the hosts that match with the provided criteria
-      #@param [Array<Host>, Host] hosts The host or hosts to run the provided block against
-      #@param [String, Symbol] filter Optional filter to apply to provided hosts - limits by name or role
-      #@param [Block] block This method will yield to a block of code passed by the caller
+      # Execute a block selecting the hosts that match with the provided criteria
+      #
+      # @param [Array<Host>, Host] hosts The host or hosts to run the provided block against
+      # @param [String, Symbol] filter Optional filter to apply to provided hosts - limits by name or role
+      # @param [Block] block This method will yield to a block of code passed by the caller
+      #
+      # @todo beaker3.0: simplify return types to Array<Result> only
+      #
+      # @return [Array<Result>, Result] If a non-empty array of hosts has been
+      #   passed (after filtering), then an array of results is returned. Else,
+      #   a result object is returned.
       def run_block_on hosts = [], filter = nil, &block
         result = nil
         block_hosts = hosts #the hosts to apply the block to after any filtering


### PR DESCRIPTION
tried in #978 to update to a simple array of results in `apply_manifest_on`, but that breaks compatibility with current uses (check there for more details).

Since that's the case, I've updated the docs appropriately for current usage, & added a note for update during Beaker 3.0 changes later.