### PR TITLE
(maint) Fix typo in solaris install_pe util function.

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1343,7 +1343,7 @@ NOASK
                 arch = 'i386'
               end
               release_file = "/repos/solaris/#{version}/#{opts[:puppet_collection]}/puppet-agent-*#{arch}.pkg.gz"
-              download_file = "puppet-agent-#{varant}-#{version}-#{arch}.tar.gz"
+              download_file = "puppet-agent-#{variant}-#{version}-#{arch}.tar.gz"
             else
               raise "No pe-promoted installation step for #{variant} yet..."
             end


### PR DESCRIPTION
Fixes typo introduced in #1016 