### PR TITLE
(MAINT) Use JSON.pretty_generate to create JSON output

### DIFF
--- a/lib/beaker/dsl/helpers/tk_helpers.rb
+++ b/lib/beaker/dsl/helpers/tk_helpers.rb
@@ -50,7 +50,7 @@ module Beaker
             new_hash.merge!(options_hash)
           end
 
-          file_string = JSON.dump(new_hash)
+          file_string = JSON.pretty_generate(new_hash)
           create_remote_file host, config_file_path, file_string
         end
 

--- a/spec/beaker/dsl/helpers/tk_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/tk_helpers_spec.rb
@@ -72,7 +72,7 @@ describe ClassMixedWithDSLHelpers do
 
       describe 'given a true value to its `replace` parameter' do
         before do
-          expect( JSON ).to receive(:dump)
+          expect( JSON ).to receive(:pretty_generate)
           expect( subject ).to receive(:create_remote_file).with(host, config_file_path, anything())
         end
         include_examples('modify-tk-config-without-error')

--- a/spec/beaker/dsl/helpers/tk_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/tk_helpers_spec.rb
@@ -35,7 +35,7 @@ describe ClassMixedWithDSLHelpers do
 
     shared_examples 'modify-tk-config-without-error' do
       it 'dumps to the SUT config file path' do
-        allow( JSON ).to receive(:dump)
+        allow( JSON ).to receive(:pretty_generate)
         allow( subject ).to receive(:create_remote_file).with(host, config_file_path, anything())
         subject.modify_tk_config(host, config_file_path, options_hash, replace)
       end


### PR DESCRIPTION
`JSON.dump` ruins the formatting of JSON files, which can make TK config files difficult to read. This commit replaces `JSON.dump` with `JSON.pretty_generate` to preserve config file formatting and readability.