### PR TITLE
(BKR-822) Ensure env options applied to bkr commands with #on

### DIFF
--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -69,7 +69,12 @@ module Beaker
               end
               command_object = Command.new(command.to_s, [], cmd_opts)
             elsif command.is_a? Command
-              command_object = command
+              if opts[:environment]
+                command_object = command.clone
+                command_object.environment = opts[:environment]
+              else
+                command_object = command
+              end
             else
               msg = "DSL method `on` can only be called with a String or Beaker::Command"
               msg << " object as the command parameter, not #{command.class}."

--- a/spec/beaker/dsl/helpers/host_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/host_helpers_spec.rb
@@ -42,6 +42,25 @@ describe ClassMixedWithDSLHelpers do
       subject.on( host, 'ls ~/.bin', :environment => {:HOME => '/tmp/test_home' } )
     end
 
+    describe 'with a beaker command object passed in as the command argument' do
+      let( :command ) { Beaker::Command.new('commander command', [], :environment => {:HOME => 'default'}) }
+
+      it 'overwrites the command environment with the environment specified in #on' do
+        expect( host ).to receive( :exec ) do |command|
+          expect(command.environment).to eq({:HOME => 'override'})
+        end
+        subject.on( host, command, :environment => {:HOME => 'override'})
+      end
+
+      it 'uses the command environment if there is no overriding argument in #on' do
+        expect( host ).to receive( :exec ) do |command|
+          expect(command.environment).to eq({:HOME => 'default'})
+        end
+        subject.on( host, command )
+      end
+
+    end
+
     it 'if the host is a String Object, finds the matching hosts with that String as role' do
       allow( subject ).to receive( :hosts ).and_return( hosts )
 


### PR DESCRIPTION
In commit f78c2db, we neglected to ensure that an environment passed in
through the options specified by #on overrides the environment specified
in the Beaker::Command object. This change ensures that #on checks for
the environment in its own options to override the command options.