### PR TITLE
(MAINT) confined file install acceptance to win/osx

### DIFF
--- a/acceptance/tests/install/from_file.rb
+++ b/acceptance/tests/install/from_file.rb
@@ -1,5 +1,7 @@
 test_name 'test generic installers'
 
+confine :except, :platform => /^windows|osx/
+
 step 'install arbitrary msi via url' do
   hosts.each do |host|
     if host['platform'] =~ /win/


### PR DESCRIPTION
This commit confines the `acceptance/tests/install/from_file.rb`
test to Windows and OSX which are currently the only platforms supported
by the test.