### PR TITLE
(BKR-859) Add rake quick start tasks

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'beaker-hostgenerator'
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
@@ -46,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stringify-hash', '~> 0.0'
   s.add_runtime_dependency 'beaker-hiera', '~> 0.0'
   s.add_runtime_dependency 'beaker-pe', '~> 0.0'
+  s.add_runtime_dependency 'beaker-hostgenerator'
 
   # Optional provisioner specific support
   s.add_runtime_dependency 'rbvmomi', '~> 1.8'

--- a/lib/beaker/tasks/quick_start.rb
+++ b/lib/beaker/tasks/quick_start.rb
@@ -1,0 +1,49 @@
+require 'beaker-hostgenerator'
+
+namespace :beaker_quickstart do
+
+  desc 'Generate Default Beaker Host Config File'
+  task :gen_hosts do
+    cli = BeakerHostGenerator::CLI.new(['redhat7-64default.mdcal-redhat7-64af'])
+    FileUtils.mkdir_p('acceptance/config') # -p ignores when dir already exists
+    File.open("acceptance/config/default_hosts.yaml", 'w') do |fh|
+      fh.print(cli.execute)
+    end
+  end
+
+  desc 'Generate Default Pre-Suite'
+  task :gen_pre_suite do
+    FileUtils.mkdir_p('acceptance/setup') # -p ignores when dir already exists
+    File.open("acceptance/setup/default_pre_suite.rb", 'w') do |fh|
+      fh.print('install_pe')
+    end
+  end
+
+  desc 'Generate Default Smoke Test'
+  task :gen_smoke_test do
+    FileUtils.mkdir_p('acceptance/tests') # -p ignores when dir already exists
+    File.open("acceptance/tests/default_smoke_test.rb", 'w') do |fh|
+      fh.print("test_name 'puppet install smoketest'
+step 'puppet install smoketest: verify \\'puppet help\\' can be successfully called on
+all hosts'
+    hosts.each do |host|
+      on host, puppet('help')
+    end")
+    end
+  end
+
+  desc 'Run Default Smoke Test'
+  task :run => ['beaker_quickstart:gen_hosts', 'beaker_quickstart:gen_pre_suite', 'beaker_quickstart:gen_smoke_test'] do
+    system(beaker_command)
+  end
+
+end
+
+def beaker_command
+  cmd_parts = []
+  cmd_parts << "beaker"
+  cmd_parts << "--hosts acceptance/config/default_hosts.yaml"
+  cmd_parts << "--hosts acceptance/setup/default_pre_suite.rb"
+  cmd_parts << "--tests acceptance/tests/default_smoke_test.rb"
+  cmd_parts.flatten.join(" ")
+end

--- a/lib/beaker/tasks/quick_start.rb
+++ b/lib/beaker/tasks/quick_start.rb
@@ -15,7 +15,7 @@ namespace :beaker_quickstart do
   task :gen_pre_suite do
     FileUtils.mkdir_p('acceptance/setup') # -p ignores when dir already exists
     File.open("acceptance/setup/default_pre_suite.rb", 'w') do |fh|
-      fh.print('install_pe')
+      fh.print('install_puppet')
     end
   end
 
@@ -43,7 +43,7 @@ def beaker_command
   cmd_parts = []
   cmd_parts << "beaker"
   cmd_parts << "--hosts acceptance/config/default_hosts.yaml"
-  cmd_parts << "--hosts acceptance/setup/default_pre_suite.rb"
+  cmd_parts << "--pre-suite acceptance/setup/default_pre_suite.rb"
   cmd_parts << "--tests acceptance/tests/default_smoke_test.rb"
   cmd_parts.flatten.join(" ")
 end

--- a/lib/beaker/tasks/rake_task.rb
+++ b/lib/beaker/tasks/rake_task.rb
@@ -97,7 +97,7 @@ module Beaker
         cmd_parts = []
         cmd_parts << "beaker"
         cmd_parts << "--keyfile #{@keyfile}" if @keyfile
-        cmd_parts << "--hosts #{@hosts}" if @hosts
+        cmd_parts << "--hosts #{@hosts}" if (@hosts!=nil && !@hosts.empty?)
         cmd_parts << "--tests #{tests}" if @tests
         cmd_parts << "--options-file #{@options_file}" if @options_file
         cmd_parts << "--type #{@type}" if @type


### PR DESCRIPTION
For generating hosts file, test suite and running test (on vmpooler).
Needed to make beaker-hostgenerator a runtime dependency in order for gen_hosts task to work.

As it stands, I think it's useful to be able to generate default host file and test files for a new user. But not sure how useful the run task would be as they would probably need to edit the files before they kicked off a test run.

Not sure about the tasks as they stand. Some questions (@kevpl @tvpartytonight) :
Should we make the gen_hosts tasks configurable so a different host config string can be passed in?
Should we make the run task configurable so that it can be used to run different pre-suite/tests?

Or do we keep this as simple as possible, as a way to show the workflow to a new user? And address the other issues if we decide to work on the subcommand functionality at a later stage.