### PR TITLE
(BKR-894) AIX - prefer local DNS if hosts file changed

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -332,6 +332,14 @@ module Beaker
       else
         host.exec(Command.new("echo '#{etc_hosts}' >> /etc/hosts"))
       end
+      # AIX must be configured to prefer local DNS over external
+      if host['platform'] =~ /aix/
+        aix_netsvc = '/etc/netsvc.conf'
+        aix_local_resolv = 'hosts = local, bind'
+        unless host.exec(Command.new("grep '#{aix_local_resolv}' #{aix_netsvc}"), :accept_all_exit_codes => true).exit_code == 0
+          host.exec(Command.new("echo '#{aix_local_resolv}' >> #{aix_netsvc}"))
+        end
+      end
     end
 
     #Make it possible to log in as root by copying the current users ssh keys to the root account


### PR DESCRIPTION
This commit adds logic to the `set_etc_hosts` method to change the
preferred DNS resolution order on AIX platforms.

By default, AIX will first use external DNS to resolve a name even
if the name has an entry in the `/etc/hosts` file. This means that
an externally resolvable hostname cannot be overridden by a local
entry in `/etc/hosts` unless the resolution order is changed. The
logic added with this commit adds the configuration to give precedence
to local DNS resolution.