### PR TITLE
(BKR-668) wrlinux5 puppet-agent install support added

### DIFF
--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -71,7 +71,7 @@ module Beaker
     # @return [String] This returns the fully formed command line invocation.
     def cmd_line host, cmd = @command, env = @environment, pc = @prepend_cmds
       env_string = host.environment_string( env )
-      prepend_commands = host.prepend_commands( pc, :cmd_exe => @cmdexe )
+      prepend_commands = host.prepend_commands( cmd, pc, :cmd_exe => @cmdexe )
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
       cmd_line_array = [env_string, prepend_commands, cmd, options_string, args_string]

--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -70,12 +70,12 @@ module Beaker
     #
     # @return [String] This returns the fully formed command line invocation.
     def cmd_line host, cmd = @command, env = @environment, pc = @prepend_cmds
-      env_string = env.nil? ? '' : environment_string_for( host, env )
-
-      cygwin = ((host['platform'] =~ /windows/) and host.is_cygwin? and @cmdexe) ? 'cmd.exe /c' : nil
+      env_string = host.environment_string( env )
+      prepend_commands = host.prepend_commands( pc, :cmd_exe => @cmdexe )
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
-      [env_string, cygwin, pc, cmd, options_string, args_string].compact.reject(&:empty?).join(' ')
+      cmd_line_array = [env_string, prepend_commands, cmd, options_string, args_string]
+      cmd_line_array.compact.reject( &:empty? ).join( ' ' )
     end
 
     # @param [Hash] opts These are the options that the command takes
@@ -120,48 +120,7 @@ module Beaker
       args.flatten.compact.join(' ')
     end
 
-    # Construct the environment string for this command
-    #
-    # @param [Host]                 host  A Host object
-    # @param [Hash{String=>String}] env   An optional Hash containing
-    #                                     key-value pairs to be treated
-    #                                     as environment variables that
-    #                                     should be set for the duration
-    #                                     of the puppet command.
-    #
-    # @return [String] Returns a string containing command line arguments that
-    #                  will ensure the environment is correctly set for the
-    #                  given host.
-    #
-    # @note I dislike the principle of this method. There is host specific
-    #       knowledge contained here. Really the relationship should be
-    #       reversed where a host is asked for an appropriate Command when
-    #       given a generic Command.
-    def environment_string_for host, env
-      return '' if env.empty?
-      env_array = []
-      env.each_key do |key|
-        val = env[key]
-        if val.is_a?(Array)
-          val = val.join(':')
-        else
-          val = val.to_s
-        end
-        env_array << "#{key.to_s.upcase}=\"#{val}\""
-      end
 
-      if not host.is_powershell?
-        environment_string = env_array.join(' ')
-        "env #{environment_string}"
-      else
-        environment_string = ''
-        env_array.each_with_index do |env|
-          environment_string += "set #{env} && "
-        end
-        environment_string
-      end
-
-    end
 
   end
 

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -902,9 +902,7 @@ module Beaker
                                   repo_filename,
                                   copy_dir )
 
-          on( host, "chmod 777 #{host.package_config_dir}" ) if host[:platform] =~ /cisco-5/
           scp_to( host, repo, host.package_config_dir )
-          on( host, "chmod 755 #{host.package_config_dir}" ) if host[:platform] =~ /cisco-5/
 
           on( host, 'apt-get update' ) if host['platform'] =~ /ubuntu-|debian-|cumulus-/
           nil

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -902,7 +902,12 @@ module Beaker
                                   repo_filename,
                                   copy_dir )
 
-          scp_to( host, repo, host.package_config_dir )
+          if host[:platform] =~ /cisco-5/
+            to_path = "#{host.package_config_dir}/#{File.basename(repo)}"
+          else
+            to_path = host.package_config_dir
+          end
+          scp_to( host, repo, to_path )
 
           on( host, 'apt-get update' ) if host['platform'] =~ /ubuntu-|debian-|cumulus-/
           nil

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -901,7 +901,10 @@ module Beaker
           repo = fetch_http_file( repo_config_folder_url,
                                   repo_filename,
                                   copy_dir )
