### PR TITLE
(maint) move recipes from confluence

### DIFF
--- a/docs/Beaker-Recipes.md
+++ b/docs/Beaker-Recipes.md
@@ -1,0 +1,13 @@
+# What is This?
+
+Patterns for best-use solutions to (not so) common problems
+
+## How do i set persistent environment variables on a SUT, such as PATH?
+    host.add_env_var('PATH', '/opt/puppetlabs/bin:$PATH')
+
+## How do i run commands on a SUT as a non-root user?
+(warning) this should be abstracted into a beaker helper, or part of on():   BKR-168 - Beaker::DSL::Helpers needs "as" method READY FOR ENGINEERING
+
+###create the user, then su with --command:
+    on(host, puppet("resource user #{username} ensure=present managehome-true"))
+    on(host, "su #{username} --command '#{command}'")

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@
   * [Let's Write a Test!](Lets-Write-a-Test.md)
   * [Access The Live Test Console with Pry](Access-the-Live-Test-Console-with-Pry.md)
   * [Test Tagging](Beaker-Test-Tagging.md)
+  * [Recipes](Beaker-Recipes.md)
 * [Beaker vs. Beaker-rspec](beaker-vs.-beaker-rspec.md)
 * [How to Write a Beaker Test for a Module Using beaker-rspec](How-to-Write-a-Beaker-Test-for-a-Module.md)
 


### PR DESCRIPTION
This change adds a document containing some recipes for solving common
problems with Beaker.  It is currently housed on confluence.