### PR TITLE
WIP (RE-6487) update the aio windows paths.

### DIFF
--- a/lib/beaker/dsl/install_utils/aio_defaults.rb
+++ b/lib/beaker/dsl/install_utils/aio_defaults.rb
@@ -17,13 +17,13 @@ module Beaker
           },
           'windows' => { #windows
             'puppetbindir'      => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/bin',
-            'privatebindir'     => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/sys/ruby/bin',
+            'privatebindir'     => '/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/sys/ruby/bin:/cygdrive/c/Program Files/Puppet Labs/Puppet/puppet/bin',
             'distmoduledir'     => '`cygpath -smF 35`/PuppetLabs/code/modules',
             # sitemoduledir not included (check PUP-4049 for more info)
           },
           'pwindows' => { #pure windows
             'puppetbindir'      => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\bin"',
-            'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin"',
+            'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin"',
             'distmoduledir'     => 'C:\\ProgramData\\PuppetLabs\\code\\environments\\production\\modules',
           }
         }


### PR DESCRIPTION
Paths to the "bin" directory for puppet, ruby, facter etc.
have been updated for the AIO agent for windows. With the
new cut over to windows vanagon the path to that directory
will now be /Program Files/Puppet Labs/Puppet/puppet/bin