### PR TITLE
BKR-874 PUPPET_MODULE_INSTALL_IGNORE

### DIFF
--- a/lib/beaker/dsl/install_utils/module_utils.rb
+++ b/lib/beaker/dsl/install_utils/module_utils.rb
@@ -16,7 +16,7 @@ module Beaker
         # The directories in the module directory that will not be scp-ed to the test system when using
         # `copy_module_to`
         PUPPET_MODULE_INSTALL_IGNORE = ['.bundle', '.git', '.idea', '.vagrant', '.vendor', 'vendor', 'acceptance',
-                                        'bundle', 'spec', 'tests', 'log']
+                                        'bundle', 'spec', 'tests', 'log', '.svn', 'junit', 'pkg', 'example']
 
         # Install the desired module on all hosts using either the PMT or a
         #   staging forge


### PR DESCRIPTION
Updated the filtering on PUPPET_MODULE_INSTALL_IGNORE to exclude .svn,
junit, pkg and example folders

Without this change, unnecessary files are copied to the SUT which slows down test execution time.  

The changes filters out build generated files as well, created when using puppetlabs_spec_helper.