### PR TITLE
touch rpm database

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -222,6 +222,7 @@ module Beaker
         when /^el-/, /centos/, /fedora/, /redhat/, /eos/
           dockerfile += <<-EOF
             RUN yum clean all
+            RUN touch /var/lib/rpm/*
             RUN yum install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
             RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key


### PR DESCRIPTION
When using the overlay storage driver for docker
it is easy to run into the yum install command
failing with

```
Rpmdb checksum is invalid: dCDPT(pkg checksums): openssh.x86_64
0:6.6.1p1-25.el7_2 - u
```

this is an overlay bug as I understand it. This should be harmless
to anyone long after the bug is fixed.

* https://docs.oracle.com/cd/E52668_01/E69348/html/uek4-czc_xmc_xt.html
* https://github.com/docker/docker/issues/10180