### PR TITLE
(BKR-753) Cisco IOS XR broken by BKR-749

### DIFF
--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -72,7 +72,7 @@ module Beaker
     def cmd_line host, cmd = @command, env = @environment, pc = @prepend_cmds
       env_string = host.environment_string( env )
       prepend_commands = host.prepend_commands( cmd, pc, :cmd_exe => @cmdexe )
-      if host[:platform] =~ /cisco_nexus/ && host[:user] != 'root'
+      if host[:platform] =~ /cisco/ && host[:user] != 'root'
           append_command = '"'
         cmd = cmd.gsub('"') { '\\"' }
       end


### PR DESCRIPTION
Quick and dirty fix for BKR-753 (breakage from #1085). It concerns me that we have no spec tests for the overall `cmd_line` construction for the Cisco platforms, which would have found this issue immediately if present.

A bigger-picture suggestion would be to reconsider the design for `Command.cmd_line` since now we have interdependencies between `command.cmd_line`, `host.prepend_commands`, and `host.environment_string`. Might be better in the long term to refactor this and have a single API like `host.munge_cmd_line` that takes all of `[cmd, env, pc]` as parameters just like `Command.cmd_line` does.