### PR TITLE
(BKR-574) Allow global restart_when_done => false

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -126,7 +126,7 @@ module Beaker
           cmdline_args = conf_opts[:__commandline_args__]
           service_args = conf_opts[:__service_args__] || {}
           restart_when_done = true
-          restart_when_done = host[:restart_when_done] if host[:restart_when_done]
+          restart_when_done = host[:restart_when_done] if host.has_key?(:restart_when_done)
           restart_when_done = conf_opts.fetch(:restart_when_done, restart_when_done)
           conf_opts = conf_opts.reject { |k,v| [:__commandline_args__, :__service_args__, :restart_when_done].include?(k) }
 

--- a/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
@@ -607,6 +607,15 @@ describe ClassMixedWithDSLHelpers do
             expect(host).to execute_commands_matching(/puppet resource service #{host['puppetservice']}.*ensure=stopped/).exactly(2).times
           end
 
+          it 'can be set globally in options' do
+            host[:restart_when_done] = false
+
+            subject.with_puppet_running_on(host, {})
+
+            expect(host).to execute_commands_matching(/puppet resource service #{host['puppetservice']}.*ensure=running/).once
+            expect(host).to execute_commands_matching(/puppet resource service #{host['puppetservice']}.*ensure=stopped/).exactly(2).times
+          end
+
           it 'yields to a block after bouncing service' do
             execution = 0
             allow( subject ).to receive(:curl_with_retries)


### PR DESCRIPTION
Previously, setting `:restart_when_done` to false on the master host, or
globally in options, did not work, because the `with_puppet_running_on`
method was checking for a truthy value.

This commit checks if the key is in the hash instead. It also preserves
the behavior where the options passed in by the test case take
precedence over the host's value.