### PR TITLE
(BKR-625) Added ability to mount a folder.

### DIFF
--- a/docs/hypervisors/vagrant.md
+++ b/docs/hypervisors/vagrant.md
@@ -1,0 +1,40 @@
+When using the Vagrant Hypervisor, beaker can mount specific local directories as synced_folders inside the vagrant box.
+This is done by using the 'mount_folders' option in the nodeset file.
+
+Example hosts file:
+
+    HOSTS:
+      ubuntu-1404-x64-master:
+        roles:
+          - master
+          - agent
+          - dashboard
+          - database
+        platform: ubuntu-1404-x86_64
+        hypervisor: vagrant
+        box: puppetlabs/ubuntu-14.04-64-nocm
+        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+        mount_folders:
+          folder1:
+            from: ./
+            to: /vagrant/folder1
+          tmp:
+            from: /tmp
+            to: /vagrant/tmp
+        ip: 192.168.20.20
+      ubuntu-1404-x64-agent:
+        roles:
+          - agent
+        platform: ubuntu-1404-x86_64
+        hypervisor: vagrant
+        box: puppetlabs/ubuntu-14.04-64-nocm
+        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+        ip: 192.168.21.21
+    CONFIG:
+      nfs_server: none
+      consoleport: 443
+
+In the above beaker will mount the folders ./ to /vagrant/folder1 and the folder /tmp to /vagrant/tmp
+
+## Supported Virtualization Providers ##
+* [Vagrant](Vagrant-Support.md)

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -35,6 +35,12 @@ module Beaker
         v_file << "    v.vm.synced_folder '.', '/vagrant', disabled: true\n" if host['synced_folder'] == 'disabled'
         v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\", :mac => \"#{randmac}\"\n"
 
+        unless host['mount_folders'].nil? 
+          host['mount_folders'].each do |name, folder|
+            v_file << "    v.vm.synced_folder '#{folder[:from]}', '#{folder[:to]}', create: true\n"
+          end
+        end
+
         if /windows/i.match(host['platform'])
           v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -14,7 +14,12 @@ module Beaker
     let( :vagrant ) { Beaker::Vagrant.new( @hosts, options ) }
 
     before :each do
-      @hosts = make_hosts()
+      @hosts = make_hosts({
+        :mount_folders => {
+          :test_temp => {:from => './', :to => '/temp'},
+          :test_tmp => {:from => '../', :to => '/tmp'}
+        }
+      })
     end
 
     it "stores the vagrant file in $WORKINGDIR/.vagrant/beaker_vagrant_files/sample.cfg" do
@@ -41,6 +46,8 @@ Vagrant.configure("2") do |c|
     v.vm.box_url = 'http://address.for.my.box.vm1'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm1", :netmask => "255.255.0.0", :mac => "0123456789"
+    v.vm.synced_folder './', '/temp', create: true
+    v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
       vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
     end
@@ -51,6 +58,8 @@ Vagrant.configure("2") do |c|
     v.vm.box_url = 'http://address.for.my.box.vm2'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm2", :netmask => "255.255.0.0", :mac => "0123456789"
+    v.vm.synced_folder './', '/temp', create: true
+    v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
       vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
     end
@@ -61,6 +70,8 @@ Vagrant.configure("2") do |c|
     v.vm.box_url = 'http://address.for.my.box.vm3'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm3", :netmask => "255.255.0.0", :mac => "0123456789"
+    v.vm.synced_folder './', '/temp', create: true
+    v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
       vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
     end


### PR DESCRIPTION
Without this patch there is no way to mount a local folder inside the beaker nodes.

With this patch folders can be mounted similar to below using the `mount_folders` option:
```
    HOSTS:
      ubuntu-1404-x64-master:
        roles:
          - master
          - agent
          - dashboard
          - database
        platform: ubuntu-1404-x86_64
        hypervisor: vagrant
        box: puppetlabs/ubuntu-14.04-64-nocm
        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
        mount_folders:
          folder1:
            from: ./
            to: /vagrant/folder1
          tmp:
            from: /tmp
            to: /vagrant/tmp
        ip: 192.168.20.20
      ubuntu-1404-x64-agent:
        roles:
          - agent
        platform: ubuntu-1404-x86_64
        hypervisor: vagrant
        box: puppetlabs/ubuntu-14.04-64-nocm
        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
        ip: 192.168.21.21
    CONFIG:
      nfs_server: none
      consoleport: 443
```

In the above beaker will mount the folders ./ to /vagrant/folder1 and the folder /tmp to /vagrant/tmp

This relates to the new feature ticket opened on puppetlab here: https://tickets.puppetlabs.com/browse/BKR-625