### PR TITLE
(BKR-770) Update EPEL package name for EL7

### DIFF
--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -166,7 +166,7 @@ module Beaker
           :add_el_extras          => false,
           :epel_url               => "http://mirrors.kernel.org/fedora-epel",
           :epel_arch              => "i386",
-          :epel_7_pkg             => "epel-release-7-5.noarch.rpm",
+          :epel_7_pkg             => "epel-release-7-6.noarch.rpm",
           :epel_6_pkg             => "epel-release-6-8.noarch.rpm",
           :epel_5_pkg             => "epel-release-5-4.noarch.rpm",
           :consoleport            => 443,

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -157,7 +157,7 @@ describe Beaker do
     it "can return the correct url for an el-7 host" do
       host = make_host( 'testhost', { :platform => Beaker::Platform.new('el-7-platform') } )
 
-      expect( subject.epel_info_for( host, options )).to be === ["http://mirrors.kernel.org/fedora-epel/7", "x86_64", "epel-release-7-5.noarch.rpm"]
+      expect( subject.epel_info_for( host, options )).to be === ["http://mirrors.kernel.org/fedora-epel/7", "x86_64", "epel-release-7-6.noarch.rpm"]
     end
 
     it "can return the correct url for an el-6 host" do


### PR DESCRIPTION
Change the default EPEL package name for EL7 from "epel-release-7-5.noarch.rpm" to "epel-release-7-6.noarch.rpm"