### PR TITLE
(maint) Fix documentation example for shell

### DIFF
--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -110,10 +110,8 @@ module Beaker
         #     end
         #
         # @example Using TestCase helpers from within a test.
-        #     agents.each do |agent|
-        #       shell('cat /etc/puppet/puppet.conf') do |result|
-        #         assert_match result.stdout, /server = #{master}/, 'WTF Mate'
-        #       end
+        #     shell('cat /etc/puppet/puppet.conf') do |result|
+        #       assert_match result.stdout, /server = #{master}/, 'WTF Mate'
         #     end
         #
         # @return [Result]   An object representing the outcome of *command*.


### PR DESCRIPTION
Shell cannot accept a host, so update inline docs accordingly.