### PR TITLE
(BKR-579) rpm calls to respect package_proxy opt

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -861,11 +861,10 @@ module Beaker
             case variant
             when /^(fedora|el|centos)$/
               variant = (($1 == 'centos') ? 'el' : $1)
+              remote = "%s/puppetlabs-release%s-%s-%s.noarch.rpm" % [opts[:release_yum_repo_url],
+		                                                       repo_name, variant, version]
 
-              rpm = "puppetlabs-release%s-%s-%s.noarch.rpm" % [repo_name, variant, version]
-              remote = URI.join( opts[:release_yum_repo_url], rpm )
-
-              on host, "rpm --replacepkgs -ivh #{remote}"
+	      host.install_package_with_rpm(remote, '--replacepkgs', {:package_proxy => opts[:package_proxy]})
 
             when /^(debian|ubuntu|cumulus)$/
               deb = "puppetlabs-release%s-%s.deb" % [repo_name, codename]

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -396,7 +396,7 @@ describe ClassMixedWithDSLInstallUtils do
     context 'on el-6' do
       let(:platform) { Beaker::Platform.new('el-6-i386') }
       it 'installs' do
-        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-el-6\.noarch\.rpm/)
+        expect(hosts[0]).to receive(:install_package_with_rpm).with(/puppetlabs-release-el-6\.noarch\.rpm/, '--replacepkgs', {:package_proxy=>false})
         expect(hosts[0]).to receive(:install_package).with('puppet')
         subject.install_puppet
       end
@@ -414,7 +414,7 @@ describe ClassMixedWithDSLInstallUtils do
     context 'on el-5' do
       let(:platform) { Beaker::Platform.new('el-5-i386') }
       it 'installs' do
-        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-el-5\.noarch\.rpm/)
+        expect(hosts[0]).to receive(:install_package_with_rpm).with(/puppetlabs-release-el-5\.noarch\.rpm/, '--replacepkgs', {:package_proxy=>false})
         expect(hosts[0]).to receive(:install_package).with('puppet')
         subject.install_puppet
       end
@@ -422,7 +422,7 @@ describe ClassMixedWithDSLInstallUtils do
     context 'on fedora' do
       let(:platform) { Beaker::Platform.new('fedora-18-x86_84') }
       it 'installs' do
-        expect(subject).to receive(:on).with(hosts[0], /puppetlabs-release-fedora-18\.noarch\.rpm/)
+        expect(hosts[0]).to receive(:install_package_with_rpm).with(/puppetlabs-release-fedora-18\.noarch\.rpm/, '--replacepkgs', {:package_proxy=>false})
         expect(hosts[0]).to receive(:install_package).with('puppet')
         subject.install_puppet
       end
@@ -580,16 +580,6 @@ describe ClassMixedWithDSLInstallUtils do
         expect(subject).to receive(:on).with( host, /wget .*/ ).ordered
         expect(subject).to receive(:on).with( host, /dpkg .*/ ).ordered
         expect(subject).to receive(:on).with( host, "apt-get update" ).ordered
-        subject.install_puppetlabs_release_repo host
-      end
-
-    end
-
-    describe "When host is a redhat-like platform" do
-      let( :platform ) { Beaker::Platform.new('el-7-i386') }
-
-      it "installs an rpm" do
-        expect(subject).to receive(:on).with( host, /^(rpm --replacepkgs -ivh).*/ ).ordered
         subject.install_puppetlabs_release_repo host
       end
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -145,6 +145,48 @@ module Beaker
 
     end
 
+    context "install_package_with_rpm" do
+
+      it "accepts a package as a single argument" do
+        @opts = {'platform' => 'el-is-me'}
+        pkg = 'redhat_package'
+        expect( Beaker::Command ).to receive(:new).with("rpm  -ivh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.install_package_with_rpm(pkg) ).to be == "hello"
+      end
+
+      it "accepts a package and additional options" do
+        @opts = {'platform' => 'el-is-me'}
+        pkg = 'redhat_package'
+        cmdline_args = '--foo'
+        expect( Beaker::Command ).to receive(:new).with("rpm #{cmdline_args} -ivh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.install_package_with_rpm(pkg, cmdline_args) ).to be == "hello"
+      end
+
+    end
+
+    context 'extract_rpm_proxy_options' do
+
+      [ 'http://myproxy.com:3128/',
+        'https://myproxy.com:3128/',
+        'https://myproxy.com:3128',
+        'http://myproxy.com:3128',
+      ].each do |url|
+        it "correctly extracts rpm proxy options for #{url}" do
+          expect( instance.extract_rpm_proxy_options(url) ).to be == '--httpproxy myproxy.com --httpport 3128'
+        end
+      end
+
+      url = 'http:/myproxy.com:3128'
+      it "fails to extract rpm proxy options for #{url}" do
+        expect{
+          instance.extract_rpm_proxy_options(url)
+        }.to raise_error(RuntimeError, /Cannot extract host and port/)
+      end
+
+    end
+
   end
 end
 


### PR DESCRIPTION
Without this patch applied, the call to rpm in Beaker::DSL::InstallUtils ignores the package_proxy option.
    
We add two new methods, extract_rpm_proxy_options and install_package_with_rpm.
    
The extract_rpm_proxy_options method is needed as the rpm command expects command line options --httpproxy and --httpport.
    
The install_package_with_rpm method is needed in order to install rpms from a remote URL address.  The existing install_package method uses yum and yum can't install an rpm from a remote URL.
    
Spec tests are provided for the extract_rpm_proxy_options method.  A redundant spec test is deleted.
