### PR TITLE
[QENG-3063] Fix reboot test timeout issues on jenkins

### DIFF
--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -81,10 +81,18 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       remote_filename = File.join(remote_tmpdir, "testfile.txt")
       contents = fixture_contents("simple_text_file")
 
-      create_remote_file default, remote_filename, contents, { :protocol => "rsync" }
+      result = create_remote_file default, remote_filename, contents, { :protocol => "rsync" }
 
-      remote_contents = on(default, "cat #{remote_filename}").stdout
-      assert_equal contents, remote_contents
+      fails_intermittently("https://tickets.puppetlabs.com/browse/BKR-612",
+        "default" => default,
+        "remote_tmpdir" => remote_tmpdir,
+        "remote_filename" => remote_filename,
+        "contents" => contents,
+        "result" => result
+        ) do
+          remote_contents = on(default, "cat #{remote_filename}").stdout
+          assert_equal contents, remote_contents
+      end
     end
   end
 
@@ -154,15 +162,26 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
 
     step "#create_remote_file creates remote files on all remote hosts, when given an array, using rsync" do
       remote_tmpdir = tmpdir_on default
+
+      # NOTE: we do not do this step in the non-hosts-array version of the test, not sure why
       on hosts, "mkdir -p #{remote_tmpdir}"
+
       remote_filename = File.join(remote_tmpdir, "testfile.txt")
       contents = fixture_contents("simple_text_file")
 
-      create_remote_file hosts, remote_filename, contents, { :protocol => 'rsync' }
+      result = create_remote_file hosts, remote_filename, contents, { :protocol => 'rsync' }
 
       hosts.each do |host|
-        remote_contents = on(host, "cat #{remote_filename}").stdout
-        assert_equal contents, remote_contents
+        fails_intermittently("https://tickets.puppetlabs.com/browse/BKR-612",
+          "host" => host,
+          "remote_tmpdir" => remote_tmpdir,
+          "remote_filename" => remote_filename,
+          "contents" => contents,
+          "result" => result
+          ) do
+          remote_contents = on(host, "cat #{remote_filename}").stdout
+          assert_equal contents, remote_contents
+        end
       end
     end
   end

--- a/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
@@ -80,17 +80,21 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
       Dir.mktmpdir do |local_dir|
         local_filename, contents = create_local_file_from_fixture("simple_text_file", local_dir, "testfile.txt")
         remote_tmpdir = tmpdir_on default
+        remote_filename = File.join(remote_tmpdir, "testfile.txt")
 
         result = rsync_to default, local_filename, remote_tmpdir
 
-        remote_filename = File.join(remote_tmpdir, "testfile.txt")
-        remote_contents = on(default, "cat #{remote_filename}").stdout
-
         fails_intermittently("https://tickets.puppetlabs.com/browse/QENG-3053",
+          "result"          => result,
           "default"         => default,
+          "contents"        => contents,
+          "local_filename"  => local_filename,
+          "local_dir"       => local_dir,
           "remote_filename" => remote_filename,
+          "remote_tmdir"    => remote_tmpdir,
           "result"          => result.inspect,
         ) do
+          remote_contents = on(default, "cat #{remote_filename}").stdout
           assert_equal contents, remote_contents
         end
       end
@@ -103,11 +107,22 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
         on hosts, "mkdir -p #{remote_tmpdir}"
         remote_filename = File.join(remote_tmpdir, "testfile.txt")
 
-        rsync_to hosts, local_filename, remote_tmpdir
+        result = rsync_to hosts, local_filename, remote_tmpdir
 
         hosts.each do |host|
-          remote_contents = on(host, "cat #{remote_filename}").stdout
-          assert_equal contents, remote_contents
+          fails_intermittently("https://tickets.puppetlabs.com/browse/QENG-3053",
+            "result"          => result,
+            "host"            => host,
+            "contents"        => contents,
+            "local_filename"  => local_filename,
+            "local_dir"       => local_dir,
+            "remote_filename" => remote_filename,
+            "remote_tmdir"    => remote_tmpdir,
+            "result"          => result.inspect,
+          ) do
+            remote_contents = on(host, "cat #{remote_filename}").stdout
+            assert_equal contents, remote_contents
+          end
         end
       end
     end

--- a/acceptance/tests/base/host_test.rb
+++ b/acceptance/tests/base/host_test.rb
@@ -175,13 +175,8 @@ hosts.each do |host|
   end
 end
 
-# TODO: re-enable via resolution of QENG-3063
-#
-# step "#reboot: can reboot the host"
-# hosts.each do |host|
-#   host.reboot
-#   fails_intermittently("https://tickets.puppetlabs.com/browse/QENG-3063",
-#     "host" => "#{host}") do
-#     on host, "echo #{host} rebooted!"
-#   end
-# end
+step "#reboot: can reboot the host"
+hosts.each do |host|
+  host.reboot
+  on host, "echo #{host} rebooted!"
+end

--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -357,6 +357,7 @@ module Beaker
         to.print color_code if @color
         to.send print_statement, msg
         to.print NORMAL if @color unless color_code == NONE
+        to.flush
       end
     end
 

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 module Beaker
   describe Logger do
-    let(:my_io)     { MockIO.new                         }
+    let(:my_io)     { StringIO.new                         }
     let(:logger)    { Logger.new(my_io, :quiet => true)  }
     let(:test_dir)  { 'tmp/tests' }
     let(:dummy_prefix)  { 'dummy' }

--- a/spec/mocks.rb
+++ b/spec/mocks.rb
@@ -1,18 +1,5 @@
 require 'rspec/mocks'
 
-class MockIO < IO
-  def initialize
-  end
-
-  methods.each do |meth|
-    define_method(:meth) {}
-  end
-
-  def === other
-    super other
-  end
-end
-
 module MockNet
   class HTTP
 


### PR DESCRIPTION
![](http://images.contentreserve.com/ImageType-100/0111-1/%7BC843D659-6E83-4408-B2AF-9E263838C71D%7DImg100.jpg)

 - [QENG-3063](https://tickets.puppetlabs.com/browse/QENG-3063)

Prior to this change, the `host_test.rb` check for rebooting systems could sometimes fail, only on our Beaker acceptance jenkins, but in such a way that it was clear that something was happening after the attempt to reboot started, but no further output was available.

Exploratory work showed that when a rebooted host changes IP address, it is possible for not only the normal long sequence of Fibonacci-fallback connect retries to happen, but for also various low-level TCP connection failures (with their own long timeouts) to occur.

Since output was being buffered, and not flushed, and neither of these phases was generating a lot of output (enough to trigger a buffer flush on its own), it was possible for more than our 10 minute jenkins output timeout to pass without effectively changing the output buffer.

Flushing our log output overcomes the jenkins timeout problem. We do not here address questions of long IP-address change timeouts.

/cc @puppetlabs/beaker 
/related: https://github.com/puppetlabs/beaker/pull/1005/