### PR TITLE
(BKR-633) Explicitly depend on mime-types.

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'google-api-client', '~> 0.8'
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
+  s.add_runtime_dependency 'mime-types', '~> 2.99' if RUBY_VERSION < '2.0' # dropped ruby 1.9 rupport in 3.0
   s.add_runtime_dependency 'fog-google', '~> 0.0.9' # dropped ruby 1.9 support in 0.1
   s.add_runtime_dependency 'fog', ['~> 1.25', '< 1.35.0']
 


### PR DESCRIPTION
  This commit will add an explicit dependency on the mime-types gem to
  beaker's gemspec that installs versions less than 3.0 on systems with
  a Ruby version less than 2.0.

  This has to be done in order for beaker to install freshly on systems
  where it hasn't been installed before.  The mime-types gem dropped
  ruby 1.9.2 support with 3.0 and one of beaker's dependency, fog
  depends on any version of mime-types greater than 0.