### PR TITLE
(MAINT) Add README Information for Beaker Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ See [Beaker Installation](https://github.com/puppetlabs/beaker/wiki/Beaker-Insta
 
 Documentation for Beaker can be found in this repository in [the docs/ folder](docs/README.md).
 
+#Beaker Libraries
+
+Beaker functionality has been extended through the use of libraries available as gems. See the
+[complete list](docs/Beaker-Libraries.md) for more details.
+
 #Beaker API
 
 [RubyDoc Beaker Documentation Server](http://rubydoc.info/github/puppetlabs/beaker/frames)

--- a/docs/Beaker-Libraries.md
+++ b/docs/Beaker-Libraries.md
@@ -1,0 +1,8 @@
+# Beaker Libraries
+The QA team at Puppet Labs has written several libraries that extends the functionality provided
+by Beaker.
+
+| Name               | Description                                                         | Docs                                                            |
+|:-------------------|:--------------------------------------------------------------------|:----------------------------------------------------------------|
+| Master Manipulator | A Beaker library for changing configuration on a Puppet Master      | [Github Repo](https://github.com/puppetlabs/master_manipulator) |
+| beaker_windows     | A Beaker library that provides helpers for testing on Windows hosts | [Github Repo](https://github.com/puppetlabs/beaker_windows)     |

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
   * [Test Tagging](Beaker-Test-Tagging.md)
 * [Beaker vs. Beaker-rspec](beaker-vs.-beaker-rspec.md)
 * [How to Write a Beaker Test for a Module Using beaker-rspec](How-to-Write-a-Beaker-Test-for-a-Module.md)
+* [Beaker Libraries](Beaker-Libraries.md)
 
 ## Other Resources
 


### PR DESCRIPTION
Update the Beaker docs README to point to the public Beaker libraries.