+
+          on( host, "chmod 777 #{host.package_config_dir}" ) if host[:platform] =~ /cisco-5/
           scp_to( host, repo, host.package_config_dir )
+          on( host, "chmod 755 #{host.package_config_dir}" ) if host[:platform] =~ /cisco-5/
 
           on( host, 'apt-get update' ) if host['platform'] =~ /ubuntu-|debian-|cumulus-/
           nil
@@ -938,7 +941,7 @@ module Beaker
                                   repo_configs_dir = nil,
                                   opts = options )
           variant, version, arch, codename = host['platform'].to_array
-          if variant !~ /^(fedora|el|centos|debian|ubuntu|cumulus)$/
+          if variant !~ /^(fedora|el|centos|debian|ubuntu|cumulus|cisco)$/
             raise "No repository installation step for #{variant} yet..."
           end
           repo_configs_dir ||= 'tmp/repo_configs'
@@ -1035,7 +1038,7 @@ module Beaker
             onhost_copy_base = opts[:copy_dir_external]
 
             case variant
-            when /^(fedora|el|centos|debian|ubuntu|cumulus)$/
+            when /^(fedora|el|centos|debian|ubuntu|cumulus|cisco)$/
               sha = opts[:puppet_agent_sha] || opts[:puppet_agent_version]
               opts[:dev_builds_repos] ||= [ opts[:puppet_collection] ]
               install_puppetlabs_dev_repo( host, 'puppet-agent', sha, nil, opts )

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -331,7 +331,7 @@ module Beaker
     # to that source dir.
     #
     # @param source [String] The path to the file/dir to upload
-    # @param target [String] The destination path on the host
+    # @param target_path [String] The destination path on the host
     # @param options [Hash{Symbol=>String}] Options to alter execution
     # @option options [Array<String>] :ignore An array of file/dir paths that will not be copied to the host
     # @example
@@ -340,9 +340,8 @@ module Beaker
     #
     #   do_scp_to('source/file.rb', 'target', { :ignore => 'file.rb' }
     #   -> will result in not files copyed to the host, all are ignored
-    def do_scp_to source, target, options
-      self.scp_prep_operations( target )
-      target = self.scp_path(target)
+    def do_scp_to source, target_path, options
+      target = self.scp_path( target_path )
       @logger.notify "localhost $ scp #{source} #{@name}:#{target} {:ignore => #{options[:ignore]}}"
 
       result = Result.new(@name, [source, target])
@@ -410,7 +409,7 @@ module Beaker
         end
       end
 
-      self.scp_post_operations( target )
+      self.scp_post_operations( target, target_path )
       return result
     end
 

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -341,6 +341,7 @@ module Beaker
     #   do_scp_to('source/file.rb', 'target', { :ignore => 'file.rb' }
     #   -> will result in not files copyed to the host, all are ignored
     def do_scp_to source, target, options
+      self.scp_prep_operations( target )
       target = self.scp_path(target)
       @logger.notify "localhost $ scp #{source} #{@name}:#{target} {:ignore => #{options[:ignore]}}"
 
@@ -409,6 +410,7 @@ module Beaker
         end
       end
 
+      self.scp_post_operations( target )
       return result
     end
 

--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -148,6 +148,17 @@ module PSWindows::Exec
     self.close #refresh the state
   end
 
+  def environment_string env
+    return '' if env.empty?
+    env_array = self.environment_variable_string_pair_array( env )
+
+    environment_string = ''
+    env_array.each_with_index do |env|
+      environment_string += "set #{env} && "
+    end
+    environment_string
+  end
+
   # Overrides the {Windows::Exec#ssh_permit_user_environment} method,
   # since no steps are needed in this setup to allow user ssh environments
   # to work.

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -254,17 +254,20 @@ module Unix::Exec
 
   # Gets the specific prepend commands as needed for this host
   #
-  # @param [String] pc List of commands to prepend
+  # @param [String] command Command to be executed
+  # @param [String] user_pc List of user-specified commands to prepend
   # @param [Hash] opts optional parameters
   #
   # @return [String] Command string as needed for this host
