### PR TITLE
added option to skip provisioning of a host

### DIFF
--- a/lib/beaker/hypervisor/vsphere.rb
+++ b/lib/beaker/hypervisor/vsphere.rb
@@ -18,7 +18,7 @@ module Beaker
       vsphere_helper = VsphereHelper.new( vsphere_credentials )
 
       vsphere_vms = {}
-      @hosts.each do |h|
+      @hosts.reject do |host| host[:provision] == false end.each do |h|
         name = h["vmname"] || h.name
         vsphere_vms[name] = h["snapshot"]
       end

--- a/spec/beaker/hypervisor/vsphere_spec.rb
+++ b/spec/beaker/hypervisor/vsphere_spec.rb
@@ -58,6 +58,20 @@ module Beaker
 
       end
 
+      it 'does not provisions hosts if provision is set to false' do
+        MockVsphereHelper.powerOff
+        hosts = make_hosts()
+        hosts[0]["provision"] = false
+        vsphere = Beaker::Vsphere.new( hosts, make_opts )
+
+        vsphere.provision
+
+        hosts.each do |host|
+          expect( MockVsphereHelper.find_vm( host.name ).powerState ) == "poweredOff"
+        end
+
+      end
+
     end
 
     describe "#cleanup" do


### PR DESCRIPTION
For Puppet beaker testing I want to reuse a puppetmaster host in vsphere. I do not want it to reset to a specific point in time, because it would require updating all puppet modules again which costs time. 
From beaker-rspec I need to copy resources to the puppetmaster like hieradata, so having the host available through the nodeset config is really helpful.

I have added a parameter `provision` to skip vsphere provisioning, but still be able to reach the host from rspec.