### PR TITLE
(BKR-758) Fix Bitvise SSH issues and Various vagrant versions not forwarding ssh properly

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -290,7 +290,12 @@ module Beaker
 
               # Certain install paths may not create the config dirs/files needed
               host.mkdir_p host['puppetpath'] unless host[:type] =~ /aio/
-              on host, "echo '' >> #{host.puppet['hiera_config']}"
+
+              if ((host['platform'] =~ /windows/) and not host.is_cygwin?)
+                # Do nothing
+              else
+                on host, "echo '' >> #{host.puppet['hiera_config']}"
+              end
             end
           end
 

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -27,8 +27,6 @@ module Windows::File
     when :bitvise
       # swap out separators
       network_path = path.gsub('\\', scp_separator)
-      # pull off drive prefix since base BitVise dir is '/'
-      network_path.gsub('C:', '')
     when :openssh
       path
     else

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -293,7 +293,11 @@ module Beaker
     def get_domain_name(host)
       domain = nil
       search = nil
-      resolv_conf = host.exec(Command.new("cat /etc/resolv.conf")).stdout
+      if ((host['platform'] =~ /windows/) and not host.is_cygwin?)
+        resolv_conf = host.exec(Command.new('type C:\Windows\System32\drivers\etc\hosts')).stdout
+      else
+        resolv_conf = host.exec(Command.new("cat /etc/resolv.conf")).stdout
+      end
       resolv_conf.each_line { |line|
         if line =~ /^\s*domain\s+(\S+)/
           domain = $1
@@ -322,6 +326,8 @@ module Beaker
     def set_etc_hosts(host, etc_hosts)
       if host['platform'] =~ /freebsd/
         host.echo_to_file(etc_hosts, '/etc/hosts')
+      elsif ((host['platform'] =~ /windows/) and not host.is_cygwin?)
+        host.exec(Command.new("echo '#{etc_hosts}' >> C:\\Windows\\System32\\drivers\\etc\\hosts"))
       else
         host.exec(Command.new("echo '#{etc_hosts}' >> /etc/hosts"))
       end

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -42,6 +42,10 @@ module Beaker
         end
 
         if /windows/i.match(host['platform'])
+          #due to a regression bug in versions of vagrant 1.6.2, 1.6.3, 1.6.4, >= 1.7.3 ssh fails to forward 
+          #automatically (note <=1.6.1, 1.6.5, 1.7.0 - 1.7.2 are uneffected)
+          #Explicitly setting SSH port forwarding due to this bug
+          v_file << "    v.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', auto_correct: true\n"
           v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"
           v_file << "    v.vm.guest = :windows\n"


### PR DESCRIPTION
Bitvise has largely been unable to function due to hard coded linux/cygwin commands, this merge request fixes bitvise ssh windows issues.

Additionally Vagrant has a regression bug where intermittent versions fail to forward ssh when os is windows. Reference: https://github.com/mitchellh/vagrant/issues/7202
