### PR TITLE
(BKR-99) - Populate host[:timesync] with host configured value.

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -103,8 +103,10 @@ module Beaker
     #to the provided SUT for test execution to be successful.
     def configure
       return unless @options[:configure]
-      if @options[:timesync]
-        timesync(@hosts, @options)
+      block_on @hosts do |host|
+        if host[:timesync]
+          timesync(host, @options)
+        end
       end
       if @options[:root_keys]
         sync_root_keys(@hosts, @options)

--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -57,6 +57,7 @@ module Beaker
         hypervisor = provision?(@options, host_hash) ? host_hash['hypervisor'] : 'none'
         @logger.debug "Hypervisor for #{name} is #{hypervisor}"
         @machines[hypervisor] = [] unless @machines[hypervisor]
+        hostless_options[:timesync] = host_hash[:timesync] if host_hash[:timesync]!=nil
         host_itself = Beaker::Host.create(name, host_hash, hostless_options)
         host_itself.validate_setup
         @machines[hypervisor] << host_itself

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -73,6 +73,25 @@ module Beaker
       let( :hosts ) { make_hosts( { :platform => 'el-5' } ) }
       let( :hypervisor ) { Beaker::Hypervisor.new( hosts, options ) }
 
+      context 'if :timesync option set true on host' do
+        it 'does call timesync for host' do
+          hosts[0][:timesync] = true
+          allow( hypervisor ).to receive( :set_env )
+          expect( hypervisor ).to receive( :timesync ).once
+          hypervisor.configure
+        end
+      end
+
+      context 'if :timesync option set true but false on host' do
+        it 'does not call timesync for host' do
+          options[:timesync] = true
+          hosts[0][:timesync] = false
+          allow( hypervisor ).to receive( :set_env )
+          expect( hypervisor ).to_not receive( :timesync )
+          hypervisor.configure
+        end
+      end
+
       context "if :disable_iptables option set false" do
         it "does not call disable_iptables" do
           options[:disable_iptables] = false


### PR DESCRIPTION
If it has been set. Otherwise use global timesync value.

Add spec tests.

example usage (hosts file):

```
  q6zus77jx2ww8tf.delivery.puppetlabs.net:
    roles:
    - agent
    - frictionless
    timesync: false
    platform: el-6-x86_64
    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
    hypervisor: vcloud
```