### PR TITLE
(BKR-634) Fix YAML deserialization for Beaker::Platform

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -110,5 +110,13 @@ module Beaker
       [@variant, @version, @arch].join('-')
     end
 
+    if RUBY_VERSION =~ /^1\.9/
+      def init_with(coder)
+        coder.map.each do |ivar, value|
+          instance_variable_set("@#{ivar}", value)
+        end
+        replace("#{@variant}-#{@version}-#{@arch}")
+      end
+    end
   end
 end

--- a/spec/beaker/platform_spec.rb
+++ b/spec/beaker/platform_spec.rb
@@ -128,6 +128,22 @@ module Beaker
 
     end
 
-  end
+    context 'round tripping from yaml', if: RUBY_VERSION =~ /^1\.9/ do
+      before do
+        @name = 'ubuntu-14.04-x86_64'
+      end
 
+      let(:round_tripped) { YAML.load(YAML.dump(platform)) }
+
+      [:variant, :arch, :version, :codename].each do |field|
+        it "deserializes the '#{field}' field" do
+          expect(round_tripped.send(field)).to eq platform.send(field)
+        end
+      end
+
+      it 'properly sets the string contents' do
+        expect(round_tripped.to_s).to eq @name
+      end
+    end
+  end
 end


### PR DESCRIPTION
The version of Psych shipped with Ruby 1.9.3-p194 did not support
subclasses of String that added additional ivars to the String class.
The Beaker::Platform class does just that - subclassing String and
additional ivars - which meant that round tripping a Beaker::Platform
object would create an object with improperly initialized instance
variables. Psych commit e2fcf9af9e95535401f816bc893839b9ad743a9e
resolved that issue but we still use platforms that have the old version
of psych.

To resolve this issue, this commit implements a custom #init_with method
that explicitly sets all instance variables on the Beaker object that
were defined inside of the YAML map instance, and then reconstructs the
string value based on those fields.

/cc @er0ck 