### PR TITLE
(BKR-680) Add Huaweios support

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -164,7 +164,7 @@ module Unix::Exec
   # @return [Result] result of restarting the SSH service
   def ssh_service_restart
     case self['platform']
-    when /debian|ubuntu|cumulus/
+    when /debian|ubuntu|cumulus|huaweios/
       exec(Beaker::Command.new("service ssh restart"))
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7/
       exec(Beaker::Command.new("systemctl restart sshd.service"))
@@ -188,7 +188,7 @@ module Unix::Exec
   #   (from {#ssh_service_restart}).
   def ssh_permit_user_environment
     case self['platform']
-    when /debian|ubuntu|cumulus/
+    when /debian|ubuntu|cumulus|huaweios/
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -34,7 +34,7 @@ module Unix::Pkg
         return false
       when /cisco|fedora|centos|eos|el-/
         result = execute("rpm -q #{name}", opts) { |result| result }
-      when /ubuntu|debian|cumulus/
+      when /ubuntu|debian|cumulus|huaweios/
         result = execute("dpkg -s #{name}", opts) { |result| result }
       when /solaris-11/
         result = execute("pkg info #{name}", opts) { |result| result }
@@ -54,7 +54,7 @@ module Unix::Pkg
   # If apt has not been updated since the last repo deployment it is
   # updated. Otherwise this is a noop
   def update_apt_if_needed
-    if self['platform'] =~ /debian|ubuntu|cumulus/
+    if self['platform'] =~ /debian|ubuntu|cumulus|huaweios/
       if @apt_needs_update
         execute("apt-get update")
         @apt_needs_update = false
@@ -78,7 +78,7 @@ module Unix::Pkg
           name = "#{name}-#{version}"
         end
         execute("yum -y #{cmdline_args} install #{name}", opts)
-      when /ubuntu|debian|cumulus/
+      when /ubuntu|debian|cumulus|huaweios/
         if version
           name = "#{name}=#{version}"
         end
@@ -152,7 +152,7 @@ module Unix::Pkg
         execute("dnf -y #{cmdline_args} remove #{name}", opts)
       when /cisco|fedora|centos|eos|el-/
         execute("yum -y #{cmdline_args} remove #{name}", opts)
-      when /ubuntu|debian|cumulus/
+      when /ubuntu|debian|cumulus|huaweios/
         execute("apt-get purge #{cmdline_args} -y #{name}", opts)
       when /solaris-11/
         execute("pkg #{cmdline_args} uninstall #{name}", opts)
@@ -180,7 +180,7 @@ module Unix::Pkg
         execute("dnf -y #{cmdline_args} update #{name}", opts)
       when /cisco|fedora|centos|eos|el-/
         execute("yum -y #{cmdline_args} update #{name}", opts)
-      when /ubuntu|debian|cumulus/
+      when /ubuntu|debian|cumulus|huaweios/
         update_apt_if_needed
         execute("apt-get install -o Dpkg::Options::='--force-confold' #{cmdline_args} -y --force-yes #{name}", opts)
       when /solaris-11/
@@ -257,7 +257,7 @@ module Unix::Pkg
         @logger.debug("Package repo deploy is not supported on rhel4")
       when /fedora|centos|eos|el-/
         deploy_yum_repo(path, name, version)
-      when /ubuntu|debian|cumulus/
+      when /ubuntu|debian|cumulus|huaweios/
         deploy_apt_repo(path, name, version)
       when /sles/
         deploy_zyp_repo(path, name, version)

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
+    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
       { :debian => { "jessie"  => "8",
@@ -42,6 +42,7 @@ module Beaker
     # Creates the Platform object.  Checks to ensure that the platform String
     # provided meets the platform formatting rules.  Platforms name must be of
     # the format /^OSFAMILY-VERSION-ARCH.*$/ where OSFAMILY is one of:
+    # * huaweios
     # * cisco_nexus
     # * cisco_ios_xr
     # * freebsd

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -111,3 +111,26 @@ module HostHelpers
   end
 
 end
+
+module PlatformHelpers
+
+  DEBIANPLATFORMS = ['debian',
+                     'ubuntu',
+                     'cumulus',
+                     'huaweios']
+
+  SYSTEMDPLATFORMS = ['el-7',
+                      'centos-7',
+                      'redhat-7',
+                      'oracle-7',
+                      'scientific-7',
+                      'eos-7']
+
+  SYSTEMVPLATFORMS = ['el-',
+                      'centos',
+                      'fedora',
+                      'redhat',
+                      'oracle',
+                      'scientific',
+                      'eos']
+end


### PR DESCRIPTION
This PR adds support for the Huaweios platform. The LXC that this support adds is a Debian jessie variant, so the Huaweios platform will just be the same as any other Unix::Host.