### PR TITLE
(BKR-480) added support for fedora23

### DIFF
--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-23-i386.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-23-i386.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f23/PC1/i386/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-23-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-23-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f23/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57


### PR DESCRIPTION
This change adds the fixtures needed for beaker to pass base acceptance for Fedora 23.