### PR TITLE
(BKR-688) Moving confine message(s) up a level

### DIFF
--- a/acceptance/tests/base/dsl/platform_tag_confiner_test.rb
+++ b/acceptance/tests/base/dsl/platform_tag_confiner_test.rb
@@ -26,7 +26,7 @@ test_name "DSL::Structure::PlatformTagConfiner" do
     begin
       tag( 'tag1' )
     rescue Beaker::DSL::Outcomes::SkipTest => e
-      if e.message =~ /^No\ suitable\ hosts\ found$/
+      if e.message =~ /^No\ suitable\ hosts\ found/
         # SkipTest is raised in the case when there are no hosts leftover for a test
         # after confining. It's a very common acceptance test case where all of the
         # hosts involved are of the same platform, and are thus all confined

--- a/acceptance/tests/base/dsl/structure_test.rb
+++ b/acceptance/tests/base/dsl/structure_test.rb
@@ -76,4 +76,27 @@ test_name "dsl::structure" do
       assert_equal hosts.dup, hosts, "#confine_block did not preserve the hosts array"
     end
   end
+
+  step "#confine reports correct message and skips test when criteria doesn't match on 'to'" do
+    begin
+      confine :to, { :platform => 'test' }
+
+      fail "#confine did not skip test but should have."
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      assert_match /No suitable hosts found with {:platform=>"test"}/, e.message, "#confine raised an unexpected skip_test"
+    end
+  end
+
+  step "#confine reports correct message  and skips test when criteria doesn't match on 'except'" do
+    begin
+      confine :except, { :platform => default['platform'] }
+
+      fail "#confine did not skip test but should have."
+
+    rescue Beaker::DSL::Outcomes::SkipTest => e
+      assert_match /No suitable hosts found without {:platform=>"#{default['platform']}"}/, e.message, "#confine raised an unexpected
+      # skip_test"
+    end
+  end
 end

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -200,18 +200,22 @@ module Beaker
             # confining to all hosts *except* provided array of hosts
             hosts_to_modify = hosts_not_modified
           end
+          if hosts_to_modify.empty?
+            logger.warn "No suitable hosts without: #{criteria.inspect}"
+            skip_test "No suitable hosts found without #{criteria.inspect}"
+          end
         when :to
           if criteria and ( not criteria.empty? )
             hosts_to_modify = select_hosts(criteria, hosts_to_modify, &block) + hosts_not_modified
           else
             # confining to only hosts in provided array of hosts
           end
+          if hosts_to_modify.empty?
+            logger.warn "No suitable hosts with: #{criteria.inspect}"
+            skip_test "No suitable hosts found with #{criteria.inspect}"
+          end
         else
           raise "Unknown option #{type}"
-        end
-        if hosts_to_modify.empty?
-          logger.warn "No suitable hosts with: #{criteria.inspect}"
-          skip_test 'No suitable hosts found'
         end
         self.hosts = hosts_to_modify
         hosts_to_modify

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -122,14 +122,20 @@ describe ClassMixedWithDSLStructure do
       allow( subject ).to receive( :logger ).and_return( logger )
     end
 
-    it 'skips the test if there are no applicable hosts' do
+    it ':to - skips the test if there are no applicable hosts' do
       allow( subject ).to receive( :hosts ).and_return( [] )
       allow( subject ).to receive( :hosts= )
       expect( logger ).to receive( :warn )
-      expect( subject ).to receive( :skip_test ).
-        with( 'No suitable hosts found' )
-
+      expect( subject ).to receive( :skip_test ).with( 'No suitable hosts found with {}' )
       subject.confine( :to, {} )
+    end
+
+    it ':except - skips the test if there are no applicable hosts' do
+      allow( subject ).to receive( :hosts ).and_return( [] )
+      allow( subject ).to receive( :hosts= )
+      expect( logger ).to receive( :warn )
+      expect( subject ).to receive( :skip_test ).with( 'No suitable hosts found without {}' )
+      subject.confine( :except, {} )
     end
 
     it ':to - uses a provided host subset when no criteria is provided' do


### PR DESCRIPTION
Moving confine message stating that criteria match has been unsuccessful in finding a matching host, to the specific case logic.

This means that we can be more detailed in what exactly has failed to be found.