### PR TITLE
(PE-16065) Bump hocon gem to get latest beaker-answers

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'json', '~> 1.8'
-  s.add_runtime_dependency 'hocon', '~> 0.1'
+  s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '~> 2.9'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 2.0'


### PR DESCRIPTION
Currently beaker is pinning the hocon gem at a version less than 1.0
but beaker-pe requires hocon 1.0 or greater so we are essentially stuck
at an older version of beaker-answers.

This commit bumps the hocon gem in beaker to be at least 1.0 to allow us
to test with the latest beaker-answers.