### PR TITLE
(MAINT) improved error output from beaker-hostgenerator workflow

### DIFF
--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 
 module Beaker
   describe CLI do
-    let(:cli)      { Beaker::CLI.new }
+    let(:cli)      {
+      allow(File).to receive(:exists?).and_return(true)
+      Beaker::CLI.new
+    }
 
     context 'execute!' do
       before :each do


### PR DESCRIPTION
If you provide bad beaker-hostgenerator input (such as `poobah-baily` in my example below), you'll get this output from running beaker with this change:

```
beaker --log-level trace --hosts poobah-baily --tests ../my_beaker_files/tests/smoke_simple.rb

Hosts file 'poobah-baily' does not exist.
Trying as beaker-hostgenerator input.

WARNING: Starting with beaker-hostgenerator 1.x platform strings for "el" hosts
will correspond to the actual linux distribution name. ie, the platform string
corresponding to a host specified as "centos4_64a" will be "centos-4-x86_64"
rather than "el-4-x86_64". It is recommended that you update your project's test
suites ASAP or be forced to do so when beaker-hostgenerator development moves on
to the 1.x series. We don't intend to backport features or platforms to 0.x.

beaker-hostgenerator was not able to use this value as input.
Exiting with an Error.

beaker/.bundle/gems/gems/beaker-hostgenerator-0.7.0/lib/beaker-hostgenerator/parser.rb:161:in `parse_node_info_token': Invalid node_info token: poobah (BeakerHostGenerator::Exceptions::InvalidNodeSpecError)
	from beaker/.bundle/gems/gems/beaker-hostgenerator-0.7.0/lib/beaker-hostgenerator/generator.rb:46:in `block in generate'
	from beaker/.bundle/gems/gems/beaker-hostgenerator-0.7.0/lib/beaker-hostgenerator/generator.rb:37:in `each'
	from beaker/.bundle/gems/gems/beaker-hostgenerator-0.7.0/lib/beaker-hostgenerator/generator.rb:37:in `generate'
	from beaker/.bundle/gems/gems/beaker-hostgenerator-0.7.0/lib/beaker-hostgenerator/cli.rb:149:in `execute'
	from beaker/lib/beaker/options/parser.rb:239:in `rescue in parse_hosts_options'
	from beaker/lib/beaker/options/parser.rb:228:in `parse_hosts_options'
	from beaker/lib/beaker/options/parser.rb:197:in `parse_args'
	from beaker/lib/beaker/cli.rb:15:in `initialize'
	from beaker/bin/beaker:6:in `new'
	from beaker/bin/beaker:6:in `<top (required)>'
	from -e:1:in `load'
	from -e:1:in `<main>'

Process finished with exit code 1
```