### PR TITLE
Swap the placement of PermiteUserEnvironment

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -3,6 +3,9 @@ require 'timeout'
 require 'benchmark'
 require 'rsync'
 
+require 'beaker/dsl/helpers'
+require 'beaker/dsl/patterns'
+
 [ 'command', 'ssh_connection'].each do |lib|
   require "beaker/#{lib}"
 end
@@ -10,6 +13,9 @@ end
 module Beaker
   class Host
     SELECT_TIMEOUT = 30
+
+    include Beaker::DSL::Helpers
+    include Beaker::DSL::Patterns
 
     class CommandFailure < StandardError; end
 

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -187,17 +187,27 @@ module Unix::Exec
   def ssh_permit_user_environment
     case self['platform']
     when /debian|ubuntu|cumulus/
-      exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
+      directory = create_tmpdir_on(self)
+      exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
+      exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7/
-      exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
+      directory = create_tmpdir_on(self)
+      exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
+      exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
     when /el-|centos|fedora|redhat|oracle|scientific|eos/
-      exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
+      directory = create_tmpdir_on(self)
+      exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
+      exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
     when /sles/
-      exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
+      directory = create_tmpdir_on(self)
+      exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
+      exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
     when /solaris/
       # kept solaris here because refactoring it into its own Host module
       # conflicts with the solaris hypervisor that already exists
-      exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> /etc/ssh/sshd_config"))
+      directory = create_tmpdir_on(self)
+      exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
+      exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
     when /(free|open)bsd/
       exec(Beaker::Command.new("sudo perl -pi -e 's/^#?PermitUserEnvironment no/PermitUserEnvironment yes/' /etc/ssh/sshd_config"), {:pty => true} )
     end


### PR DESCRIPTION
  This commit will rework the way PermitUserEnvironment is added to
  sshd_config by putting it at the top of the file.

  Without this commit you will create a bad sshd_config if your sut's
  base image containes matching blocks the end of its sshd_config
  because the PermitUserEnvironment option is not allowed there.  This
  ordering is likely perferred since it is generally the norm to put
  matching blocks at the end of the sshd_config.