### PR TITLE
(BRK-617) Print exception message for test cases

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -160,7 +160,7 @@ module Beaker
         #
         # @param exception [Exception] exception to fail with
         def log_and_fail_test(exception)
-          logger.error(exception.inspect)
+          logger.error("#{exception.class}: #{exception.message}")
           bt = exception.backtrace
           logger.pretty_backtrace(bt).each_line do |line|
             logger.error(line)


### PR DESCRIPTION
Some exceptions implement the `#inspect` method to only print the class
name or otherwise change the output to not include the error message in
question, which makes such exceptions very challenging to deubg. This
commit changes the test case exception printing method to explicitly
print the exception class and message so that there's always relevant
context available when an exception is raised.