### PR TITLE
(maint) Add missing parenthesis in dsl.rb docs

### DIFF
--- a/lib/beaker/dsl.rb
+++ b/lib/beaker/dsl.rb
@@ -56,8 +56,8 @@ module Beaker
   #     require 'spec_helper'
   #
   #     describe 'A Test With RSpec' do
-  #       let(:hosts)  { Host.new('blah', 'blah', 'not helpful' }
-  #       let(:logger) { Where.is('the', 'rspec', 'logger')     }
+  #       let(:hosts)  { Host.new('blah', 'blah', 'not helpful') }
+  #       let(:logger) { Where.is('the', 'rspec', 'logger')      }
   #
   #       after do
   #         on master, puppet('resource mything ensure=absent')


### PR DESCRIPTION
Prior to this commit, there was a missing closing paren in the code
examples in the DSL documentation.

This commit adds the missing paren.