### PR TITLE
(MAINT) Document how to do ssh agent forwarding.

### DIFF
--- a/docs/how_to/ssh_agent_forwarding.md
+++ b/docs/how_to/ssh_agent_forwarding.md
@@ -1,0 +1,31 @@
+# How to Forward ssh(1) Agent
+
+`ssh(1)` agent forwarding can is activated in the `CONFIG` section of the hosts
+file:
+
+~~~yaml
+HOSTS:
+  ...
+CONFIG:
+  forward_ssh_agent: true
+~~~
+
+Beaker will then be able to use the user's agent on the host machine.  There is
+a gotcha though: the agent socket file in the virtual machine is only available
+to the user who signed in.  If you want to access remote machine resources as
+another user, you *must* change the socket permission.
+
+A dirty hack is to `chmod -R 777 /tmp/ssh-*` before changing to another user
+and relying on `$SSH_AUTH_SOCK`.
+
+Example:
+
+~~~puppet
+exec { '/bin/chmod -R 777 /tmp/ssh-*':
+} ->
+vcsrepo { '/var/www/app':
+  provider => 'git',
+  source   => 'https://example.com/git/app.git',
+  user     => 'deploy'
+}
+~~~

--- a/docs/how_to/ssh_agent_forwarding.md
+++ b/docs/how_to/ssh_agent_forwarding.md
@@ -10,8 +10,8 @@ CONFIG:
   forward_ssh_agent: true
 ~~~
 
-Beaker will then be able to use the user's agent on the host machine.  There is
-a gotcha though: the agent socket file in the virtual machine is only available
+Beaker will then make the ssh agent running on the beaker coordinator available to the Systems Under Test (SUT).  There is
+a gotcha though: the agent socket file in the SUT is only available
 to the user who signed in.  If you want to access remote machine resources as
 another user, you *must* change the socket permission.
 


### PR DESCRIPTION
I literally spent hours understanding that the `@option` / `option` hash in the code was coming from the `CONFIG` section of the hosts file…  Such a howto would have saved my day :-)