-  def prepend_commands(pc = '', opts = {})
+  def prepend_commands(command = '', user_pc = '', opts = {})
     if self[:platform] =~ /cisco-5/
+      return user_pc unless command.index('vsh').nil?
+
       prepend_cmds = 'source /etc/profile; sudo ip netns exec '
       prepend_cmds << ( self[:vrf] ? self[:vrf] : '' )
       return prepend_cmds
     end
-    pc
+    user_pc
   end
 
   # Fills the user SSH environment file.

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -235,7 +235,13 @@ module Unix::Exec
     env_array = self.environment_variable_string_pair_array( env )
 
     environment_string = env_array.join(' ')
-    "env #{environment_string}"
+    command = 'env'
+    punctuation = ''
+    if self[:platform] =~ /cisco-5/
+      command = 'export'
+      punctuation = ';'
+    end
+    "#{command} #{environment_string}#{punctuation}"
   end
 
   def environment_variable_string_pair_array env

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -70,6 +70,16 @@ module Unix::Exec
     result.exit_code == 0
   end
 
+  # Gets the prefix that's needed for commands on a particular platform
+  #
+  # @return [String] Command prefix
+  def command_prefix
+    prefix = ''
+    prefix = "ip netns exec #{self[:vrf]} " if self[:platform] =~ /cisco-/
+    prefix = "sudo #{prefix}" if self[:platform] =~ /cisco-5/
+    prefix
+  end
+
   # Converts the provided environment file to a new shell script in /etc/profile.d, then sources that file.
   # This is for sles and debian based hosts.
   # @param [String] env_file The ssh environment file to read from

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -15,8 +15,10 @@ module Unix::File
 
   # Handles any changes needed in a path for SCP
   #
-  # @note This is really only needed in Windows at this point. Refer to
-  #   {Windows::File#scp_path} for more info
+  # @param [String] path File path to SCP to
+  #
+  # @return [String] path, changed if needed due to host
+  #   constraints
   def scp_path(path)
     if self[:platform] =~ /cisco-5/
       @home_dir ||= execute( 'pwd' )

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -147,4 +147,34 @@ NOASK
     end
     noask
   end
+
+  protected
+
+  # Handles host operations needed before an SCP takes place
+  #
+  # @param [String] scp_file_target File path to SCP to on the host
+  #
+  # @return nil
+  def scp_prep_operations scp_file_target
+    if self[:platform] =~ /cisco-5/
+      msg = "cisco-5 requires an SCP prep chmod, because it's using the #{self[:user]} user rather than root."
+      logger.trace( msg )
+      execute( "chmod 777 #{scp_file_target}" )
+    end
+    nil
+  end
+
+  # Handles host operations needed after an SCP takes place
+  #
+  # @param [String] scp_file_target File path to SCP to on the host
+  #
+  # @return nil
+  def scp_post_operations scp_file_target
+    if self[:platform] =~ /cisco-5/
+      msg = 'cleaning up cisco-5 SCP chmod'
+      logger.trace( msg )
+      execute( "chmod 755 #{scp_file_target}" )
+    end
+    nil
+  end
 end

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -37,6 +37,8 @@ module Unix::File
   # @return [String] Path to package config dir
   def package_config_dir
     case self['platform']
+    when /cisco-/
+      '/etc/yum/repos.d/'
     when /fedora|el-|centos/
       '/etc/yum.repos.d/'
     when /debian|ubuntu|cumulus/
@@ -60,8 +62,9 @@ module Unix::File
     repo_filename = "pl-%s-%s-" % [ package_name, build_version ]
 
     case variant
-    when /fedora|el|centos/
+    when /fedora|el|centos|cisco/
       variant = 'el' if variant == 'centos'
+      variant = 'cisco-wrlinux' if variant == 'cisco'
       fedora_prefix = ((variant == 'fedora') ? 'f' : '')
       pattern = "%s-%s%s-%s.repo"
       pattern = "repos-pe-#{pattern}" if self.is_pe?
@@ -90,7 +93,7 @@ module Unix::File
   # @return [String] Type of repo (rpm|deb)
   def repo_type
     case self['platform']
