### PR TITLE
(BKR-521) handle priority of :acceptable_exit_codes

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -324,7 +324,8 @@ module Beaker
           # exit codes at the host level and then raising...
           # is it necessary to break execution??
           if options[:accept_all_exit_codes] && options[:acceptable_exit_codes]
-            @logger.warn ":accept_all_exit_codes & :acceptable_exit_codes set. :accept_all_exit_codes overrides, but they shouldn't both be set at once"
+            @logger.warn ":accept_all_exit_codes & :acceptable_exit_codes set. :acceptable_exit_codes overrides, but they shouldn't both be set at once"
+            options[:accept_all_exit_codes] = false
           end
           if !options[:accept_all_exit_codes] && !result.exit_code_in?(Array(options[:acceptable_exit_codes] || [0, nil]))
             raise CommandFailure, "Host '#{self}' exited with #{result.exit_code} running:\n #{cmdline}\nLast #{@options[:trace_limit]} lines of output were:\n#{result.formatted_output(@options[:trace_limit])}"

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -293,7 +293,7 @@ module Beaker
         expect { host.exec(command, opts) }.to raise_error(Beaker::Host::CommandFailure)
       end
 
-      it 'does not throw an error when an unacceptable exit code is returned and the accept_all_exit_codes flag is set' do
+      it 'does throw an error when an unacceptable exit code is returned and the accept_all_exit_codes flag is set' do
         result.exit_code = 7
         opts = {
           :acceptable_exit_codes  => [0, 1],
@@ -301,11 +301,11 @@ module Beaker
         }
         allow( host.logger ).to receive( :warn )
 
-        expect { host.exec(command, opts) }.to_not raise_error
+        expect { host.exec(command, opts) }.to raise_error
       end
 
       it 'sends a warning when both :acceptable_exit_codes & :accept_all_exit_codes are set' do
-        result.exit_code = 7
+        result.exit_code = 1
         opts = {
           :acceptable_exit_codes  => [0, 1],
           :accept_all_exit_codes  => true


### PR DESCRIPTION
Make acceptable_exit_codes override accept_all_exit_codes => true as the more specific of the two options.
