### PR TITLE
BKR-629: Adds compile masters to the array of roles 

### DIFF
--- a/lib/beaker/dsl/roles.rb
+++ b/lib/beaker/dsl/roles.rb
@@ -100,7 +100,7 @@ module Beaker
       #     end
       #
       def not_controller(host)
-        controllers = ['dashboard', 'database', 'master', 'console']
+        controllers = ['dashboard', 'database', 'master', 'console', 'compile_master']
         matched_roles = host['roles'].select { |v| controllers.include?(v) }
         matched_roles.length == 0
       end


### PR DESCRIPTION
in the not_controller method, so that agents on compile_master systems will show as controllers