### PR TITLE
(BKR-219) Add support for :is_puppetserver per host

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -133,7 +133,7 @@ module Beaker
           curl_retries = host['master-start-curl-retries'] || options['master-start-curl-retries']
           logger.debug "Setting curl retries to #{curl_retries}"
 
-          if options[:is_puppetserver]
+          if options[:is_puppetserver] || host[:is_puppetserver]
             confdir = host.puppet('master')['confdir']
             vardir = host.puppet('master')['vardir']
 

--- a/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
@@ -551,6 +551,15 @@ describe ClassMixedWithDSLHelpers do
         })
       end
 
+      describe 'when the global option for :is_puppetserver is false' do
+        it 'checks the option for the host object' do
+          allow( subject ).to receive( :options) .and_return( {:is_puppetserver => false})
+          host[:is_puppetserver] = true
+          expect( subject ).to receive( :modify_tk_config)
+          subject.with_puppet_running_on(host, conf_opts)
+        end
+      end
+
       describe 'and command line args passed' do
         it 'modifies SUT trapperkeeper configuration w/ command line args' do
           host['puppetserver-confdir'] = '/etc/puppetserver/conf.d'


### PR DESCRIPTION
This commit adds a check for each host's :is_puppetserver key when using
the `with_puppet_running_on` command. Previously, it would only check
the global option for this key.