### PR TITLE
(BKR-48) Change how --dry_run is defined - should not be global variable.

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -265,8 +265,17 @@ module Beaker
     end
 
     def exec command, options={}
+      result = nil
       # I've always found this confusing
       cmdline = command.cmd_line(self)
+
+      # use the value of :dry_run passed to the method unless
+      # undefined, then use parsed @options hash.
+      options[:dry_run] ||= @options[:dry_run]
+
+      if options[:dry_run]
+        @logger.debug "\n Running in :dry_run mode. Command #{cmdline} not executed."
+      end
 
       if options[:silent]
         output_callback = nil
@@ -279,11 +288,10 @@ module Beaker
         end
       end
 
-      unless $dry_run
+      unless options[:dry_run]
         # is this returning a result object?
         # the options should come at the end of the method signature (rubyism)
         # and they shouldn't be ssh specific
-        result = nil
 
         @logger.step_in()
         seconds = Benchmark.realtime {
@@ -320,9 +328,8 @@ module Beaker
             raise CommandFailure, "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{@options[:trace_limit]} lines of output were:\n#{result.formatted_output(@options[:trace_limit])}"
           end
         end
-        # Danger, so we have to return this result?
-        result
       end
+      result
     end
 
     # scp files from the localhost to this test host, if a directory is provided it is recursively copied.
@@ -343,7 +350,18 @@ module Beaker
     #   do_scp_to('source/file.rb', 'target', { :ignore => 'file.rb' }
     #   -> will result in not files copyed to the host, all are ignored
     def do_scp_to source, target_path, options
+      result = nil
       target = self.scp_path( target_path )
+
+      # use the value of :dry_run passed to the method unless
+      # undefined, then use parsed @options hash.
+      options[:dry_run] ||= @options[:dry_run]
+
+      if options[:dry_run]
+        @logger.debug "\n Running in :dry_run mode. localhost $ scp #{source} #{@name}:#{target} not executed."
+        return result
+      end
+
       @logger.notify "localhost $ scp #{source} #{@name}:#{target} {:ignore => #{options[:ignore]}}"
 
       result = Result.new(@name, [source, target])
@@ -371,7 +389,7 @@ module Beaker
           result.exit_code = 1
         end
         if source_file
-          result = connection.scp_to(source_file, target, options, $dry_run)
+          result = connection.scp_to(source_file, target, options)
           @logger.trace result.stdout
         end
       else # a directory with ignores
@@ -406,7 +424,7 @@ module Beaker
           else
             file_path = File.join(target, File.dirname(s))
           end
-          result = connection.scp_to(s, file_path, options, $dry_run)
+          result = connection.scp_to(s, file_path, options)
           @logger.trace result.stdout
         end
       end
@@ -416,9 +434,18 @@ module Beaker
     end
 
     def do_scp_from source, target, options
+      result = nil
+      # use the value of :dry_run passed to the method unless
+      # undefined, then use parsed @options hash.
+      options[:dry_run] ||= @options[:dry_run]
+
+      if options[:dry_run]
+        @logger.debug "\n Running in :dry_run mode. localhost $ scp #{@name}:#{source} #{target} not executed."
+        return result
+      end
 
       @logger.debug "localhost $ scp #{@name}:#{source} #{target}"
-      result = connection.scp_from(source, target, options, $dry_run)
+      result = connection.scp_from(source, target, options)
       @logger.debug result.stdout
       return result
     end

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -275,6 +275,8 @@ module Beaker
 
       if options[:dry_run]
         @logger.debug "\n Running in :dry_run mode. Command #{cmdline} not executed."
+        result = Beaker::NullResult.new(self, command)
+        return result
       end
 
       if options[:silent]
@@ -350,7 +352,6 @@ module Beaker
     #   do_scp_to('source/file.rb', 'target', { :ignore => 'file.rb' }
     #   -> will result in not files copyed to the host, all are ignored
     def do_scp_to source, target_path, options
-      result = nil
       target = self.scp_path( target_path )
 
       # use the value of :dry_run passed to the method unless
@@ -358,8 +359,9 @@ module Beaker
       options[:dry_run] ||= @options[:dry_run]
 
       if options[:dry_run]
-        @logger.debug "\n Running in :dry_run mode. localhost $ scp #{source} #{@name}:#{target} not executed."
-        return result
+        scp_cmd = "scp #{source} #{@name}:#{target}"
+        @logger.debug "\n Running in :dry_run mode. localhost $ #{scp_cmd} not executed."
+        return NullResult.new(self, scp_cmd)
       end
 
       @logger.notify "localhost $ scp #{source} #{@name}:#{target} {:ignore => #{options[:ignore]}}"
@@ -434,14 +436,14 @@ module Beaker
     end
 
     def do_scp_from source, target, options
-      result = nil
       # use the value of :dry_run passed to the method unless
       # undefined, then use parsed @options hash.
       options[:dry_run] ||= @options[:dry_run]
 
       if options[:dry_run]
-        @logger.debug "\n Running in :dry_run mode. localhost $ scp #{@name}:#{source} #{target} not executed."
-        return result
+        scp_cmd = "scp #{@name}:#{source} #{target}"
+        @logger.debug "\n Running in :dry_run mode. localhost $ #{scp_cmd} not executed."
+        return  NullResult.new(self, scp_cmd)
       end
 
       @logger.debug "localhost $ scp #{@name}:#{source} #{target}"

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -154,7 +154,6 @@ module Beaker
                    'Report what would happen on targets',
                    '(default: false)' do |bool|
             @cmd_options[:dry_run] = bool
-            $dry_run = bool
           end
 
           opts.on '--fail-mode [MODE]',

--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -48,4 +48,11 @@ module Beaker
       range.include?(@exit_code)
     end
   end
+
+  class NullResult < Result
+    def initialize(host, cmd)
+      super(host, cmd)
+      @exit_code = 0
+    end
+  end
 end

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -162,11 +162,6 @@ module Beaker
                 stderr_callback = stdout_callback
 
       result = Result.new(@hostname, command)
-      # why are we getting to this point on a dry run anyways?
-      # also... the host creates connections through the class method,
-      # which automatically connects, so you can't do a dry run unless you also
-      # can connect to your hosts?
-      return result if options[:dry_run]
 
       @ssh.open_channel do |channel|
         request_terminal_for( channel, command ) if options[:pty]
@@ -267,8 +262,7 @@ module Beaker
       channel.eof!
     end
 
-    def scp_to source, target, options = {}, dry_run = false
-      return if dry_run
+    def scp_to source, target, options = {}
 
       local_opts = options.dup
       if local_opts[:recursive].nil?
@@ -278,10 +272,10 @@ module Beaker
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
+
       @ssh.scp.upload! source, target, local_opts do |ch, name, sent, total|
         result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
       end
-
       # Setting these values allows reporting via result.log(test_name)
       result.stdout << "  SCP'ed file #{source} to #{@hostname}:#{target}"
 
@@ -292,8 +286,7 @@ module Beaker
       return result
     end
 
-    def scp_from source, target, options = {}, dry_run = false
-      return if dry_run
+    def scp_from source, target, options = {}
 
       local_opts = options.dup
       if local_opts[:recursive].nil?
@@ -303,10 +296,10 @@ module Beaker
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
+
       @ssh.scp.download! source, target, local_opts do |ch, name, sent, total|
         result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
       end
-
       # Setting these values allows reporting via result.log(test_name)
       result.stdout << "  SCP'ed file #{@hostname}:#{source} to #{target}"
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -412,7 +412,7 @@ module Beaker
         @options = { :logger => logger }
         host.instance_variable_set :@connection, conn
         args = [ '/source', 'target', {} ]
-        conn_args = args + [ nil ]
+        conn_args = args
 
         expect( logger ).to receive(:trace)
         expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
@@ -430,7 +430,7 @@ module Beaker
         @options = { :logger => logger }
         host.instance_variable_set :@connection, conn
         args = [ '/source', 'target', {} ]
-        conn_args = args + [ nil ]
+        conn_args = args
 
         allow( logger ).to receive(:trace)
         expect( conn ).to receive(:scp_to).ordered.with(
@@ -488,7 +488,7 @@ module Beaker
           conn = double(:connection)
           @options = { :logger => logger }
           host.instance_variable_set :@connection, conn
-          args = [ source_path, target_path, {:ignore => [exclude_file]} ]
+          args = [ source_path, target_path, {:ignore => [exclude_file], :dry_run => false} ]
 
           allow( Dir ).to receive( :glob ).and_return( @fileset1 + @fileset2 )
 
@@ -498,12 +498,12 @@ module Beaker
 
           (@fileset1 + @fileset2).each do |file|
             if file !~ /#{exclude_file}/
-              file_args = [ file, File.join(created_target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file]} ]
-              conn_args = file_args + [ nil ]
+              file_args = [ file, File.join(created_target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file], :dry_run => false} ]
+              conn_args = file_args
               expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
             else
