### PR TITLE
(BKR-596) Fix Windows Path Support

### DIFF
--- a/lib/beaker/dsl/install_utils/module_utils.rb
+++ b/lib/beaker/dsl/install_utils/module_utils.rb
@@ -133,8 +133,12 @@ module Beaker
               #move to the host
               logger.debug "Using scp to transfer #{source_path} to #{target_path}"
               scp_to host, source_path, target_module_dir, {:ignore => ignore_list}
+
               #rename to the selected module name, if not correct
               cur_path = File.join(target_module_dir, source_name)
+              if host.is_powershell? #make sure our slashes are correct
+                cur_path = cur_path.gsub(/\//,'\\')
+              end
               host.mv cur_path, target_path unless cur_path == target_path
             when 'rsync'
               logger.debug "Using rsync to transfer #{source_path} to #{target_path}"

--- a/spec/beaker/dsl/install_utils/module_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/module_utils_spec.rb
@@ -187,7 +187,7 @@ describe ClassMixedWithDSLInstallUtils do
         expect( subject ).to receive(:on).with(host, "echo C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules" ).and_return( result )
 
         expect( subject ).to receive(:scp_to).with(host, "/opt/testmodule2", "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules", {:ignore => ignore_list})
-        expect( host ).to receive(:mv).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules/testmodule2', 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules\\testmodule')
+        expect( host ).to receive(:mv).with('C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules\\testmodule2', 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\modules\\testmodule')
 
         subject.copy_module_to(host, {:module_name => 'testmodule', :source => '/opt/testmodule2'})
       end


### PR DESCRIPTION
The "copy_module_to" method does not detect if the target machine is Windows
after SCP copy of the module. It attempts to move the directory because path
joining does not account for "/" separators in the path.