### PR TITLE
(BKR-715) Use puppet_agent_version for MSI from dev repos

### DIFF
--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -65,7 +65,13 @@ module Windows::Pkg
     # - we do not have install_32 set on host
     # - we do not have install_32 set globally
     arch_suffix = should_install_64bit ? '64' : '86'
-    release_file = "puppet-agent-x#{arch_suffix}.msi"
+    # If a version was specified, use it; otherwise fall back to a default name.
+    # Avoid when puppet_agent_version is set to a SHA, which isn't used in package names.
+    if puppet_agent_version =~ /^\d+\.\d+\.\d+/
+      release_file = "puppet-agent-#{puppet_agent_version}-x#{arch_suffix}.msi"
+    else
+      release_file = "puppet-agent-x#{arch_suffix}.msi"
+    end
     return release_path_end, release_file
   end
 

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -952,12 +952,12 @@ describe ClassMixedWithDSLInstallUtils do
       host['platform'] = platform
       opts = { :version => '0.1.0' }
       allow( subject ).to receive( :options ).and_return( {} )
-      copied_path = "#{win_temp}\\puppet-agent-x86.msi"
+      copied_path = "#{win_temp}\\puppet-agent-0.1.0-x86.msi"
       mock_echo = Object.new()
       allow( mock_echo ).to receive( :raw_output ).and_return( copied_path )
 
-      expect(subject).to receive(:fetch_http_file).once.with(/\/windows$/, 'puppet-agent-x86.msi', /\/windows$/)
-      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-x86.msi$/, /#{external_copy_base}/)
+      expect(subject).to receive(:fetch_http_file).once.with(/\/windows$/, 'puppet-agent-0.1.0-x86.msi', /\/windows$/)
+      expect(subject).to receive(:scp_to).once.with(host, /\/puppet-agent-0.1.0-x86.msi$/, /#{external_copy_base}/)
       expect(subject).to receive(:install_msi_on).with(host, copied_path, {}, {:debug => nil}).once
       expect(subject).to receive(:on).ordered.with(host, /echo/).and_return(mock_echo)
 
@@ -1063,7 +1063,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to receive( :install_msi_on ).with( any_args )
       copy_base = 'copy_base_cygwin'
       allow( host ).to receive( :external_copy_base ).and_return( copy_base )
-      expect( subject ).to receive( :scp_to ).with( host, /puppet-agent-x86\.msi/, /#{copy_base}/ )
+      expect( subject ).to receive( :scp_to ).with( host, /puppet-agent-1\.0\.0-x86\.msi/, /#{copy_base}/ )
       expect( subject ).to receive( :configure_type_defaults_on ).with(host)
       expect( subject ).to receive( :fetch_http_file ).with( /[^\/]\z/, anything, anything )
       subject.install_puppet_agent_dev_repo_on( host, opts.merge({ :puppet_agent_version => '1.0.0' }) )


### PR DESCRIPTION
If a `puppet_agent_version` is specified, use it in
`install_puppet_agent_dev_repo_on` to fetch the MSI, so we get an MSI
unique to that SHA. This provides a work-around for BKR-712, and
normalizes behavior with `install_puppet_agent_on`.