-              file_args = [ file, File.join(created_target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file]} ]
-              conn_args = file_args + [ nil ]
+              file_args = [ file, File.join(created_target_path, File.dirname(file).gsub(source_path,'')), {:ignore => [exclude_file], :dry_run => false} ]
+              conn_args = file_args
               expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
           end
@@ -553,7 +553,7 @@ module Beaker
           conn = double(:connection)
           @options = { :logger => logger }
           host.instance_variable_set :@connection, conn
-          args = [ 'tmp', 'target', {:ignore => [exclude_file]} ]
+          args = [ 'tmp', 'target', {:ignore => [exclude_file], :dry_run => false} ]
 
           allow( Dir ).to receive( :glob ).and_return( @fileset1 + @fileset2 )
 
@@ -562,19 +562,18 @@ module Beaker
           expect( host ).to receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset1 + @fileset2).each do |file|
             if file !~ /#{exclude_file}/
-              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
-              conn_args = file_args + [ nil ]
+              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file], :dry_run => false} ]
+              conn_args = file_args
               expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
             else
-              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
-              conn_args = file_args + [ nil ]
+              file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file], :dry_run => false} ]
+              conn_args = file_args
               expect( conn ).to_not receive(:scp_to).with( *conn_args )
             end
           end
           allow( conn ).to receive(:ip).and_return(host['ip'])
           allow( conn ).to receive(:vmhostname).and_return(host['vmhostname'])
           allow( conn ).to receive(:hostname).and_return(host.name)
