### PR TITLE
Add privatebindir to PATH

### DIFF
--- a/lib/beaker/dsl/install_utils/puppet_utils.rb
+++ b/lib/beaker/dsl/install_utils/puppet_utils.rb
@@ -35,7 +35,7 @@ module Beaker
         #Given a host construct a PATH that includes puppetbindir, facterbindir and hierabindir
         # @param [Host] host    A single host to construct pathing for
         def construct_puppet_path(host)
-          path = (%w(puppetbindir facterbindir hierabindir)).compact.reject(&:empty?)
+          path = (%w(puppetbindir privatebindir facterbindir hierabindir)).compact.reject(&:empty?)
           #get the PATH defaults
           path.map! { |val| host[val] }
           path = path.compact.reject(&:empty?)


### PR DESCRIPTION
  This commit will add privatebindir to the list of paths added to the
  PATH variable stored in ~/.ssh/environment.

  This needs to happen so that the gem command and any excutables
  installed using that gem command are available for use during a suite.
  A requirement if your suite deploys dependencies with r10k on both aio
  and foss agent types.