### PR TITLE
(BKR-884) Fix issue in run_block_on

### DIFF
--- a/lib/beaker/shared/host_manager.rb
+++ b/lib/beaker/shared/host_manager.rb
@@ -102,7 +102,7 @@ module Beaker
         end
         if block_hosts.is_a? Array
           if block_hosts.length > 0
-            if opts[:run_in_parallel]
+            if opts[:run_in_parallel] == true
               # Pass caller[1] - the line that called block_on - for logging purposes.
               result = block_hosts.map.each_in_parallel(caller[1]) do |h|
                 run_block_on h, &block

--- a/spec/beaker/shared/host_manager_spec.rb
+++ b/spec/beaker/shared/host_manager_spec.rb
@@ -163,6 +163,14 @@ module Beaker
           }
         end
 
+        it "will ignore run_in_parallel global option" do
+          myhosts = host_handler.run_block_on( hosts, nil, { :run_in_parallel => [] } ) do |host|
+            host
+          end
+          expect( InParallel::InParallelExecutor ).not_to receive(:_execute_in_parallel).with(any_args)
+          expect(myhosts).to eq(hosts)
+        end
+
         it "does not run in parallel if there is only 1 host in the array" do
           myhosts = host_handler.run_block_on( [hosts[0]], nil, { :run_in_parallel => true } ) do |host|
             puts host


### PR DESCRIPTION
Need to check if opts[:run_in_parallel] == true.
If it evaluates to [], it will go into the if statement as it stands.