### PR TITLE
[DO NOT MERGE] (BKR-355) web_helpers acceptance test spike

### DIFF
--- a/acceptance/tests/base/dsl/helpers/web_helpers_test.rb
+++ b/acceptance/tests/base/dsl/helpers/web_helpers_test.rb
@@ -4,31 +4,54 @@ $LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..
 
 test_name 'dsl::helpers::web_helpers #link_exists?' do
 
-  step '#link_exists? uses SSL if it\'s used in the link' do
-    assert hosts.length > 0
+  step '#link_exists? can tell if a basic link exists' do
     host = hosts[0]
-    file_dir = create_tmpdir_on(host)
-    file_path = File.join(file_dir, 'link_exists_test01.txt')
-    puts "file path: '#{file_path}'"
-    create_remote_file(host, file_path, 'dooot dooot')
 
-    # python_check_result = on(host, 'python --version')
-    # assert python_check_result.exit_code == 0
-    # on(host, 'python -m SimpleHTTPServer &')
+    python_check_result = on(host, 'python --version')
+    assert python_check_result.exit_code == 0
+    on(host, 'nohup python -m SimpleHTTPServer 80 > pants.log < /dev/null 2>&1 &')
+    sleep(1) # needs a sleep to setup the HTTP server, otherwise not ready for request
 
-    ruby_check_result = on(host, 'ruby --version')
-    assert ruby_check_result.exit_code == 0
-    host_ruby_version = ruby_check_result.stdout.split()[1]
-    puts "ruby version: '#{host_ruby_version}'"
+    # ruby_check_result = on(host, 'ruby --version')
+    # assert ruby_check_result.exit_code == 0
+    # host_ruby_version = ruby_check_result.stdout.split()[1]
+    # puts "ruby version: '#{host_ruby_version}'"
+    #
+    # if version_is_less(host_ruby_version, '1.9.2')
+    #   http_cmd = "ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => 80, :DocumentRoot => Dir.pwd).start'"
+    # else
+    #   http_cmd = 'ruby -run -ehttpd . -p80'
+    # end
+    # http_cmd << ' &'
+    # puts "normal ssh dir: '#{on(host, 'pwd').stdout}'"
+    # on(host, http_cmd)
 
-    if version_is_less(host_ruby_version, '1.9.2')
-      http_cmd = "ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => Dir.pwd).start'"
-    else
-      http_cmd = 'ruby -run -ehttpd . -p8000'
-    end
-    http_cmd << ' &'
-    puts "normal ssh dir: '#{on(host, 'pwd').stdout}'"
-    on(host, http_cmd)
+    puts "trying assert!"
+    assert link_exists?("http://#{host}")
+    puts "done trying assert"
   end
+
+#   step '#link_exists? can use an ssl link' do
+#     host = hosts[0]
+#     ssl_server_file = <<END
+# import BaseHTTPServer, SimpleHTTPServer
+# import ssl
+#
+# httpd = BaseHTTPServer.HTTPServer(('localhost', 443), SimpleHTTPServer.SimpleHTTPRequestHandler)
+# httpd.socket = ssl.wrap_socket (httpd.socket, certfile='path/to/localhost.pem', server_side=True)
+# httpd.serve_forever()
+# END
+#
+#     file_dir = create_tmpdir_on(host)
+#     file_path = File.join(file_dir, 'ssl_server.py')
+#     puts "file path: '#{file_path}'"
+#     create_remote_file(host, file_path, ssl_server_file)
+#     on(host, "nohup python #{file_path} > ssl.log < /dev/null 2>&1 &")
+#     sleep(1)
+#
+#     assert link_exists?("https://#{host}")
+#   end
+
+
 
 end

--- a/acceptance/tests/base/dsl/helpers/web_helpers_test.rb
+++ b/acceptance/tests/base/dsl/helpers/web_helpers_test.rb
@@ -1,0 +1,34 @@
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', '..', '..', 'lib'))
+
+# require 'helpers/test_helper'
+
+test_name 'dsl::helpers::web_helpers #link_exists?' do
+
+  step '#link_exists? uses SSL if it\'s used in the link' do
+    assert hosts.length > 0
+    host = hosts[0]
+    file_dir = create_tmpdir_on(host)
+    file_path = File.join(file_dir, 'link_exists_test01.txt')
+    puts "file path: '#{file_path}'"
+    create_remote_file(host, file_path, 'dooot dooot')
+
+    # python_check_result = on(host, 'python --version')
+    # assert python_check_result.exit_code == 0
+    # on(host, 'python -m SimpleHTTPServer &')
+
+    ruby_check_result = on(host, 'ruby --version')
+    assert ruby_check_result.exit_code == 0
+    host_ruby_version = ruby_check_result.stdout.split()[1]
+    puts "ruby version: '#{host_ruby_version}'"
+
+    if version_is_less(host_ruby_version, '1.9.2')
+      http_cmd = "ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => 8000, :DocumentRoot => Dir.pwd).start'"
+    else
+      http_cmd = 'ruby -run -ehttpd . -p8000'
+    end
+    http_cmd << ' &'
+    puts "normal ssh dir: '#{on(host, 'pwd').stdout}'"
+    on(host, http_cmd)
+  end
+
+end

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -21,11 +21,15 @@ module Beaker
           require "net/http"
           require "net/https"
           require "open-uri"
+          puts "link_exists? link: #{link}"
           url = URI.parse(link)
           http = Net::HTTP.new(url.host, url.port)
           http.use_ssl = (url.scheme == 'https')
+          puts "link_exists? request_uri: #{url.request_uri}"
           http.start do |http|
-            return http.head(url.request_uri).code == "200"
+            head_code = http.head(url.request_uri).code
+            puts "link_exists? head code: #{head_code}"
+            return head_code == "200"
           end
         end
 


### PR DESCRIPTION
This is obviously not merge-able, but it was an old branch I had lying around from an earlier spike, and I'd like to have a conversation around what is probably a better way to setup these acceptance tests.

I don't think that requiring python on a beaker coordinator for acceptance testing purposes is a good idea, it's just the fastest way I know to get a simple HTTP server up.  I'm sure webrick has an analog to this, and if this is the path we want to take, I'll look into setting that up, but my real question is "is this the right way we should go about testing this type of functionality (testing retrieval of off-host resources/artifacts)?"

@puppetlabs/beaker ?