### PR TITLE
(maint) Extra quoting for Windows versions.txt

### DIFF
--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -144,10 +144,10 @@ exit /B %errorlevel%
             # emit the misc/versions.txt file which contains component versions for
             # puppet, facter, hiera, pxp-agent, packaging and vendored Ruby
             [
-              "\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\"",
-              "\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\""
+              "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
+              "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\""
             ].each do |path|
-              on host, Command.new("if exist #{path} type #{path}", [], { :cmdexe => true })
+              on host, Command.new("\"if exist #{path} type #{path}\"", [], { :cmdexe => true })
             end
           end
         end

--- a/spec/beaker/dsl/install_utils/windows_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/windows_utils_spec.rb
@@ -42,11 +42,11 @@ describe ClassMixedWithDSLInstallUtils do
 
   def expect_version_log_called(times = hosts.length)
     [
-      "\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\"",
-      "\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\"",
+      "\\\"%ProgramFiles%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
+      "\\\"%ProgramFiles(x86)%\\Puppet Labs\\puppet\\misc\\versions.txt\\\"",
     ].each do |path|
       expect( Beaker::Command ).to receive( :new )
-        .with( "if exist #{path} type #{path}", [], {:cmdexe => true} )
+        .with( "\"if exist #{path} type #{path}\"", [], {:cmdexe => true} )
         .exactly( times ).times
     end
   end


### PR DESCRIPTION
 - Adds quotes around the "if exist path type path" command passed to
   cmd.exe, which also requires that quotes around filenames have
   their quoting escaped