### PR TITLE
(BKR-843) Use hypervisor specific logic for ip

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -228,7 +228,15 @@ module Beaker
     def get_public_ip
       case host_hash[:hypervisor]
       when 'ec2'
-        host_hash[:instance].ip_address
+        if host_hash[:instance]
+          host_hash[:instance].ip_address
+        else
+          # In the case of using ec2 instances with the --no-provision flag, the ec2
+          # instance object does not exist and we should just use the curl endpoint
+          # specified here:
+          # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html
+          execute("curl http://169.254.169.254/latest/meta-data/public-ipv4").strip
+        end
       end
     end
 

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -224,10 +224,18 @@ module Beaker
       @logger.warn("Uh oh, this should be handled by sub-classes but hasn't been")
     end
 
+    # Determine the ip address using logic specific to the hypervisor
+    def get_public_ip
+      case host_hash[:hypervisor]
+      when 'ec2'
+        host_hash[:instance].ip_address
+      end
+    end
+
     #Return the ip address of this host
     #Always pull fresh, because this can sometimes change
     def ip
-      self['ip'] = get_ip
+      self['ip'] = get_public_ip || get_ip
     end
 
     #@return [Boolean] true if x86_64, false otherwise

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -235,7 +235,11 @@ module Beaker
           # instance object does not exist and we should just use the curl endpoint
           # specified here:
           # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html
+          if self.instance_of?(Windows::Host)
+          execute("wget http://169.254.169.254/latest/meta-data/public-ipv4").strip
+          else
           execute("curl http://169.254.169.254/latest/meta-data/public-ipv4").strip
+          end
         end
       end
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -709,7 +709,15 @@ module Beaker
         host.host_hash[:hypervisor] = 'vmpooler'
         expect(host.get_public_ip).to be(nil)
       end
+
+      it 'calls execute with curl if the instance is not defined' do
+        host.host_hash[:hypervisor] = 'ec2'
+        host.host_hash[:instance] = nil
+        expect(host).to receive(:execute).with("curl http://169.254.169.254/latest/meta-data/public-ipv4").and_return('127.0.0.1')
+        host.get_public_ip
+      end
     end
+
     describe '#ip' do
       it 'calls #get_ip when get_public_ip returns nil' do
         allow( host ).to receive(:get_public_ip).and_return(nil)

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -710,10 +710,19 @@ module Beaker
         expect(host.get_public_ip).to be(nil)
       end
 
-      it 'calls execute with curl if the instance is not defined' do
+      it 'calls execute with curl if the host_hash[:instance] is not defined and the host is not an instance of Windows::Host' do
         host.host_hash[:hypervisor] = 'ec2'
         host.host_hash[:instance] = nil
+        expect(host).to receive(:instance_of?).with(Windows::Host).and_return(false)
         expect(host).to receive(:execute).with("curl http://169.254.169.254/latest/meta-data/public-ipv4").and_return('127.0.0.1')
+        host.get_public_ip
+      end
+
+      it 'calls execute with wget if the host_hash[:instance] is not defined and the host is an instance of Windows::Host' do
+        host.host_hash[:hypervisor] = 'ec2'
+        host.host_hash[:instance] = nil
+        expect(host).to receive(:instance_of?).with(Windows::Host).and_return(true)
+        expect(host).to receive(:execute).with("wget http://169.254.169.254/latest/meta-data/public-ipv4").and_return('127.0.0.1')
         host.get_public_ip
       end
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -696,5 +696,32 @@ module Beaker
       end
     end
 
+    describe '#get_public_ip' do
+      let (:aws) { double('AWSmock')}
+      it 'calls upon the ec2 instance to get the ip address' do
+        host.host_hash[:hypervisor] = 'ec2'
+        host.host_hash[:instance] = aws
+        expect(aws).to receive(:ip_address)
+        host.get_public_ip
+      end
+
+      it 'returns nil when no matching hypervisor is found' do
+        host.host_hash[:hypervisor] = 'vmpooler'
+        expect(host.get_public_ip).to be(nil)
+      end
+    end
+    describe '#ip' do
+      it 'calls #get_ip when get_public_ip returns nil' do
+        allow( host ).to receive(:get_public_ip).and_return(nil)
+        expect(host).to receive(:get_ip).and_return('127.0.0.2')
+        expect(host.ip).to eq('127.0.0.2')
+      end
+
+      it 'does not call get_ip when #get_public_ip returns an address' do
+        allow( host ).to receive(:get_public_ip).and_return('127.0.0.1')
+        expect(host).to_not receive(:get_ip)
+        expect(host.ip).to eq('127.0.0.1')
+      end
+    end
   end
 end


### PR DESCRIPTION
When determining the ip address of a machine, beaker normally ssh'd into
the box and would run a command that would return the ip configured on
that box. However, this doesn't work for several cloud hypervisors, as
the public ip of the box may not match the internally configured ip
address. This change allows for hypervisor specific logic to be executed
instead of sshing into the box. Specifically, this commit changes all
ec2 instances to use the public ip address instead of the private one.