### PR TITLE
(maint) Improves error message for Docker failure

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -23,7 +23,7 @@ module Beaker
       begin
         ::Docker.validate_version!
       rescue Excon::Errors::SocketError => e
-        raise "Docker instance not connectable.\nError was: #{e}\nIf you are on OSX, you might not have Boot2Docker setup correctly\nCheck your DOCKER_HOST variable has been set"
+        raise "Docker instance not connectable.\nError was: #{e}\nCheck your DOCKER_HOST variable has been set\nIf you are on OSX or Windows, you might not have Docker Machine setup correctly: https://docs.docker.com/machine/\n"
       end
 
       # Pass on all the logging from docker-api to the beaker logger instance

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -93,6 +93,8 @@ module Beaker
       end
       it 'should fail when docker not present' do
         expect { docker }.to raise_error(RuntimeError, /Docker instance not connectable./)
+        expect { docker }.to raise_error(RuntimeError, /Check your DOCKER_HOST variable has been set/)
+        expect { docker }.to raise_error(RuntimeError, /If you are on OSX or Windows, you might not have Docker Machine setup correctly/)
         expect { docker }.to raise_error(RuntimeError, /Error was: oops/)
       end
     end


### PR DESCRIPTION
* Frontload the DOCKER_HOST variable, as it's the easiest thing to check
* boot2docker-cli is deprecated (https://github.com/boot2docker/boot2docker-cli#deprecated)
* Error could also occur on Windows