### PR TITLE
(maint) Improve the error message returned when failing to request vms

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -160,7 +160,7 @@ module Beaker
             raise "Vmpooler.provision - requested VM templates #{request_payload.keys} not available"
           end
         else
-          raise "Vmpooler.provision - requested host set not available"
+          raise "Vmpooler.provision - response from pooler not ok. Requested host set #{request_payload.keys} not available in pooler"
         end
       rescue JSON::ParserError, RuntimeError, *SSH_EXCEPTIONS => e
         @logger.debug "Failed vmpooler provision: #{e.class} : #{e.message}"

--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -160,7 +160,7 @@ module Beaker
             raise "Vmpooler.provision - requested VM templates #{request_payload.keys} not available"
           end
         else
-          raise "Vmpooler.provision - response from pooler not ok. Requested host set #{request_payload.keys} not available in pooler"
+          raise "Vmpooler.provision - response from pooler not ok. Requested host set #{request_payload.keys} not available in pooler.\n#{parsed_response}"
         end
       rescue JSON::ParserError, RuntimeError, *SSH_EXCEPTIONS => e
         @logger.debug "Failed vmpooler provision: #{e.class} : #{e.message}"


### PR DESCRIPTION
This commit gives a better error message to the user when beaker fails
to request a host set that doesn't exist in vmpooler.

Example updated error message:

```
Failed: errored in Vmpooler.provision
#<RuntimeError: Vmpooler.provision - response from pooler not ok. Requested host set ["fedora-20-x86_64"] not available in pooler>
/Users/brian/.rvm/gems/ruby-2.1.1@beaker-strings/gems/beaker-rspec-5.3.0/lib/beaker-rspec/spec_helper.rb:46
/Users/brian/.rvm/gems/ruby-2.1.1@beaker-strings/gems/beaker-rspec-5.3.0/lib/beaker-rspec/spec_helper.rb:5
/Users/brian/workspace/puppetlabs-strings/spec/spec_helper_acceptance.rb:1
/Users/brian/workspace/puppetlabs-strings/spec/spec_helper_acceptance.rb:1
/Users/brian/workspace/puppetlabs-strings/spec/acceptance/running_strings_yardoc.rb:1
/Users/brian/workspace/puppetlabs-strings/spec/acceptance/running_strings_yardoc.rb:1
/Users/brian/.rvm/gems/ruby-2.1.1@beaker-strings/gems/rspec-core-3.4.4/exe/rspec:4
/Users/brian/.rvm/gems/ruby-2.1.1@beaker-strings/bin/ruby_executable_hooks:15
/Users/brian/.rvm/gems/ruby-2.1.1@beaker-strings/bin/ruby_executable_hooks:15
```

![](https://media.giphy.com/media/qgKTPNN7Kg3Qs/giphy.gif)