### PR TITLE
(MAINT) add generic dmg and msi installers

### DIFF
--- a/acceptance/tests/install/from_file.rb
+++ b/acceptance/tests/install/from_file.rb
@@ -1,0 +1,18 @@
+test_name 'test generic installers'
+
+step 'install arbitrary msi via url' do
+  hosts.each do |host|
+    if host['platform'] =~ /win/
+      # this should be implemented at the host/win/pkg.rb level someday
+      generic_install_msi_on(host, 'https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.msi', {}, {:debug => true})
+    end
+  end
+end
+
+step 'install arbitrary dmg via url' do
+  hosts.each do |host|
+    if host['platform'] =~ /osx/
+      host.generic_install_dmg('https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg', 'Vagrant', 'Vagrant.pkg')
+    end
+  end
+end

--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -6,8 +6,26 @@ module Mac::Pkg
   end
 
   def install_package(name, cmdline_args = '', version = nil)
-    execute("hdiutil attach #{name}.dmg")
-    execute("installer -pkg /Volumes/#{name}/#{name}.pkg -target /")
+    generic_install_dmg("#{name}.dmg", name, "#{name}.pkg")
+  end
+
+  # Install a package from a specified dmg
+  #
+  # @param [String] dmg_file      The dmg file, including path if not
+  #                               relative. Can be a URL.
+  # @param [String] pkg_base      The base name of the directory that the dmg
+  #                               attaches to under `/Volumes`
+  # @param [String] pkg_name      The name of the package file that should be
+  #                               used by the installer
+  # @example: Install vagrant from URL
+  #   mymachost.generic_install_dmg('https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg', 'Vagrant', 'Vagrant.pkg')
+  def generic_install_dmg(dmg_file, pkg_base, pkg_name)
+    execute("test -f #{dmg_file}", :accept_all_exit_codes => true) do |result|
+      execute("curl -O #{dmg_file}") unless result.exit_code == 0
+    end
+    dmg_name = File.basename(dmg_file, '.dmg')
+    execute("hdiutil attach #{dmg_name}.dmg")
+    execute("installer -pkg /Volumes/#{pkg_base}/#{pkg_name} -target /")
   end
 
   def uninstall_package(name, cmdline_args = '')


### PR DESCRIPTION
This commit adds a generic dmg installer to the OS X package facility.
This allows either a either a local file location or a URL to be specified
to install a dmg on an OS X host. It is based on the existing `install_dmg`
method, but requires the Volume location and package name to be specified by
the caller. These values cannot be introspected without making assumptions
about the packaging.

It also adds a generic msi installer as a helper. It is based on the
`install_msi_on` helper. The additional helper requirements make it a larger
effort to port to the Windows package facility which is not pursued in this
commit. The interface of the `generic_install_msi_on` method is the same as
the `install_msi_on`, it simply removes the validations that are puppet
specific.