-
           host.do_scp_to *args
         end
 
@@ -584,7 +583,7 @@ module Beaker
           conn = double(:connection)
           @options = { :logger => logger }
           host.instance_variable_set :@connection, conn
-          args = [ 'tmp', 'target', {:ignore => [exclude_file]} ]
+          args = [ 'tmp', 'target', {:ignore => [exclude_file], :dry_run => false} ]
 
           allow( Dir ).to receive( :glob ).and_return( @fileset1 + @fileset2 )
 
@@ -592,13 +591,13 @@ module Beaker
           expect( host ).to_not receive( :mkdir_p ).with('target/tmp/tests')
           expect( host ).to receive( :mkdir_p ).with('target/tmp/tests2')
           (@fileset1).each do |file|
-            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
-            conn_args = file_args + [ nil ]
+            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file], :dry_run => false} ]
+            conn_args = file_args
             expect( conn ).to_not receive(:scp_to).with( *conn_args )
           end
           (@fileset2).each do |file|
-            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file]} ]
-            conn_args = file_args + [ nil ]
+            file_args = [ file, File.join('target', File.dirname(file)), {:ignore => [exclude_file], :dry_run => false} ]
+            conn_args = file_args
             expect( conn ).to receive(:scp_to).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))
           end
 
@@ -617,7 +616,7 @@ module Beaker
         @options = { :logger => logger }
         host.instance_variable_set :@connection, conn
         args = [ 'source', 'target', {} ]
-        conn_args = args + [ nil ]
+        conn_args = args
 
         expect( logger ).to receive(:debug)
         expect( conn ).to receive(:scp_from).with( *conn_args ).and_return(Beaker::Result.new(host, 'output!'))


### PR DESCRIPTION
Removed $dry_run as a global variable.
Should be able to overwrite value from calling methods or use the parsed options hash value as default.
Returning from the original method if dry_run instead of continuing on and attempting a host connection.