### PR TITLE
(MAINT) updated yard doc location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 options.rb
 test.cfg
 .yardoc
+yard_docs
 coverage
 .bundle
 .vendor

--- a/Rakefile
+++ b/Rakefile
@@ -75,8 +75,9 @@ end
 #   Documentation Tasks
 #
 ###########################################################
-DOCS_DAEMON = "yard server --reload --daemon --server thin"
-FOREGROUND_SERVER = 'bundle exec yard server --reload --verbose --server thin lib/beaker'
+DOCS_DIR = 'yard_docs'
+DOCS_DAEMON = "yard server --reload --daemon --server thin --docroot #{DOCS_DIR}"
+FOREGROUND_SERVER = "bundle exec yard server --reload --verbose --server thin lib/beaker --docroot #{DOCS_DIR}"
 
 def running?( cmdline )
   ps = `ps -ef`
@@ -107,7 +108,7 @@ namespace :docs do
   task :clear do
     original_dir = Dir.pwd
     Dir.chdir( File.expand_path(File.dirname(__FILE__)) )
-    sh 'rm -rf docs'
+    sh "rm -rf #{DOCS_DIR}"
     Dir.chdir( original_dir )
   end
 
@@ -115,7 +116,7 @@ namespace :docs do
   task :gen => 'docs:clear' do
     original_dir = Dir.pwd
     Dir.chdir( File.expand_path(File.dirname(__FILE__)) )
-    output = `bundle exec yard doc`
+    output = `bundle exec yard doc -o #{DOCS_DIR}`
     puts output
     if output =~ /\[warn\]|\[error\]/
       fail "Errors/Warnings during yard documentation generation"


### PR DESCRIPTION
Since moving the wiki docs into the repo itself, there's been
an issue where if you ran the yard rake tasks, you'd blow away
the in-repo docs, because the default yard doc location is the
same as the in-repo docs location: . This change makes
yard create the  folder, and use it for local doc
generation