### PR TITLE
(maint) Fix Windows user_list functionality

### DIFF
--- a/lib/beaker/host/pswindows/user.rb
+++ b/lib/beaker/host/pswindows/user.rb
@@ -5,7 +5,7 @@ module PSWindows::User
     execute('cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value') do |result|
       users = []
       result.stdout.each_line do |line|
-        users << (line.match(/^Name=([\w ]+)/) or next)[1]
+        users << (line.match(/^Name=(.+)/) or next)[1]
       end
 
       yield result if block_given?

--- a/lib/beaker/host/windows/user.rb
+++ b/lib/beaker/host/windows/user.rb
@@ -5,7 +5,7 @@ module Windows::User
     execute('cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value') do |result|
       users = []
       result.stdout.each_line do |line|
-        users << (line.match(/^Name=([\w ]+)/) or next)[1]
+        users << (line.match(/^Name=(.+)/) or next)[1]
       end
 
       yield result if block_given?

--- a/spec/beaker/host/pswindows/user_spec.rb
+++ b/spec/beaker/host/pswindows/user_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+class PSWindowsUserTest
+  include PSWindows::User
+end
+
+describe PSWindowsUserTest do
+  let( :wmic_output ) do <<-EOS
+
+
+
+
+Name=Administrator
+
+
+
+
+
+Name=bob foo
+
+
+
+
+
+Name=bob-dash
+
+
+
+
+
+Name=bob.foo
+
+
+
+
+
+Name=cyg_server
+
+
+
+
+
+
+
+
+EOS
+  end
+  let( :command )  { 'cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value' }
+  let( :host ) { double.as_null_object }
+  let( :result ) { Beaker::Result.new( host, command ) }
+
+  describe '#user_list' do
+
+    it 'returns user names list correctly' do
+      result.stdout = wmic_output
+      expect( subject ).to receive( :execute ).with( command ).and_yield(result)
+      expect( subject.user_list ).to be === ['Administrator', 'bob foo', 'bob-dash', 'bob.foo', 'cyg_server']
+    end
+
+    it 'yields correctly with the result object' do
+      result.stdout = wmic_output
+      expect( subject ).to receive( :execute ).and_yield(result)
+      subject.user_list { |result|
+        expect( result.stdout ).to be === wmic_output
+      }
+    end
+
+  end
+
+end

--- a/spec/beaker/host/windows/user_spec.rb
+++ b/spec/beaker/host/windows/user_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+class WindowsUserTest
+  include Windows::User
+end
+
+describe WindowsUserTest do
+  let( :wmic_output ) do <<-EOS
+
+
+
+
+Name=Administrator
+
+
+
+
+
+Name=bob foo
+
+
+
+
+
+Name=bob-dash
+
+
+
+
+
+Name=bob.foo
+
+
+
+
+
+Name=cyg_server
+
+
+
+
+
+
+
+
+EOS
+  end
+  let( :command )  { 'cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value' }
+  let( :host ) { double.as_null_object }
+  let( :result ) { Beaker::Result.new( host, command ) }
+
+  describe '#user_list' do
+
+    it 'returns user names list correctly' do
+      result.stdout = wmic_output
+      expect( subject ).to receive( :execute ).with( command ).and_yield(result)
+      expect( subject.user_list ).to be === ['Administrator', 'bob foo', 'bob-dash', 'bob.foo', 'cyg_server']
+    end
+
+    it 'yields correctly with the result object' do
+      result.stdout = wmic_output
+      expect( subject ).to receive( :execute ).and_yield(result)
+      subject.user_list { |result|
+        expect( result.stdout ).to be === wmic_output
+      }
+    end
+
+  end
+
+end


### PR DESCRIPTION
 - Existing functionality used an overly restrictive regex that didn't
   account for characters like - or . in Windows user names, which are
   completely valid.

   Use a less restrictive regex to capture the value correctly.  The
   results of wmic always include the username immediately after the
   = in the Name= string