### PR TITLE
(BKR-832) Add `box_download_insecure` for vagrant

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -30,12 +30,13 @@ module Beaker
         v_file << "    v.vm.hostname = '#{host.name}'\n"
         v_file << "    v.vm.box = '#{host['box']}'\n"
         v_file << "    v.vm.box_url = '#{host['box_url']}'\n" unless host['box_url'].nil?
+        v_file << "    v.vm.box_download_insecure = '#{host['box_download_insecure'] ||= 'false'}'\n"
         v_file << "    v.vm.box_version = '#{host['box_version']}'\n" unless host['box_version'].nil?
         v_file << "    v.vm.box_check_update = '#{host['box_check_update'] ||= 'true'}'\n"
         v_file << "    v.vm.synced_folder '.', '/vagrant', disabled: true\n" if host['synced_folder'] == 'disabled'
         v_file << "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\", :mac => \"#{randmac}\"\n"
 
-        unless host['mount_folders'].nil? 
+        unless host['mount_folders'].nil?
           host['mount_folders'].each do |name, folder|
             v_file << "    v.vm.synced_folder '#{folder[:from]}', '#{folder[:to]}', create: true\n"
           end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -45,6 +45,7 @@ Vagrant.configure("2") do |c|
     v.vm.hostname = 'vm1'
     v.vm.box = 'vm2vm1_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm1'
+    v.vm.box_download_insecure = 'false'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm1", :netmask => "255.255.0.0", :mac => "0123456789"
     v.vm.synced_folder './', '/temp', create: true
@@ -57,6 +58,7 @@ Vagrant.configure("2") do |c|
     v.vm.hostname = 'vm2'
     v.vm.box = 'vm2vm2_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm2'
+    v.vm.box_download_insecure = 'false'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm2", :netmask => "255.255.0.0", :mac => "0123456789"
     v.vm.synced_folder './', '/temp', create: true
@@ -69,6 +71,7 @@ Vagrant.configure("2") do |c|
     v.vm.hostname = 'vm3'
     v.vm.box = 'vm2vm3_of_my_box'
     v.vm.box_url = 'http://address.for.my.box.vm3'
+    v.vm.box_download_insecure = 'false'
     v.vm.box_check_update = 'true'
     v.vm.network :private_network, ip: "ip.address.for.vm3", :netmask => "255.255.0.0", :mac => "0123456789"
     v.vm.synced_folder './', '/temp', create: true
@@ -101,6 +104,17 @@ EOF
 
       vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
       expect( vagrantfile ).to match(/v.vm.synced_folder .* disabled: true/)
+    end
+
+    it "can make a Vagrantfile with box_download_insecure enabled" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      hosts = make_hosts({:box_download_insecure => 'true'},1)
+      vagrant.make_vfile( hosts, options )
+
+      vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+      expect( vagrantfile ).to match(/v.vm.box_download_insecure = 'true'/)
     end
 
     it "generates a valid windows config" do
@@ -137,19 +151,19 @@ EOF
       expect( match ).to_not be nil
 
     end
-    
+
     it "uses the cpus defined per vagrant host" do
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
-  
+
       vagrant.make_vfile( @hosts, {'vagrant_cpus' => 'goodbye!'} )
-  
+
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
-  
+
       match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!'\]/)
-  
+
       expect( match ).to_not be nil
-  
+
     end
 
     it "can generate a new /etc/hosts file referencing each host" do


### PR DESCRIPTION
Without this patch, vagrant nodesets cannot disable SSL server certificate
verification.  This patch fixes the issue by introducing a
`box_download_insecure` option for vagrant hosts.