### PR TITLE
(MAINT) bump google-api-client to ~> 0.8, < 0.9.5

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   # Optional provisioner specific support
   s.add_runtime_dependency 'rbvmomi', '~> 1.8'
   s.add_runtime_dependency 'fission', '~> 0.4'
-  s.add_runtime_dependency 'google-api-client', '~> 0.8'
+  s.add_runtime_dependency 'google-api-client', ['~> 0.8', '< 0.9.5'] # dropped ruby 1.9 rupport in 0.9.5
   s.add_runtime_dependency 'aws-sdk', '~> 1.57'
   s.add_runtime_dependency 'docker-api'
   s.add_runtime_dependency 'mime-types', '~> 2.99' if RUBY_VERSION < '2.0' # dropped ruby 1.9 rupport in 3.0


### PR DESCRIPTION
google-api-client dropped ruby 1.9 support in 0.9.5.
Ubuntu Trusty (current LTS) still have Ruby 1.9 by default, so it's
impossible to run beaker on this platform with official packaging.

See https://github.com/google/google-api-ruby-client/issues/397