### PR TITLE
(BKR-631) Add memory option to vagrant libvirt.

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -1,11 +1,31 @@
 require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantLibvirt < Beaker::Vagrant
+  @memory = nil
+
+  class << self
+    attr_reader :memory
+  end
+
   def provision(provider = 'libvirt')
     super
   end
 
   def self.provider_vfile_section(host, options)
-    "    v.vm.provider :libvirt"
+    "    v.vm.provider :libvirt do |node|\n" +
+      "      node.memory = #{memory(host, options)}\n" +
+      "    end\n"
+  end
+
+  def self.memory(host, options)
+    return @memory unless @memory.nil?
+    @memory = case
+    when host['vagrant_memsize']
+      host['vagrant_memsize']
+    when options['vagrant_memsize']
+      options['vagrant_memsize']
+    else
+      '512'
+    end
   end
 end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -21,14 +21,23 @@ describe Beaker::VagrantLibvirt do
     vagrant.provision
   end
 
-  it "can make a Vagranfile for a set of hosts" do
-    FakeFS.activate!
-    path = vagrant.instance_variable_get( :@vagrant_path )
-    allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+  context 'Correct vagrant configuration' do
+    before(:each) do
+      FakeFS.activate!
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
 
-    vagrant.make_vfile( @hosts )
+      vagrant.make_vfile( @hosts )
+      @vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+    end
 
-    vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :libvirt})
+    it "can make a Vagranfile for a set of hosts" do
+      expect( @vagrantfile ).to include( %Q{    v.vm.provider :libvirt do |node|})
+    end
+
+    it "can specify the memory as an integer" do
+      expect( @vagrantfile.split("\n").map(&:strip) )
+        .to include('node.memory = 512')
+    end
   end
 end


### PR DESCRIPTION
This add the possibility to specify the memory for each host separately
or for every host.