### PR TITLE
(MAINT) Use the upgrade install option for rpm packages

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -139,7 +139,7 @@ module Unix::Pkg
     if name =~ /^http/ and opts[:package_proxy]
       proxy = extract_rpm_proxy_options(opts[:package_proxy])
     end
-    execute("rpm #{cmdline_args} -ivh #{name} #{proxy}")
+    execute("rpm #{cmdline_args} -Uvh #{name} #{proxy}")
   end
 
   def uninstall_package(name, cmdline_args = '', opts = {})

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -257,7 +257,7 @@ module Beaker
       it "accepts a package as a single argument" do
         @opts = {'platform' => 'el-is-me'}
         pkg = 'redhat_package'
-        expect( Beaker::Command ).to receive(:new).with("rpm  -ivh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( Beaker::Command ).to receive(:new).with("rpm  -Uvh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package_with_rpm(pkg) ).to be == "hello"
       end
@@ -266,7 +266,7 @@ module Beaker
         @opts = {'platform' => 'el-is-me'}
         pkg = 'redhat_package'
         cmdline_args = '--foo'
-        expect( Beaker::Command ).to receive(:new).with("rpm #{cmdline_args} -ivh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( Beaker::Command ).to receive(:new).with("rpm #{cmdline_args} -Uvh #{pkg} ", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
         expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.install_package_with_rpm(pkg, cmdline_args) ).to be == "hello"
       end


### PR DESCRIPTION
Images used in beaker tests might have all kinds of preinstalled
packages on them, some of which may be out of date. In our case, we
were preinstalling the puppetlabs el 7.10 release package on images,
but then running beaker's install_puppet function as a provisional step
in our tests. Since a new release package was added, this started
failing[1]. We were able to fix this easily by fixing our images, but
users depending on externally hosted images, such as vagrant boxes, may
not be so lucky.

This patch changes the -i flag of the rpm install command to -U so that
the package will be either installed or, if already present but out of
date, upgraded. This will not change functionality for users with clean
images who do not need to upgrade anything. The --replacepkgs flag that
was already present in the rpm command is not sufficient to remove
conflicting files from older versions of packages.

[1] http://logs.openstack.org/77/308277/2/check/gate-openstackci-beaker-centos-7/0736982/console.html#_2016-04-20_14_14_12_690