### PR TITLE
(MAINT) Remove keepalive_interval

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -196,8 +196,7 @@ module Beaker
                                      :forward_agent         => true,
                                      :keys                  => ["#{ENV['HOME']}/.ssh/id_rsa"],
                                      :user_known_hosts_file => "#{ENV['HOME']}/.ssh/known_hosts",
-                                     :keepalive             => true,
-                                     :keepalive_interval    => 2
+                                     :keepalive             => true
           }
         })
       end


### PR DESCRIPTION
This commit removes the keepalive_interval setting in presets.rb. This
was introduced to detect disconnections that were otherwise not noticed
unless beaker tried to write to the SSH session.

This change does still have keep alive enabled, but is now adhering to
the default interval of 300 (5 minutes).