### PR TITLE
Feature/libvirt options

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -2,6 +2,7 @@ require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantLibvirt < Beaker::Vagrant
   @memory = nil
+  @cpu    = nil
 
   class << self
     attr_reader :memory
@@ -13,8 +14,21 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
 
   def self.provider_vfile_section(host, options)
     "    v.vm.provider :libvirt do |node|\n" +
+      "      node.cpus = #{cpu(host, options)}\n" +
       "      node.memory = #{memory(host, options)}\n" +
       "    end\n"
+  end
+
+  def self.cpu(host, options)
+    return @cpu unless @cpu.nil?
+    @cpu = case
+    when host['vagrant_cpus']
+      host['vagrant_cpus']
+    when options['vagrant_cpus']
+      options['vagrant_cpus']
+    else
+      '1'
+    end
   end
 
   def self.memory(host, options)

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -16,6 +16,7 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     "    v.vm.provider :libvirt do |node|\n" +
       "      node.cpus = #{cpu(host, options)}\n" +
       "      node.memory = #{memory(host, options)}\n" +
+      build_options_str(options) +
       "    end\n"
   end
 
@@ -41,5 +42,17 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     else
       '512'
     end
+  end
+
+  def self.build_options_str(options)
+    other_options_str = ''
+    if options['libvirt']
+      other_options = []
+      options['libvirt'].each do |k, v|
+        other_options << "      node.#{k} = '#{v}'"
+      end
+      other_options_str = other_options.join("\n")
+    end
+    "#{other_options_str}\n"
   end
 end


### PR DESCRIPTION
Those patches enable one to specify:

    vagrant_cpus: 2
  libvirt:
    uri: qemu+ssh://root@blah/system
    management_network_name: my_vagrant