-    when /fedora|el-|centos/
+    when /fedora|el-|centos|cisco-/
       'rpm'
     when /debian|ubuntu|cumulus/
       'deb'

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -77,7 +77,7 @@ module Unix::Pkg
         if version
           name = "#{name}-#{version}"
         end
-        execute("yum -y #{cmdline_args} install #{name}", opts)
+        execute("#{self.command_prefix}yum -y #{cmdline_args} install #{name}", opts)
       when /ubuntu|debian|cumulus/
         if version
           name = "#{name}=#{version}"

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -77,7 +77,7 @@ module Unix::Pkg
         if version
           name = "#{name}-#{version}"
         end
-        execute("#{self.command_prefix}yum -y #{cmdline_args} install #{name}", opts)
+        execute("yum -y #{cmdline_args} install #{name}", opts)
       when /ubuntu|debian|cumulus/
         if version
           name = "#{name}=#{version}"

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -78,14 +78,15 @@ module Windows::Exec
 
   # Gets the specific prepend commands as needed for this host
   #
-  # @param [String] pc List of commands to prepend
+  # @param [String] command Command to be executed
+  # @param [String] user_pc List of user-specified commands to prepend
   # @param [Hash] opts optional parameters
   # @option opts [Boolean] :cmd_exe whether cmd.exe should be used
   #
   # @return [String] Command string as needed for this host
-  def prepend_commands(pc = nil, opts = {})
+  def prepend_commands(command = '', user_pc = nil, opts = {})
     cygwin_prefix = (self.is_cygwin? and opts[:cmd_exe]) ? 'cmd.exe /c' : ''
-    spacing = (pc && !cygwin_prefix.empty?) ? ' ' : ''
-    "#{cygwin_prefix}#{spacing}#{pc}"
+    spacing = (user_pc && !cygwin_prefix.empty?) ? ' ' : ''
+    "#{cygwin_prefix}#{spacing}#{user_pc}"
   end
 end

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -76,4 +76,16 @@ module Windows::Exec
     ssh_service_restart()
   end
 
+  # Gets the specific prepend commands as needed for this host
+  #
+  # @param [String] pc List of commands to prepend
+  # @param [Hash] opts optional parameters
+  # @option opts [Boolean] :cmd_exe whether cmd.exe should be used
+  #
+  # @return [String] Command string as needed for this host
+  def prepend_commands(pc = nil, opts = {})
+    cygwin_prefix = (self.is_cygwin? and opts[:cmd_exe]) ? 'cmd.exe /c' : ''
+    spacing = (pc && !cygwin_prefix.empty?) ? ' ' : ''
+    "#{cygwin_prefix}#{spacing}#{pc}"
+  end
 end

--- a/spec/beaker/dsl/helpers/host_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/host_helpers_spec.rb
@@ -50,7 +50,7 @@ describe ClassMixedWithDSLHelpers do
       subject.on( 'master', 'echo hello')
     end
 
-    it 'if the host is a Symbol Object, finds the matching hsots with that Symbol as role' do
+    it 'if the host is a Symbol Object, finds the matching hosts with that Symbol as role' do
       allow( subject ).to receive( :hosts ).and_return( hosts )
 
       expect( master ).to receive( :exec ).once
@@ -156,6 +156,18 @@ describe ClassMixedWithDSLHelpers do
           expect( subject.exit_code ).to be == 0
         end
       end
+    end
+
+    it 'errors if command is not a String or Beaker::Command' do
+      expect {
+        subject.on( host, Object.new )
+      }.to raise_error( ArgumentError, /called\ with\ a\ String\ or\ Beaker/ )
+    end
+
+    it 'executes the passed Beaker::Command if given as command argument' do
+      command_test = Beaker::Command.new( 'echo face_testing' )
+      expect( master ).to receive( :exec ).with( command_test, anything )
+      subject.on( master, command_test )
     end
   end
 

--- a/spec/beaker/dsl/install_utils/module_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/module_utils_spec.rb
@@ -80,7 +80,7 @@ describe ClassMixedWithDSLInstallUtils do
       allow( subject ).to receive( :hosts ).and_return( hosts )
       master = hosts.first
 
