### PR TITLE
(MAINT) clarifying between install docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,10 +3,9 @@
 ## Beaker Info
 
 * [MAINTAINERS](/MAINTAINERS.md)
-* [How to install](Beaker-Installation.md)
+* [Installing Beaker](Beaker-Installation.md)
 * [How to Beaker](How-To-Beaker.md)
   * [Overview](Overview.md)
-  * [Beaker Installation](Beaker-Installation.md)
   * [Creating A Test Environment](Creating-A-Test-Environment.md)
     * [Roles, What Are They?](Roles-What-Are-They.md)
     * Supported Virtualization Techniques


### PR DESCRIPTION
This confusion isn't actually about the docs themselves. Both phrases "beaker-installation" and "how to install" link to the same document. But they are listed in the same TOC, which doesn't make much sense.

This PR is to clarify between the two entries and gain a little more consistency here.