### PR TITLE
(BKR-672) Add support for specifying paravirtprovider in VirtualBox

### DIFF
--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -19,10 +19,11 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
     # Allow memory and CPUs to be set at a per node level or overall, and take the most specific setting
     host_memory = host['vagrant_memsize'] ? host['vagrant_memsize'] : (options['vagrant_memsize'] ? options['vagrant_memsize'] : 1024)
     host_cpus = host['vagrant_cpus'] ? host['vagrant_cpus'] : (options['vagrant_cpus'] ? options['vagrant_cpus'] : 1)
+    host_paravirtprovider = host['vagrant_paravirtprovider'] ? host['vagrant_paravirtprovider'] : (options['vagrant_paravirtprovider'] ? options['vagrant_paravirtprovider'] : 'default')
 
     provider_section  = ""
     provider_section << "    v.vm.provider :virtualbox do |vb|\n"
-    provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{host_memory}', '--cpus', '#{host_cpus}']\n"
+    provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{host_memory}', '--cpus', '#{host_cpus}', '--paravirtprovider', '#{host_paravirtprovider}']\n"
     provider_section << "      vb.vbguest.auto_update = false" if options[:vbguest_plugin] == 'disable'
 
     # Guest volume support

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |c|
     v.vm.synced_folder './', '/temp', create: true
     v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--paravirtprovider', 'default']
     end
   end
   c.vm.define 'vm2' do |v|
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |c|
     v.vm.synced_folder './', '/temp', create: true
     v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--paravirtprovider', 'default']
     end
   end
   c.vm.define 'vm3' do |v|
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |c|
     v.vm.synced_folder './', '/temp', create: true
     v.vm.synced_folder '../', '/tmp', create: true
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--paravirtprovider', 'default']
     end
   end
 end
@@ -132,7 +132,7 @@ EOF
 
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
 
-      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', 'hello!', '--cpus', '1'\]/)
+      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', 'hello!', '--cpus', '1', '--paravirtprovider', 'default'\]/)
 
       expect( match ).to_not be nil
 
@@ -146,10 +146,24 @@ EOF
   
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
   
-      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!'\]/)
+      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!', '--paravirtprovider', 'default'\]/)
   
       expect( match ).to_not be nil
   
+    end
+
+    it "uses the paravirtualization interface defined per vagrant host" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      vagrant.make_vfile( @hosts, {'vagrant_paravirtprovider' => 'farewell!'} )
+
+      generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
+
+      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', '1!', '--paravirtprovider', 'farewell!'\]/)
+
+      expect( match ).to_not be nil
+
     end
 
     it "can generate a new /etc/hosts file referencing each host" do

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -27,7 +27,7 @@ describe Beaker::VagrantVirtualbox do
     vagrant.make_vfile( @hosts )
 
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']\n    end})
+    expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--paravirtprovider', 'default']\n    end})
   end
 
   it "can disable the vb guest plugin" do


### PR DESCRIPTION
**PLEASE REVIEW THIS CAREFULLY**

I admit that I have little experience in this. I based my changes on:
- (BKR-417) https://github.com/puppetlabs/beaker/pull/896/files, option for cpu's
- (QA-794) https://github.com/puppetlabs/beaker/pull/141/files
- https://www.virtualbox.org/manual/ch08.html#idp46608648159600 -> --paravirtprovider

I took as much care as I could

Actuall is this code ok? "match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!'\]/)" in spec/beaker/hypervisor/vagrant_spec.rb -> see https://github.com/puppetlabs/beaker/pull/896/files

This looks strange, but anyway I continued on this.