### PR TITLE
(BKR-592) Add < 1.35.0 dep constraint to fog

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'fog-google', '~> 0.0.9' # dropped ruby 1.9 support in 0.1
-  s.add_runtime_dependency 'fog', '~> 1.25'
+  s.add_runtime_dependency 'fog', ['~> 1.25', '< 1.35.0']
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'


### PR DESCRIPTION
This commit adds a < 1.35.0 dependency constraint to the fog entry in
beaker's gemspec file. This fixes a problem introduced in fog 1.35.0
where it starts depending on a newer version of fog-google than beaker
currently allows.