### PR TITLE
(BKR-671) - Add error handing for Beaker failing to acquire a VM from vmpooler

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -127,6 +127,10 @@ module Beaker
           domain = parsed_response['domain']
 
           @hosts.each_with_index do |h, i|
+            # If one of the requested hosts is not available on vmpooler
+            if parsed_response[h['template']].nil?
+              raise "Vmpooler.provision - requested host #{h['template']} not available"
+            end
             if parsed_response[h['template']]['hostname'].is_a?(Array)
               hostname = parsed_response[h['template']]['hostname'].shift
             else

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -87,6 +87,14 @@ module Beaker
           })
     end
 
+    # Get host info hash from parsed json response
+    # @param [Hash] parsed_response hash
+    # @param [String] template string
+    # @return [Hash] Host info hash
+    def get_host_info(parsed_response, template)
+      parsed_response[template]
+    end
+
     def provision
       request_payload = {}
       start = Time.now
@@ -127,8 +135,8 @@ module Beaker
           domain = parsed_response['domain']
 
           @hosts.each_with_index do |h, i|
-            # If one of the requested hosts is not available on vmpooler
-            if parsed_response[h['template']].nil?
+            # If the requested host template is not available on vmpooler
+            if get_host_info(parsed_response, h['template']).nil?
               raise "Vmpooler.provision - requested host #{h['template']} not available"
             end
             if parsed_response[h['template']]['hostname'].is_a?(Array)

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -73,6 +73,17 @@ module Beaker
           expect( host['vmhostname'] ).to be === 'pool'
         end
       end
+
+      it 'raises an error when a host template is not found in returned json' do
+        vmpooler = Beaker::Vmpooler.new( make_hosts, make_opts )
+        host          = vmpooler.instance_variable_get(:@hosts)[0][:template]
+
+        allow( vmpooler ).to receive( :require ).and_return( true )
+        allow( vmpooler ).to receive( :sleep ).and_return( true )
+        allow( vmpooler ).to receive(:get_host_info).and_return(nil)
+
+        expect {vmpooler.provision}.to raise_error RuntimeError,"Vmpooler.provision - requested host #{host} not available"
+      end
     end
 
     describe "#cleanup" do


### PR DESCRIPTION
The issue is when one of the specified host cannot be acquired.
Raise an error and attempt again until timeout (the same as with other provisioning errors).