### PR TITLE
(BKR-635) Add VM hostname to VMX data during cloning operations

### DIFF
--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -58,7 +58,12 @@ module Beaker
           'Creation time:  ' + Time.now.strftime("%Y-%m-%d %H:%M") + "\n\n" +
           'CI build link:  ' + ( ENV['BUILD_URL'] || 'Deployed independently of CI' ) +
           'department:     ' + @options[:department] +
-          'project:        ' + @options[:project]
+          'project:        ' + @options[:project],
+        :extraConfig => [
+          { :key   => 'guestinfo.hostname',
+            :value => host['vmhostname']
+          }
+        ]
       )
 
       # Are we using a customization spec?


### PR DESCRIPTION
This commit adds a custom guestinfo keyword and hostname variable
that allows the VMware Tools to query the hostname.

Related to puppetlabs/vmpooler#139