### PR TITLE
(BKR-597) Add cumulus logic to remove_puppet_on

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1403,6 +1403,8 @@ NOASK
             cmdline_args = ''
             # query packages
             case host[:platform]
+            when /cumulus/
+              pkgs = on(host, "dpkg-query -l  | awk '{print $2}' | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
             when /aix/
               pkgs = on(host, "rpm -qa  | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
               pkgs.concat on(host, "rpm -q tar", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -1185,6 +1185,7 @@ describe ClassMixedWithDSLInstallUtils do
     let(:aixhost) { make_host('aix', :platform => 'aix-53-power') }
     let(:sol10host) { make_host('sol10', :platform => 'solaris-10-x86_64') }
     let(:sol11host) { make_host('sol11', :platform => 'solaris-11-x86_64') }
+    let(:cumulushost) { make_host('cumulus', :platform => 'cumulus-2.2-amd64') }
     let(:el6host) { make_host('el6', :platform => 'el-6-x64') }
 
     pkg_list = 'foo bar'
@@ -1229,6 +1230,19 @@ describe ClassMixedWithDSLInstallUtils do
       expect( sol11host ).to receive(:uninstall_package).with(expected_list, cmd_args)
 
       subject.remove_puppet_on( sol11host  )
+    end
+
+    it 'uninstalls packages on cumulus' do
+      result = Beaker::Result.new(cumulushost,'')
+      result.stdout = pkg_list
+
+      expected_list = pkg_list
+      cmd_args = ''
+
+      expect( subject ).to receive(:on).exactly(2).times.and_return(result, result)
+      expect( cumulushost ).to receive(:uninstall_package).with(expected_list, cmd_args)
+
+      subject.remove_puppet_on( cumulushost  )
     end
 
     it 'raises error on other platforms' do


### PR DESCRIPTION
This commit adds logic for gathering installed puppet packages
on cumulus for removal in the `remove_puppet_on` method