### PR TITLE
(maint) Avoid scoping change in Ruby 2.2

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1073,8 +1073,8 @@ module Beaker
             when /^windows$/
               result = on host, "echo #{onhost_copied_file}"
               onhost_copied_file = result.raw_output.chomp
-              opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
-              install_msi_on(host, onhost_copied_file, {}, opts)
+              msi_opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
+              install_msi_on(host, onhost_copied_file, {}, msi_opts)
             when /^osx$/
               host.install_package("puppet-agent-#{opts[:puppet_agent_version]}*")
             when /^solaris$/


### PR DESCRIPTION
Using Ruby 2.2, the `opts` assignment in the Windows case of
`install_puppet_agent_dev_repo_on` overwrites the `opts` method
argument. This causes installs after Windows to fail in Puppet
acceptance runs. Fix by avoiding using the same variable name.