### PR TITLE
(BKR-849) Change AIO distmoduledir to global module directory

### DIFF
--- a/lib/beaker/dsl/install_utils/aio_defaults.rb
+++ b/lib/beaker/dsl/install_utils/aio_defaults.rb
@@ -24,7 +24,7 @@ module Beaker
           'pwindows' => { #pure windows
             'puppetbindir'      => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\bin"',
             'privatebindir'     => '"C:\\Program Files (x86)\\Puppet Labs\\Puppet\\sys\\ruby\\bin";"C:\\Program Files\\Puppet Labs\\Puppet\\sys\\ruby\\bin"',
-            'distmoduledir'     => 'C:\\ProgramData\\PuppetLabs\\code\\environments\\production\\modules',
+            'distmoduledir'     => 'C:\\ProgramData\\PuppetLabs\\code\\modules',
           }
         }
 


### PR DESCRIPTION
In https://github.com/puppetlabs/beaker/pull/932 code was added to AIO to support "pure windows"/pswindows/bitvise directory paths. Unfortunately this hard coded the distmoduledir to C:\ProgramData\PuppetLabs\code\environments\production\modules causing many functions to utilize that directory path, this does not work very well when when the SUT test require different environments (or the node flows through different environments). 

This change modifies distmoduledir to C:\ProgramData\PuppetLabs\code\modules 
