### PR TITLE
(MAINT) pinned minitest to fix spec testing

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
 
   # Run time dependencies
-  s.add_runtime_dependency 'minitest', '~> 5.4'
+  s.add_runtime_dependency 'minitest', '~> 5.8.4'
   s.add_runtime_dependency 'json', '~> 1.8'
   s.add_runtime_dependency 'hocon', '~> 0.1'
   s.add_runtime_dependency 'net-ssh', '~> 2.9'


### PR DESCRIPTION
In 5.8.4, [this block](https://github.com/seattlerb/minitest/blame/master/lib/minitest/assertions.rb#L64-L70) of code returns false, leading to no diff being required.

In 5.9.0, that same block calls [`system("diff")`](https://github.com/seattlerb/minitest/blame/master/lib/minitest/assertions.rb#L37-L38) successfully, so that block returns "diff -u", which causes the above-mentioned block to try to diff, which fails when it tries to use `/tmp` from the `Tempfile` module.

I've tried setting environment variables to configure the [temp file](http://ruby-doc.org/stdlib-2.1.2/libdoc/tmpdir/rdoc/Dir.html#method-c-tmpdir), using `TMPDIR`, `TMP`, & `TEMP`, but none of them helped in this case (unlike just using the `Tempfile` module myself, which used the ENV VAR I passed). 

Since this is the case, I think the best route forward here for beaker is to pin minitest to the 5.8 series rather than trying to keep moving forward with 5.9.