### PR TITLE
(BKR-789) enable --no-provision for Solaris 11 guests

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -410,7 +410,7 @@ module Beaker
         elsif host['platform'] =~ /solaris-10/
           host.exec(Command.new("sudo gsed -i -e 's/#PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config"), {:pty => true} )
         elsif host['platform'] =~ /solaris-11/
-          host.exec(Command.new("sudo rolemod -K type=normal root"), {:pty => true} )
+          host.exec(Command.new("if grep \"root::::type=role\" /etc/user_attr; then sudo rolemod -K type=normal root; else echo \"root user already type=normal\"; fi"), {:pty => true} )
           host.exec(Command.new("sudo gsed -i -e 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config"), {:pty => true} )
         elsif not host.is_powershell?
           host.exec(Command.new("sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""), {:pty => true})

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -56,6 +56,18 @@ describe Beaker do
     "sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /etc/sshd_config"
   ]
 
+  # Solaris
+  it_should_behave_like 'enables_root_login', 'solaris-10', [
+    "sudo -E svcadm restart network/ssh",
+    "sudo gsed -i -e 's/#PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config"
+  ], true
+
+  it_should_behave_like 'enables_root_login', 'solaris-11', [
+    "sudo -E svcadm restart network/ssh",
+    "sudo gsed -i -e 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
+    "if grep \"root::::type=role\" /etc/user_attr; then sudo rolemod -K type=normal root; else echo \"root user already type=normal\"; fi"
+  ], true
+
   ['debian','ubuntu','cumulus'].each do | deb_like |
     it_should_behave_like 'enables_root_login', deb_like, [
       "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\"",


### PR DESCRIPTION
Without this change, it is not possible to run beaker against solaris
hosts with --no-provision, which means for every test run the VMs must
be re-provisioned, which has a big impact on the length of time to be
able to run tests during development lifecycle.

For Solaris the 'rolemod' command is used, but this can only be run
successfully once, the second time it runs it fails because the root
user has already been changes from a role to a user.  This change adds a
check to ensure rolemod is only run if it is needed.