### PR TITLE
(BKR-797) timesync helper should handle ntpd already running

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -52,7 +52,7 @@ module Beaker
             when host['platform'] =~ /sles-/
               ntp_command = "sntp #{ntp_server}"
             else
-              ntp_command = "ntpdate -t 20 #{ntp_server}"
+              ntp_command = "ntpdate -u -t 20 #{ntp_server}"
           end
           success=false
           try = 0


### PR DESCRIPTION
This commit fixes a bug where timesync causes beaker to error if the host has ntpd already running.
The fix is simply to use the -u option for ntpdate to use an alternate network port.

Tested on Redhat and Ubuntu.