### PR TITLE
[QENG-3063] Forget SSH connection IP address on reboot

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -8,6 +8,12 @@ module Unix::Exec
       exec(Beaker::Command.new("/sbin/shutdown -r now"), :expect_connection_failure => true)
     end
     sleep(10) #if we attempt a reconnect too quickly we end up blocking ¯\_(ツ)_/¯
+
+    # Our SSH connection can save the old IP address (even if the host IP changes
+    # on reboot), and we also may store the IP address in self['ip']. Ensure that
+    # an IP change across reboot will access the host directly.
+    self['ip'] = nil
+    close
   end
 
   def echo(msg, abs=true)


### PR DESCRIPTION
![cd5129-rock-n-roll-birthday-card](https://cloud.githubusercontent.com/assets/6259/10772653/2d9fb2f2-7cc5-11e5-97e5-0d3158085d3b.jpg)

Prior to this, as seen during acceptance test runs for BKR-358, on centos7 and debian7 (at least), if the DHCP lease time for the SUT was short, and a test run was sufficiently long, a late reboot would never come back as far as beaker was concerned.

The DHCP lease expiry would issue a new IP address for the SUT, but since the host object would often (but not always) have the IP address cached in `self['ip']`, when the SSH connection would be reinstantiated, it would go to `@ip` first, before going to `@vmhostname` or `@hostname`, meaning
that connections would never connect to the new IP address.

The tests for this will land with #930 (BKR-358), so not including them here.

I vetted this approach over a couple of days, tracing the runs, determining the root cause, and then applying this fix (with additional logging output to verify the change worked).

Test run output:

```
* #reboot: can reboot the host

kasibwkdzsf7utx.delivery.puppetlabs.net (centos7-64-1) 15:50:46$ /sbin/shutdown -r now
  Connecting... ip[10.32.121.132] vmhostname[kasibwkdzsf7utx.delivery.puppetlabs.net] hostname[centos7-64-1] self[Beaker::SshConnection]
  Connecting... by IP [10.32.121.132]
  Warning: ssh channel on centos7-64-1 received exception post command execution IOError - closed stream
  Warning: ssh.close: connection is already closed, no action needed
  Warning: ssh connection to centos7-64-1 has been terminated

kasibwkdzsf7utx.delivery.puppetlabs.net (centos7-64-1) executed in 0.21 seconds
Warning: ssh.close: connection is already closed, no action needed
Warning: ssh connection to centos7-64-1 has been terminated

kasibwkdzsf7utx.delivery.puppetlabs.net (centos7-64-1) 15:50:56$ echo kasibwkdzsf7utx.delivery.puppetlabs.net rebooted!
  Connecting... ip[] vmhostname[kasibwkdzsf7utx.delivery.puppetlabs.net] hostname[centos7-64-1] self[Beaker::SshConnection]
  Connecting... by vmhostname [kasibwkdzsf7utx.delivery.puppetlabs.net]
  Attempting ssh connection to kasibwkdzsf7utx.delivery.puppetlabs.net, user: root, opts: {:config=>false, :paranoid=>false, :auth_methods=>["publickey"], :port=>22, :forward_agent=>true, :keys=>["/Users/rick/.ssh/id_rsa-puppetlabs-vmpooler"], :user_known_hosts_file=>"/Users/rick/.ssh/known_hosts", :user=>"root"}
  Call-stack: /Users/rick/pl/beaker/lib/beaker/ssh_connection.rb:84:in `connect'
  /Users/rick/pl/beaker/lib/beaker/ssh_connection.rb:40:in `connect'
  /Users/rick/pl/beaker/lib/beaker/host.rb:229:in `connection'
  /Users/rick/pl/beaker/lib/beaker/host.rb:279:in `block in exec'
  /opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
  /Users/rick/pl/beaker/lib/beaker/host.rb:278:in `exec'
  /Users/rick/pl/beaker/lib/beaker/dsl/helpers/host_helpers.rb:73:in `block in on'
  /Users/rick/pl/beaker/lib/beaker/shared/host_manager.rb:115:in `run_block_on'
  /Users/rick/pl/beaker/lib/beaker/dsl/patterns.rb:35:in `block_on'
  /Users/rick/pl/beaker/lib/beaker/dsl/helpers/host_helpers.rb:63:in `on'
  acceptance/tests/base/host_test.rb:184:in `block (3 levels) in run_test'
  /Users/rick/pl/beaker/acceptance/lib/helpers/test_helper.rb:99:in `fails_intermittently'
  acceptance/tests/base/host_test.rb:181:in `block (2 levels) in run_test'
  acceptance/tests/base/host_test.rb:179:in `each'
  acceptance/tests/base/host_test.rb:179:in `block in run_test'
  /Users/rick/pl/beaker/lib/beaker/test_case.rb:128:in `eval'
  /Users/rick/pl/beaker/lib/beaker/test_case.rb:128:in `block in run_test'
  /opt/boxen/rbenv/versions/2.1.5/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
  /Users/rick/pl/beaker/lib/beaker/test_case.rb:125:in `run_test'
  /Users/rick/pl/beaker/lib/beaker/test_suite.rb:311:in `block in run'
  /Users/rick/pl/beaker/lib/beaker/test_suite.rb:308:in `each'
  /Users/rick/pl/beaker/lib/beaker/test_suite.rb:308:in `run'
  /Users/rick/pl/beaker/lib/beaker/test_suite.rb:357:in `run_and_raise_on_failure'
  /Users/rick/pl/beaker/lib/beaker/cli.rb:159:in `run_suite'
  /Users/rick/pl/beaker/lib/beaker/cli.rb:99:in `execute!'
  /Users/rick/pl/beaker/bin/beaker:6:in `<top (required)>'
  /Users/rick/pl/beaker/vendor/bundler/ruby/2.1.0/bin/beaker:23:in `load'
  /Users/rick/pl/beaker/vendor/bundler/ruby/2.1.0/bin/beaker:23:in `<main>'
  host: "kasibwkdzsf7utx.delivery.puppetlabs.net"
  Connecting... ip[] vmhostname[kasibwkdzsf7utx.delivery.puppetlabs.net] hostname[centos7-64-1] self[Beaker::SshConnection]
  kasibwkdzsf7utx.delivery.puppetlabs.net rebooted!

kasibwkdzsf7utx.delivery.puppetlabs.net (centos7-64-1) executed in 3.97 seconds
```

The tea leaves may not be :100:% readable, but on reboot the IP address changed, but the connection forgot the old IP and connected by the next level of information (`vmhostname`), which allowed the connection to succeed.

/cc @puppetlabs/beaker 