### PR TITLE
(BKR-451) Fix broken logger warnings

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -209,7 +209,7 @@ module Unix::Pkg
     codename = self['platform'].codename
 
     if codename.nil?
-      @logger.warning "Could not determine codename for debian platform #{self['platform']}. Skipping deployment of repo #{name}"
+      @logger.warn "Could not determine codename for debian platform #{self['platform']}. Skipping deployment of repo #{name}"
       return
     end
 
@@ -248,7 +248,7 @@ module Unix::Pkg
   #       params
   def deploy_package_repo(path, name, version)
     if not File.exists? path
-      @logger.warning "Was asked to deploy package repository from #{path}, but it doesn't exist!"
+      @logger.warn "Was asked to deploy package repository from #{path}, but it doesn't exist!"
       return
     end
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -28,8 +28,61 @@ module Beaker
     let (:logger)   { double( 'logger' ).as_null_object }
     let (:instance) { UnixPkgTest.new(opts, logger) }
 
-    context "check_for_package" do
+    context 'Package deployment tests' do
+      path = '/some/file/path'
+      name = 'package_name'
+      version = '1.0.0'
 
+      describe '#deploy_package_repo' do
+
+        it 'returns a warning if there is no file at the path specified' do
+          expect(logger).to receive(:warn)
+          allow(File).to receive(:exists?).with(path).and_return(false)
+          instance.deploy_package_repo(path,name,version)
+        end
+
+        it 'calls #deploy_apt_repo for debian systems' do
+          @opts = {'platform' => 'ubuntu-is-me'}
+          expect(instance).to receive(:deploy_apt_repo)
+          allow(File).to receive(:exists?).with(path).and_return(true)
+          instance.deploy_package_repo(path,name,version)
+        end
+
+        it 'calls #deploy_yum_repo for el systems' do
+          @opts = {'platform' => 'el-is-me'}
+          expect(instance).to receive(:deploy_yum_repo)
+          allow(File).to receive(:exists?).with(path).and_return(true)
+          instance.deploy_package_repo(path,name,version)
+        end
+
+        it 'calls #deploy_zyp_repo for sles systems' do
+          @opts = {'platform' => 'sles-is-me'}
+          expect(instance).to receive(:deploy_zyp_repo)
+          allow(File).to receive(:exists?).with(path).and_return(true)
+          instance.deploy_package_repo(path,name,version)
+        end
+
+        it 'raises an error for unsupported systems' do
+          @opts = {'platform' => 'windows-is-me'}
+          allow(File).to receive(:exists?).with(path).and_return(true)
+          expect{instance.deploy_package_repo(path,name,version)}.to raise_error(RuntimeError)
+        end
+      end
+
+      describe '#deploy_apt_repo' do
+
+        it 'warns and exits when no codename exists for the debian platform' do
+          @opts = {'platform' => 'ubuntu-is-me'}
+          expect(logger).to receive(:warn)
+          allow(@opts['platform']).to receive(:codename).and_return(nil)
+          expect(instance).to receive(:deploy_apt_repo).and_return(instance.deploy_apt_repo(path,name,version))
+          allow(File).to receive(:exists?).with(path).and_return(true)
+          instance.deploy_package_repo(path,name,version)
+        end
+      end
+    end
+
+    context "check_for_package" do
       it "checks correctly on sles" do
         @opts = {'platform' => 'sles-is-me'}
         pkg = 'sles_package'


### PR DESCRIPTION
The `warning` methods in `deploy_package_repo` should have been simply
`warn`. This PR changes them to warn and adds appropriate spec testing
for the methods to ensure they `warn` correctly.