-
+      allow( subject ).to receive( :on ).once
       expect( subject ).to receive( :puppet ).with('module install test ', {}).once
 
       subject.install_puppet_module_via_pmt_on( master, {:module_name => 'test'} )
@@ -92,6 +92,7 @@ describe ClassMixedWithDSLInstallUtils do
       trace_opts = { :trace => nil }
       master['default_module_install_opts'] = trace_opts
 
+      allow( subject ).to receive( :on ).once
       expect( subject ).to receive( :puppet ).with('module install test ', trace_opts).once
 
       subject.install_puppet_module_via_pmt_on( master, {:module_name => 'test'} )

--- a/spec/beaker/host/pswindows/exec_spec.rb
+++ b/spec/beaker/host/pswindows/exec_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+module Beaker
+  describe PSWindows::Exec do
+    class PSWindowsExecTest
+      include PSWindows::Exec
+
+      def initialize(hash, logger)
+        @hash = hash
+        @logger = logger
+      end
+
+      def [](k)
+        @hash[k]
+      end
+
+      def to_s
+        "me"
+      end
+
+    end
+
+    let (:opts)     { @opts || {} }
+    let (:logger)   { double( 'logger' ).as_null_object }
+    let (:instance) { PSWindowsExecTest.new(opts, logger) }
+
+    context "rm" do
+
+      it "deletes" do
+        path = '/path/to/delete'
+        corrected_path = '\\path\\to\\delete'
+        expect( instance ).to receive(:execute).with("del /s /q #{corrected_path}").and_return(0)
+        expect( instance.rm_rf(path) ).to be === 0
+      end
+    end
+
+    context 'mv' do
+      let(:origin)      { '/origin/path/of/content' }
+      let(:destination) { '/destination/path/of/content' }
+
+      it 'rm first' do
+        expect( instance ).to receive(:execute).with("del /s /q #{destination.gsub(/\//, '\\')}").and_return(0)
+        expect( instance ).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
+        expect( instance.mv(origin, destination) ).to be === 0
+
+      end
+
+      it 'does not rm' do
+        expect( instance ).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
+        expect( instance.mv(origin, destination, false) ).to be === 0
+      end
+    end
+  end
+end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -50,6 +50,25 @@ module Beaker
       end
     end
 
+    describe '#command_prefix' do
+      it 'returns an empty string for non-cisco platforms' do
+        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'el-7-x86_64' )
+        expect( instance.command_prefix ).to be === ''
+      end
+
+      it 'returns the exec prefix for any cisco platform' do
+        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'cisco-7-x86_64' )
+        allow( instance ).to receive( :[] ).with( :vrf ).and_return( 'vrf' )
+        expect( instance.command_prefix ).to be === 'ip netns exec vrf '
+      end
+
+      it 'uses sudo on cisco-5 platforms' do
+        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'cisco-5-x86_64' )
+        allow( instance ).to receive( :[] ).with( :vrf ).and_return( 'vrf' )
+        expect( instance.command_prefix ).to be === 'sudo ip netns exec vrf '
+      end
+    end
+
     describe '#ssh_permit_user_environment' do
       it 'raises an error on unsupported platforms' do
         opts['platform'] = 'notarealthing01-parts-arch'

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -92,7 +92,7 @@ module Beaker
       it 'returns the pc parameter unchanged for non-cisco platforms' do
         allow( instance ).to receive( :[] ).with( :platform ).and_return( 'notcisco' )
         answer_prepend_commands = 'pc_param_unchanged_13579'
-        answer_test = instance.prepend_commands( answer_prepend_commands )
+        answer_test = instance.prepend_commands( 'fake_cmd', answer_prepend_commands )
         expect( answer_test ).to be === answer_prepend_commands
       end
 
@@ -121,6 +121,13 @@ module Beaker
           command_start_index = answer_test.index( '; ' ) + 2
           command_actual = answer_test[command_start_index, answer_test.length - command_start_index]
           expect( command_actual ).to match( /^sudo / )
