### PR TITLE
(BKR-896) Fix SELinux context on root's SSH keys

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -360,6 +360,10 @@ module Beaker
         else
           host.exec(Command.new('sudo su -c "cp -r .ssh /root/."'), {:pty => true})
         end
+
+        if host.exec(Command.new('sudo selinuxenabled'), :accept_all_exit_codes => true).exit_code == 0
+          host.exec(Command.new('sudo fixfiles restore /root'))
+        end
       end
     end
 


### PR DESCRIPTION
This runs fixfiles on root's home directory after copying in the user
keys so that systems with SELinux enabled by default will allow root to
login afterwards.