### PR TITLE
(BKR-696) Fix :ignore corruption in host.rb

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -482,10 +482,10 @@ module Beaker
       end
 
       if opts.has_key?(:ignore) and not opts[:ignore].empty?
-        opts[:ignore].map! do |value|
+        exclude_list = opts[:ignore].map do |value|
           "--exclude '#{value}'"
         end
-        rsync_args << opts[:ignore].join(' ')
+        rsync_args << exclude_list.join(' ')
       end
 
       # We assume that the *contents* of the directory 'from_path' needs to be


### PR DESCRIPTION
do_rsync_to was overwriting its :ignore option,
which broke things when it was called in a loop.