+        end
+
+        it 'guards against "vsh" usage (only scenario we dont want prefixing)' do
+          allow( instance ).to receive( :[] ).with( :vrf ).and_return( nil )
+          answer_prepend_commands = 'pc_param_unchanged_13584'
+          answer_test = instance.prepend_commands( 'fake/vsh/command', answer_prepend_commands )
+          expect( answer_test ).to be === answer_prepend_commands
         end
       end
     end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -50,22 +50,22 @@ module Beaker
       end
     end
 
-    describe '#command_prefix' do
-      it 'returns an empty string for non-cisco platforms' do
-        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'el-7-x86_64' )
-        expect( instance.command_prefix ).to be === ''
+    describe '#environment_string' do
+      let(:host) { {'pathseparator' => ':'} }
+
+      it 'returns a blank string if theres no env' do
+        expect( instance ).to receive( :is_powershell? ).never
+        expect( instance.environment_string( {} ) ).to be == ''
       end
 
-      it 'returns the exec prefix for any cisco platform' do
-        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'cisco-7-x86_64' )
-        allow( instance ).to receive( :[] ).with( :vrf ).and_return( 'vrf' )
-        expect( instance.command_prefix ).to be === 'ip netns exec vrf '
+      it 'takes an env hash with var_name/value pairs' do
+        expect( instance.environment_string( {:HOME => '/'} ) ).
+          to be == "env HOME=\"/\""
       end
 
-      it 'uses sudo on cisco-5 platforms' do
-        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'cisco-5-x86_64' )
-        allow( instance ).to receive( :[] ).with( :vrf ).and_return( 'vrf' )
-        expect( instance.command_prefix ).to be === 'sudo ip netns exec vrf '
+      it 'takes an env hash with var_name/value[Array] pairs' do
+        expect( instance.environment_string( {:LD_PATH => ['/', '/tmp']}) ).
+          to be == "env LD_PATH=\"/:/tmp\""
       end
     end
 
