### PR TITLE
(maint) Correct install_puppet_agent_on args

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -324,7 +324,7 @@ module Beaker
         # @return nil
         # @raise [StandardError] When encountering an unsupported platform by default, or if gem cannot be found when default_action => 'gem_install'
         # @raise [FailTest] When error occurs during the actual installation process
-        def install_puppet_agent_on(hosts, opts)
+        def install_puppet_agent_on(hosts, opts = {})
           opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
           opts[:puppet_collection] ||= 'pc1' #hi!  i'm case sensitive!  be careful!
           opts[:puppet_agent_version] ||= opts[:version] #backwards compatability with old parameter name


### PR DESCRIPTION
The docs for `install_puppet_agent_on` specify that the `opts` arg is
optional, but it doesn't have a default value so in practice it's
required. Update the call signature to specify a default empty hash, so
the function matches its description.