### PR TITLE
(BKR-644) Prepend 'f' to the fedora version

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1112,6 +1112,7 @@ module Beaker
               release_path << release_path_end
             when /^(fedora|el|centos|sles)$/
               variant = ((variant == 'centos') ? 'el' : variant)
+              version = ((variant == 'fedora') ? "f#{version}" : version)
               release_path << "#{variant}/#{version}/#{opts[:puppet_collection]}/#{arch}"
               release_file = "puppet-agent-#{opts[:puppet_agent_version]}-1.#{variant}#{version}.#{arch}.rpm"
             when /^(aix)$/

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -882,6 +882,21 @@ describe ClassMixedWithDSLInstallUtils do
       subject.install_puppet_agent_dev_repo_on( host, opts )
     end
 
+    it 'prepends f to the version in the URL and rpm' do
+      platform = Object.new()
+      allow(platform).to receive(:to_array) { ['fedora', '22', 'x4']}
+      host = basic_hosts.first
+      host['platform'] = platform
+      opts = { :version => '0.1.0' }
+      allow( subject ).to receive( :options ).and_return( {} )
+
+      expect(subject).to receive(:fetch_http_file).once.with(/\/fedora\/f22\//, /-agent-0.1.0-1.fedoraf22/, /fedora/)
+      expect(subject).to receive(:scp_to).once.with(host, /puppet-agent-0.1.0-1.fedoraf22.x4.rpm/, "/root")
+      expect(subject).to receive(:on).ordered.with(host, /rpm -ivh/)
+
+      subject.install_puppet_agent_dev_repo_on( host, opts )
+    end
+
     it 'runs the correct install for windows platforms' do
       platform = Object.new()
       allow(platform).to receive(:to_array) { ['windows', '5', 'x64']}


### PR DESCRIPTION
Previously, install_puppet_agent_dev_repo_on did not work for fedora,
because we were constructing a URL of the form:

    http://<host>/puppet-agent/<sha>/repos/fedora/22/PC1/x86_64/puppet-agent-1.3.2-1.fedora22.x86_64.rpm

However, we unfortunately prepend 'f' to the version string when
publishing the package, see RE-4191.

This commit prepends an 'f' to the version string for fedora-only, so
the new URL is:

    http://<host>/puppet-agent/<sha>/repos/fedora/f22/PC1/x86_64/puppet-agent-1.3.2-1.fedoraf22.x86_64.rpm

Note f22 appears in two places, "fedora/f22" and
"puppet-agent...-fedoraf22.x86_64.rpm"