@@ -84,6 +84,44 @@ module Beaker
         expect {
           instance.ssh_service_restart
         }.to raise_error( ArgumentError, /#{opts['platform']}/ )
+      end
+    end
+
+    describe '#prepend_commands' do
+
+      it 'returns the pc parameter unchanged for non-cisco platforms' do
+        allow( instance ).to receive( :[] ).with( :platform ).and_return( 'notcisco' )
+        answer_prepend_commands = 'pc_param_unchanged_13579'
+        answer_test = instance.prepend_commands( answer_prepend_commands )
+        expect( answer_test ).to be === answer_prepend_commands
+      end
+
+      context 'for cisco-5' do
+
+        before :each do
+          allow( instance ).to receive( :[] ).with( :platform ).and_return( 'cisco-5' )
+        end
+
+        it 'ends with the :vrf host parameter' do
+          vrf_answer = 'vrf_answer_135246'
+          allow( instance ).to receive( :[] ).with( :vrf ).and_return( vrf_answer )
+          answer_test = instance.prepend_commands( 'fake_command' )
+          expect( answer_test ).to match( /#{vrf_answer}$/ )
+        end
+
+        it 'begins with sourcing the /etc/profile script' do
+          allow( instance ).to receive( :[] ).with( :vrf ).and_return( nil )
+          answer_test = instance.prepend_commands( 'fake_command' )
+          expect( answer_test ).to match( /^#{Regexp.escape('source /etc/profile; ')}/ )
+        end
+
+        it 'uses sudo at the beginning of the actual command to execute' do
+          allow( instance ).to receive( :[] ).with( :vrf ).and_return( nil )
+          answer_test = instance.prepend_commands( 'fake_command' )
+          command_start_index = answer_test.index( '; ' ) + 2
+          command_actual = answer_test[command_start_index, answer_test.length - command_start_index]
+          expect( command_actual ).to match( /^sudo / )
+        end
       end
     end
   end

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -47,6 +47,11 @@ module Beaker
         expect( instance.repo_type ).to be === 'deb'
       end
 
+      it 'returns correctly for cisco platforms' do
+        @platform = 'cisco-5-x86_64'
+        expect( instance.repo_type ).to be === 'rpm'
+      end
+
       it 'errors for all other platform types' do
         @platform = 'eos-4-x86_64'
         expect {
@@ -65,6 +70,11 @@ module Beaker
       it 'returns correctly for debian-based platforms' do
         @platform = 'debian-6-x86_64'
         expect( instance.package_config_dir ).to be === '/etc/apt/sources.list.d'
+      end
+
+      it 'returns correctly for cisco platforms' do
+        @platform = 'cisco-5-x86_64'
+        expect( instance.package_config_dir ).to be === '/etc/yum/repos.d/'
       end
 
       it 'errors for all other platform types' do
@@ -102,16 +112,23 @@ module Beaker
 
       it 'builds the filename correctly for debian-based platforms' do
         @platform = 'debian-8-x86_64'
-        filename = instance.repo_filename( 'pkg_name', 'pkg_version9' )
-        correct = 'pl-pkg_name-pkg_version9-jessie.list'
+        filename = instance.repo_filename( 'pkg_name', 'pkg_version10' )
+        correct = 'pl-pkg_name-pkg_version10-jessie.list'
         expect( filename ).to be === correct
       end
 
       it 'uses the variant for the codename on the cumulus platform' do
         @platform = 'cumulus-2.5-x86_64'
-        filename = instance.repo_filename( 'pkg_name', 'pkg_version10' )
-        correct = 'pl-pkg_name-pkg_version10-cumulus.list'
+        filename = instance.repo_filename( 'pkg_name', 'pkg_version11' )
+        correct = 'pl-pkg_name-pkg_version11-cumulus.list'
         expect( filename ).to be === correct
+      end
+
+      it 'adds wrlinux to variant on cisco platforms' do
+        @platform = 'cisco-5-x86_64'
+        allow( instance ).to receive( :is_pe? ) { false }
+        filename = instance.repo_filename( 'pkg_name', 'pkg_version12' )
+        expect( filename ).to match( /sion12\-cisco\-wrlinux\-/ )
       end
 
       it 'errors for non-el or debian-based platforms' do

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -130,6 +130,7 @@ module Beaker
       it "uses yum on fedora-20" do
         @opts = {'platform' => 'fedora-20-is-me'}
         pkg = 'fedora_package'
+        allow( instance ).to receive( :command_prefix ).and_return( '' )
         expect( Beaker::Command ).to receive(:new).with("yum -y  install #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package(pkg) ).to be == "hello"
@@ -139,6 +140,16 @@ module Beaker
         @opts = {'platform' => 'fedora-22-is-me'}
         pkg = 'fedora_package'
         expect( Beaker::Command ).to receive(:new).with("dnf -y  install #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.install_package(pkg) ).to be == "hello"
+      end
+
+      it 'uses the command prefix on el-based systems' do
+        @opts = {'platform' => 'fedora-20-is-me'}
+        pkg = 'fedora_package'
+        command_prefix_value = 'command_prefix_value_cisco'
+        allow( instance ).to receive( :command_prefix ).and_return( command_prefix_value )
+        expect( Beaker::Command ).to receive(:new).with("#{command_prefix_value}yum -y  install #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package(pkg) ).to be == "hello"
       end

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -130,7 +130,6 @@ module Beaker
       it "uses yum on fedora-20" do
         @opts = {'platform' => 'fedora-20-is-me'}
         pkg = 'fedora_package'
-        allow( instance ).to receive( :command_prefix ).and_return( '' )
         expect( Beaker::Command ).to receive(:new).with("yum -y  install #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package(pkg) ).to be == "hello"
@@ -143,17 +142,6 @@ module Beaker
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package(pkg) ).to be == "hello"
       end
-
-      it 'uses the command prefix on el-based systems' do
-        @opts = {'platform' => 'fedora-20-is-me'}
-        pkg = 'fedora_package'
-        command_prefix_value = 'command_prefix_value_cisco'
-        allow( instance ).to receive( :command_prefix ).and_return( command_prefix_value )
-        expect( Beaker::Command ).to receive(:new).with("#{command_prefix_value}yum -y  install #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
-        expect( instance.install_package(pkg) ).to be == "hello"
-      end
-
     end
 
     context "install_package_with_rpm" do

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -27,13 +27,13 @@ module Beaker
     describe '#prepend_commands' do
       it 'sets spacing correctly if both parts are defined' do
         allow( instance ).to receive( :is_cygwin? ).and_return( true )
-        command_str = instance.prepend_commands( 'pants', { :cmd_exe => true } )
+        command_str = instance.prepend_commands( 'command', 'pants', { :cmd_exe => true } )
         expect( command_str ).to be === 'cmd.exe /c pants'
       end
 
       it 'sets spacing empty if one is not supplied' do
         allow( instance ).to receive( :is_cygwin? ).and_return( true )
-        command_str = instance.prepend_commands( 'pants' )
+        command_str = instance.prepend_commands( 'command', 'pants' )
         expect( command_str ).to be === 'pants'
       end
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -423,27 +423,6 @@ module Beaker
         host.do_scp_to *args
       end
 
-      it 'calls for host scp prep operations before SCPing happens' do
-        create_files(['source'])
-        logger = host[:logger]
-        conn = double(:connection)
-        @options = { :logger => logger }
-        host.instance_variable_set :@connection, conn
-        args = [ '/source', 'target', {} ]
-        conn_args = args + [ nil ]
-
-        expect( host ).to receive( :scp_prep_operations ).ordered
-        allow( logger ).to receive(:trace)
-        expect( conn ).to receive(:scp_to).ordered.with(
-          *conn_args
-        ).and_return(Beaker::Result.new(host, 'output!'))
-        allow( conn ).to receive(:ip).and_return(host['ip'])
-        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
-        allow( conn ).to receive(:hostname).and_return(host.name)
-
-        host.do_scp_to *args
-      end
-
       it 'calls for host scp post operations after SCPing happens' do
         create_files(['source'])
         logger = host[:logger]

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -423,6 +423,48 @@ module Beaker
         host.do_scp_to *args
       end
 
+      it 'calls for host scp prep operations before SCPing happens' do
+        create_files(['source'])
+        logger = host[:logger]
+        conn = double(:connection)
+        @options = { :logger => logger }
+        host.instance_variable_set :@connection, conn
+        args = [ '/source', 'target', {} ]
+        conn_args = args + [ nil ]
+
+        expect( host ).to receive( :scp_prep_operations ).ordered
+        allow( logger ).to receive(:trace)
+        expect( conn ).to receive(:scp_to).ordered.with(
+          *conn_args
+        ).and_return(Beaker::Result.new(host, 'output!'))
+        allow( conn ).to receive(:ip).and_return(host['ip'])
+        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+        allow( conn ).to receive(:hostname).and_return(host.name)
+
+        host.do_scp_to *args
+      end
+
+      it 'calls for host scp post operations after SCPing happens' do
+        create_files(['source'])
+        logger = host[:logger]
+        conn = double(:connection)
+        @options = { :logger => logger }
+        host.instance_variable_set :@connection, conn
+        args = [ '/source', 'target', {} ]
+        conn_args = args + [ nil ]
+
+        allow( logger ).to receive(:trace)
+        expect( conn ).to receive(:scp_to).ordered.with(
+          *conn_args
+        ).and_return(Beaker::Result.new(host, 'output!'))
+        allow( conn ).to receive(:ip).and_return(host['ip'])
+        allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
+        allow( conn ).to receive(:hostname).and_return(host.name)
+        expect( host ).to receive( :scp_post_operations ).ordered
+
+        host.do_scp_to *args
+      end
+
       it 'throws an IOError when the file given doesn\'t exist' do
         expect { host.do_scp_to "/does/not/exist", "does/not/exist/over/there", {} }.to raise_error(IOError)
       end


### PR DESCRIPTION
Adds support for both puppet-agent install methods on wrlinux-5:
`install_puppet_agent_on` (from yum.puppetlabs.com)
`install_puppet_agent_dev_repo_on` (from builds.puppetlabs.net)