### PR TITLE
(BKR-890) Surface and provide more visibility into where failures occured

### DIFF
--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -132,8 +132,7 @@ module Beaker
               test = File.read(path)
               eval test,nil,path,1
             rescue FailTest, TEST_EXCEPTION_CLASS => e
-              @test_status = :fail
-              @exception   = e
+              log_and_fail_test(e, :fail)
             rescue PendingTest
               @test_status = :pending
             rescue SkipTest
@@ -166,13 +165,14 @@ module Beaker
         # individually as well.
         #
         # @param exception [Exception] exception to fail with
-        def log_and_fail_test(exception)
+        # @param exception [Symbol] the test status
+        def log_and_fail_test(exception, status=:error)
           logger.error("#{exception.class}: #{exception.message}")
           bt = exception.backtrace
           logger.pretty_backtrace(bt).each_line do |line|
             logger.error(line)
           end
-          @test_status = :error
+          @test_status = status
           @exception   = exception
         end
       end

--- a/spec/beaker/test_case_spec.rb
+++ b/spec/beaker/test_case_spec.rb
@@ -49,7 +49,7 @@ module Beaker
           f.write "raise FailTest"
         end
         @path = path
-        expect( testcase ).to_not receive( :log_and_fail_test )
+        expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(Beaker::DSL::FailTest), :fail).and_call_original
         testcase.run_test
         status = testcase.instance_variable_get(:@test_status)
         expect(status).to be === :fail


### PR DESCRIPTION
BKR-890 - Print failure message and stack trace inline when a test failure occurs