### PR TITLE
(BKR-871) Don't test packages on Windows

### DIFF
--- a/acceptance/tests/base/packages.rb
+++ b/acceptance/tests/base/packages.rb
@@ -1,5 +1,5 @@
 test_name 'confirm packages on hosts behave correctly'
-confine :except, :platform => %w(osx)
+confine :except, :platform => [/osx/,/windows/]
 
 def get_host_pkg(host)
   case


### PR DESCRIPTION
An update to the Windows2008r2 image template broke the packages test
because it tries to run installation from a folder that has restricted
permissions. This commit makes it so CI will skip testing packages on OSX;
it should be reverted when the install_package method is fixed.