### PR TITLE
(BKR-661) Change to use pkgng for package installs

### DIFF
--- a/lib/beaker/host/freebsd/pkg.rb
+++ b/lib/beaker/host/freebsd/pkg.rb
@@ -2,17 +2,12 @@ module FreeBSD::Pkg
   include Beaker::CommandFactory
 
   def install_package(name, cmdline_args = nil, opts = {})
-    case self['platform']
-    when /freebsd-9/
-      cmdline_args ||= '-rF'
-      result = execute("pkg_add #{cmdline_args} #{name}", opts) { |result| result }
-    when /freebsd-10/
-      cmdline_args ||= '-y'
-      result = execute("pkg install #{cmdline_args} #{name}", opts) { |result| result }
-    else
-      raise "Package #{name} could not be installed on #{self}"
-    end
-    result.exit_code == 0
+    cmdline_args ||= '-y'
+    execute("pkg install #{cmdline_args} #{name}", opts) { |result| result }
+  end
+
+  def check_for_package(name, opts = {})
+    execute("pkg info #{name}", opts) { |result| result }
   end
 
 end

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -43,10 +43,6 @@ module Unix::Pkg
         if result.exit_code == 1
           result = execute("pkginfo CSW#{name}", opts) { |result| result }
         end
-      when /freebsd-9/
-        result = execute("pkg_info #{name}", opts) { |result| result }
-      when /freebsd-10/
-        result = execute("pkg info #{name}", opts) { |result| result }
       when /openbsd/
         result = execute("pkg_info #{name}", opts) { |result| result }
       else
@@ -97,10 +93,6 @@ module Unix::Pkg
         execute("pkg #{cmdline_args} install #{name}", opts)
       when /solaris-10/
         execute("pkgutil -i -y #{cmdline_args} #{name}", opts)
-      when /freebsd-9/
-        execute("pkg_add -fr #{cmdline_args} #{name}", opts)
-      when /freebsd-10/
-        execute("pkg #{cmdline_args} install #{name}", opts)
       when /openbsd/
         begin
           execute("pkg_add -I #{cmdline_args} #{name}", opts) do |command|

--- a/spec/beaker/host/freebsd/pkg_spec.rb
+++ b/spec/beaker/host/freebsd/pkg_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+module Beaker
+  describe FreeBSD::Pkg do
+    class FreeBSDPkgTest
+      include FreeBSD::Pkg
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+
+      def exec
+        #noop
+      end
+
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { FreeBSDPkgTest.new(opts, logger) }
+
+    context "install_package" do
+
+      it "runs the correct install command" do
+        expect( Beaker::Command ).to receive(:new).with('pkg install -y rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+        instance.install_package('rsync')
+      end
+
+    end
+
+    context "check_for_package" do
+
+      it "runs the correct checking command" do
+        expect( Beaker::Command ).to receive(:new).with('pkg info rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+        instance.check_for_package('rsync')
+      end
+
+    end
+
+  end
+end
+


### PR DESCRIPTION
* pkg_* is EOL as of Sept 2014 https://lists.freebsd.org/pipermail/freebsd-ports-announce/2014-February/000077.html
* On most base boxes, the pkg_* pointers are now 404:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

pkg_add -r rsync

Stdout from the command:

Error: Unable to get ftp://ftp.freebsd.org/pub/FreeBSD/ports/amd64/packages-9-stable/Latest/rsync.tbz: File unavailable (e.g., file not found, no access)
```

* Also fixes (BK-438), as we're changing package install result to be the result, as is the same with other pkg helpers.