### PR TITLE
(BKR-658) Fix BEAKER_provision=no when using Docker

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -91,7 +91,11 @@ module Beaker
           end
         end
 
-        raise RuntimeError, "Unable to create container because provision=false" if container.nil?
+        if container.nil?
+          raise RuntimeError, 'Cannot continue because no existing container ' +
+                              'could be found and provisioning is disabled.'
+        end
+
         fix_ssh(container) if @options[:provision] == false
 
         @logger.debug("Starting container #{container.id}")

--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -12,11 +12,13 @@ module Beaker
     # - only if we are running with ---provision
     # - only if we have a hypervisor
     # - only if either the specific hosts has no specification or has 'provision' in its config
-    # - always if it is a vagrant box (vagrant boxes are always provisioned as they always need ssh key hacking)
+    # - always if it is a vagrant or docker box (vagrant boxes are always provisioned
+    #     as they always need ssh key hacking. docker boxes need to have docker_container_name
+    #     specified)
     def provision? options, host
       command_line_says = options[:provision]
       host_says = host['hypervisor'] && (host.has_key?('provision') ? host['provision'] : true)
-      (command_line_says && host_says) or (host['hypervisor'] =~/vagrant/)
+      (command_line_says && host_says) or (host['hypervisor'] =~/(vagrant|docker)/)
     end
 
     def initialize(options, logger)

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -296,9 +296,6 @@ module Beaker
       end
 
       context 'provision=false' do
-        before do
-        end
-
         let(:options) {{
           :logger => logger,
           :forward_ssh_agent => true,


### PR DESCRIPTION
Per BKR-658, the Docker provisioner does not behave correctly when `BEAKER_provision=no` is used from beaker-rspec.  This corrects that behavior so the container is reused.  It defers to ::Docker::Container.create throwing raising an exception if `BEAKER_provision=yes` and the container currently exists, rather than blindly reusing the container (the previous behavior). 

Also added is a best effort at sshd_config repair for root logins.  Puppet users will often disable root logins, which breaks Beaker, so this attempts to revert such changes via Docker::Container#exec.