### PR TITLE
(BKR-622) Fix Regular Expression to give correct Host IP Address

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -106,7 +106,7 @@ module Beaker
       ip = ''
       if File.file?(@vagrant_file) #we should have a vagrant file available to us for reading
         f = File.read(@vagrant_file)
-        m = /#{hostname}.*?ip:\s*('|")\s*([^'"]+)('|")/m.match(f)
+        m = /'#{hostname}'.*?ip:\s*('|")\s*([^'"]+)('|")/m.match(f)
         if m
           ip = m[2]
           @logger.debug("Determined existing vagrant box #{hostname} ip to be: #{ip} ")

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -32,12 +32,13 @@ module Beaker
       vagrant.make_vfile( @hosts )
 
       vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+      puts "file is #{path}\n"
       expect( vagrantfile ).to be === <<-EOF
 Vagrant.configure("2") do |c|
   c.ssh.insert_key = false
   c.vm.define 'vm1' do |v|
     v.vm.hostname = 'vm1'
-    v.vm.box = 'vm1_of_my_box'
+    v.vm.box = 'vm2vm1_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm1'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm1", :netmask => "255.255.0.0", :mac => "0123456789"
@@ -47,7 +48,7 @@ Vagrant.configure("2") do |c|
   end
   c.vm.define 'vm2' do |v|
     v.vm.hostname = 'vm2'
-    v.vm.box = 'vm2_of_my_box'
+    v.vm.box = 'vm2vm2_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm2'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm2", :netmask => "255.255.0.0", :mac => "0123456789"
@@ -57,7 +58,7 @@ Vagrant.configure("2") do |c|
   end
   c.vm.define 'vm3' do |v|
     v.vm.hostname = 'vm3'
-    v.vm.box = 'vm3_of_my_box'
+    v.vm.box = 'vm2vm3_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm3'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm3", :netmask => "255.255.0.0", :mac => "0123456789"
@@ -235,7 +236,6 @@ EOF
           expect{ vagrant.get_ip_from_vagrant_file(host.name) }.to raise_error
         end
       end
-
     end
 
     describe "provisioning and cleanup" do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -39,7 +39,7 @@ module HostHelpers
   HOST_NAME     = "vm%d"
   HOST_SNAPSHOT = "snapshot%d"
   HOST_IP       = "ip.address.for.%s"
-  HOST_BOX      = "%s_of_my_box"
+  HOST_BOX      = "vm2%s_of_my_box"
   HOST_BOX_URL  = "http://address.for.my.box.%s"
   HOST_DNS_NAME = "%s.box.tld"
   HOST_TEMPLATE = "%s_has_a_template"


### PR DESCRIPTION
Without this patch applied the hostname can sometimes be incorrectly picked up and this
creates problem with all the hostnames getting the same IP addresses on a multi-node setup.

Example Nodeset that can cause this problem:
```
HOSTS:
  staging:
    roles:
      - sta
      - master
    platform: el-6-x86_64
    box: puppetlabs/centos-6.6-64-puppet
    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-puppet
    hypervisor: vagrant
    shared_folder: abc
    NetworkSettings:
      IPAddress: 10.255.50.100
  etl:
    roles:
      - etl
    platform: el-6-x86_64
    box: puppetlabs/centos-6.6-64-puppet
    box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-puppet
    hypervisor: vagrant
    NetworkSettings:
      IPAddress: 10.255.50.120
CONFIG:
  type: git
  destroy: no
```

In the above scenario, the hostname 'etl' is also available when you search 'puppetlabs'.

The patch fixes this by changing the regular expression to look for the string 'etl' (including
the quote marks).