### PR TITLE
Add info log when teardown begins

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -136,6 +136,7 @@ module Beaker
             rescue StandardError, ScriptError, SignalException => e
               log_and_fail_test(e)
             ensure
+              @logger.info('Begin teardown')
               @teardown_procs.each do |teardown|
                 begin
                   teardown.call
@@ -143,6 +144,7 @@ module Beaker
                   log_and_fail_test(e)
                 end
               end
+              @logger.info('End teardown')
             end
           end
           @sublog = @logger.get_sublog


### PR DESCRIPTION
I didn't consult anyone on this, but it is confusing to me when looking at logs, when my test case completes and when the teardown begins.  This message would help remove some of that confusion, especially in the case where you run into https://tickets.puppetlabs.com/browse/BKR-570