### PR TITLE
(BKR-472) (BKR-475) Fix solaris for install_pe_on with 2015.2

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1338,6 +1338,12 @@ NOASK
             when /^osx$/
               release_file = "/repos/apple/#{opts[:puppet_collection]}/puppet-agent-*"
               download_file = "puppet-agent-#{variant}-#{version}.tar.gz"
+            when /^solaris$/
+              if arch == 'x86_64'
+                arch = 'i386'
+              end
+              release_file = "/repos/solaris/#{version}/#{opts[:puppet_collection]}/puppet-agent-*#{arch}.pkg.gz"
+              download_file = "puppet-agent-#{varant}-#{version}-#{arch}.tar.gz"
             else
               raise "No pe-promoted installation step for #{variant} yet..."
             end


### PR DESCRIPTION
When trying to install puppet-agent collection packages through
`install_pe_on`, eventually `install_puppet_agent_pe_promoted_repo_on`
gets called but has no entry for where the solaris packages are kept.
This commit adds the ability for solaris to install PC puppet-agent
packages.