### PR TITLE
(BKR-430) Adding rake tasks for running beaker acceptance tests.

### DIFF
--- a/acceptance/config/base/acceptance-options.rb
+++ b/acceptance/config/base/acceptance-options.rb
@@ -1,0 +1,3 @@
+{
+    :tests                => 'acceptance/tests/base'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/config/hypervisor/acceptance-options.rb
+++ b/acceptance/config/hypervisor/acceptance-options.rb
@@ -1,0 +1,3 @@
+{
+    :tests                => 'acceptance/tests/hypervisor'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/config/puppetgem/acceptance-options.rb
+++ b/acceptance/config/puppetgem/acceptance-options.rb
@@ -1,0 +1,4 @@
+{
+    :pre_suite            => 'acceptance/pre_suite/puppet_gem/install.rb',
+    :tests                => 'acceptance/tests/puppet'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/config/puppetgit/acceptance-options.rb
+++ b/acceptance/config/puppetgit/acceptance-options.rb
@@ -1,0 +1,4 @@
+{
+    :pre_suite            => 'acceptance/pre_suite/puppet_git/install.rb',
+    :tests                => 'acceptance/tests/puppet'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/config/puppetpe/acceptance-options.rb
+++ b/acceptance/config/puppetpe/acceptance-options.rb
@@ -1,0 +1,5 @@
+{
+    :pre_suite            => 'acceptance/pre_suite/pe/install.rb',
+    :tests                => 'acceptance/tests/puppet',
+    :pe_dir               => 'http://neptune.puppetlabs.lan/archives/releases/3.7.2'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/config/puppetpkg/acceptance-options.rb
+++ b/acceptance/config/puppetpkg/acceptance-options.rb
@@ -1,0 +1,4 @@
+{
+    :pre_suite            => 'acceptance/pre_suite/puppet_pkg/install.rb',
+    :tests                => 'acceptance/tests/puppet'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'
+  s.add_development_dependency 'beaker-hostgenerator'
 
   # Documentation dependencies
   s.add_development_dependency 'yard'


### PR DESCRIPTION
'rake acceptance' for the main acceptance run.
Also the following individual tasks for individual sets of tests.
rake test:base
rake test:hypervisor
rake test:puppetpe
rake test:puppetgem
rake test:puppetgit
rake test:puppetpkg