### PR TITLE
(BKR-869) Skip deploy_package_repo tests when Fedora

### DIFF
--- a/acceptance/tests/base/packages_unix.rb
+++ b/acceptance/tests/base/packages_unix.rb
@@ -56,6 +56,7 @@ end
 
 step '#deploy_package_repo : deploy puppet-server nightly repo'
 hosts.each do |host|
+  next if host['platform'] =~ /fedora/
   host.deploy_package_repo(pkg_fixtures, pkg_name, 'latest')
   clean_file(host, pkg_name)
 end


### PR DESCRIPTION
Because we are missing packages for Fedora for puppetserver, we should
skip them until they become available.