### PR TITLE
(BKR-511) Beaker fails to launch Vagrant VMs when run within Bundler

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -84,7 +84,7 @@ module Beaker
     def set_ssh_config host, user
         f = Tempfile.new("#{host.name}")
         ssh_config = Dir.chdir(@vagrant_path) do
-          stdin, stdout, stderr, wait_thr = Open3.popen3('vagrant', 'ssh-config', host.name)
+          stdin, stdout, stderr, wait_thr = Open3.popen3(@vagrant_env, 'vagrant', 'ssh-config', host.name)
           if not wait_thr.value.success?
             raise "Failed to 'vagrant ssh-config' for #{host.name}"
           end
@@ -128,7 +128,7 @@ module Beaker
       @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', '.vagrant', 'beaker_vagrant_files', File.basename(options[:hosts_file])))
       FileUtils.mkdir_p(@vagrant_path)
       @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
-
+      @vagrant_env = { "RUBYLIB" => "" }
     end
 
     def provision(provider = nil)
@@ -182,7 +182,7 @@ module Beaker
     def vagrant_cmd(args)
       Dir.chdir(@vagrant_path) do
         exit_status = 1
-        Open3.popen3("vagrant #{args}") {|stdin, stdout, stderr, wait_thr|
+        Open3.popen3(@vagrant_env, "vagrant #{args}") {|stdin, stdout, stderr, wait_thr|
           while line = stdout.gets
             @logger.info(line)
           end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -196,7 +196,7 @@ EOF
       allow( state ).to receive( :success? ).and_return( true )
       wait_thr.value = state
 
-      allow( Open3 ).to receive( :popen3 ).with( 'vagrant', 'ssh-config', name ).and_return( [ "", out, "", wait_thr ])
+      allow( Open3 ).to receive( :popen3 ).with( {"RUBYLIB"=>""}, 'vagrant', 'ssh-config', name ).and_return( [ "", out, "", wait_thr ])
 
       file = double( 'file' )
       allow( file ).to receive( :path ).and_return( '/path/sshconfig' )


### PR DESCRIPTION
Unset the RUBYLIB variable before shelling out to run vagrant.  Fixes dependency on outdated version of bundler