### PR TITLE
(BKR-704) Allow relative `mount_folders` in docker

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -84,7 +84,7 @@ module Beaker
         unless host['mount_folders'].nil?
           container_opts['HostConfig'] ||= {}
           container_opts['HostConfig']['Binds'] = host['mount_folders'].values.map do |mount|
-            a = [ mount['host_path'], mount['container_path'] ]
+            a = [ File.expand_path(mount['host_path']), mount['container_path'] ]
             a << mount['opts'] if mount.has_key?('opts')
             a.join(':')
           end

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -220,6 +220,14 @@ module Beaker
               'container_path' => '/different_mount',
               'opts' => 'rw',
             },
+            'mount4' => {
+              'host_path' => './',
+              'container_path' => '/relative_mount',
+            },
+            'mount5' => {
+              'host_path' => 'local_folder',
+              'container_path' => '/another_relative_mount',
+            }
           }
 
           expect( ::Docker::Container ).to receive(:create).with({
@@ -230,6 +238,8 @@ module Beaker
                 '/source_folder:/mount_point',
                 '/another_folder:/another_mount:ro',
                 '/different_folder:/different_mount:rw',
+                "#{File.expand_path('./')}:/relative_mount",
+                "#{File.expand_path('local_folder')}:/another_relative_mount",
               ]
             }
           })


### PR DESCRIPTION
Without this patch, a nodeset using relative `from:` paths under
`mount_folders:` with the `docker` hypervisor will encounter a
test-halting `Docker::Error::ClientError`.  This is a problem because
it forces docker-based nodesets to specify host-side mounts with
absolute paths, which isn't portable.

This patch fixes the issue by using Ruby's `File.expand_path()` method to
translate any relative `mount_folders:`/`from:` entries into absolute
paths before passing them on to docker.