### PR TITLE
(QENG-4068) Remove unnecessary gem documentation dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'open3'
 require 'securerandom'
 require 'beaker-hostgenerator'
-
+require 'beaker'
 HOSTS_PRESERVED  = 'log/latest/hosts_preserved.yml'
 
 task :default => [ 'test:spec' ]
@@ -27,7 +27,7 @@ task :history do
 end
 
 task :travis do
-  Rake::Task['yard'].invoke
+  Rake::Task['yard'].invoke if !Beaker::Shared::Semvar.version_is_less(RUBY_VERSION, '2.0.0')
   Rake::Task['spec'].invoke
 end
 
@@ -256,8 +256,8 @@ end
 #
 ###########################################################
 DOCS_DIR = 'yard_docs'
-DOCS_DAEMON = "yard server --reload --daemon --server thin --docroot #{DOCS_DIR}"
-FOREGROUND_SERVER = "bundle exec yard server --reload --verbose --server thin lib/beaker --docroot #{DOCS_DIR}"
+DOCS_DAEMON = "yard server --reload --daemon --docroot #{DOCS_DIR}"
+FOREGROUND_SERVER = "bundle exec yard server --reload --verbose lib/beaker --docroot #{DOCS_DIR}"
 
 def running?( cmdline )
   ps = `ps -ef`

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -27,12 +27,7 @@ Gem::Specification.new do |s|
 
   # Documentation dependencies
   s.add_development_dependency 'yard'
-  s.add_development_dependency 'markdown'
-  s.add_development_dependency 'thin'
 
-  # Temporary pin for gems no longer compatible with ruby 1.9.3
-  s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'rack', '~> 1.6'
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'json', '~> 1.8'


### PR DESCRIPTION
These gems are not necessary for beaker itself, and they do not need to
be specified in the the gemspec.