### PR TITLE
(BKR-607) Remove tar dependency for AIX

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1212,19 +1212,6 @@ module Beaker
             when /^(aix)$/
               # NOTE: AIX does not support repo management. This block assumes
               # that the desired rpm has been mirrored to the 'repos' location.
-              #
-              # NOTE: tar is a dependency for puppet packages on AIX. So,
-              # we install it prior to the 'repo' file.
-              tar_pkg_path = "ftp://ftp.software.ibm.com/aix/freeSoftware/aixtoolbox/RPMS/ppc/tar"
-              if version == "5.3" then
-                tar_pkg_file = "tar-1.14-2.aix5.1.ppc.rpm"
-              else
-                tar_pkg_file = "tar-1.22-1.aix6.1.ppc.rpm"
-              end
-              fetch_http_file( tar_pkg_path, tar_pkg_file, copy_dir_local)
-              scp_to host, File.join(copy_dir_local, tar_pkg_file), onhost_copy_base
-              onhost_copied_tar_file = File.join(onhost_copy_base, tar_pkg_file)
-              on host, "rpm -ivh #{onhost_copied_tar_file}"
 
               # install the repo file
               on host, "rpm -ivh #{onhost_copied_file}"
@@ -1416,7 +1403,6 @@ NOASK
               pkgs = on(host, "dpkg-query -l  | awk '{print $2}' | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
             when /aix/
               pkgs = on(host, "rpm -qa  | grep -E '(^pe-|puppet)'", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
-              pkgs.concat on(host, "rpm -q tar", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)
             when /solaris-10/
               cmdline_args = '-a noask'
               pkgs = on(host, "pkginfo | egrep '(^pe-|puppet)' | cut -f2 -d ' '", :acceptable_exit_codes => [0,1]).stdout.chomp.split(/\n+/)

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -1180,17 +1180,14 @@ describe ClassMixedWithDSLInstallUtils do
 
     pkg_list = 'foo bar'
 
-    it 'uninstalls packages on aix, including tar' do
-      aix_depend_list = 'tar'
+    it 'uninstalls packages on aix' do
       result = Beaker::Result.new(aixhost,'')
       result.stdout = pkg_list
-      result2 = Beaker::Result.new(aixhost,'')
-      result2.stdout = aix_depend_list
 
-      expected_list = pkg_list + " " + aix_depend_list
+      expected_list = pkg_list
       cmd_args = ''
 
-      expect( subject ).to receive(:on).exactly(3).times.and_return(result, result2, result)
+      expect( subject ).to receive(:on).exactly(2).times.and_return(result, result)
       expect( aixhost ).to receive(:uninstall_package).with(expected_list, cmd_args)
 
       subject.remove_puppet_on( aixhost )


### PR DESCRIPTION
Prior to this commit, Beaker installed -- and removed -- tar as
a dependency of the puppet-agent package on AIX. This dependency
has been removed from puppet-agent.

This commit removes the logic to install and remove the tar rpm
from AIX. It also updates the rpec test for `remove_puppet_on`
on AIX to remove the expectation that `tar` would a dependency.