### PR TITLE
(MAINT) Output informational message at debug level.

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -102,7 +102,7 @@ module Beaker
         raise e
       ensure
         @ssh = nil
-        @logger.warn("ssh connection to #{@hostname} has been terminated")
+        @logger.debug("ssh connection to #{@hostname} has been terminated")
       end
     end
 


### PR DESCRIPTION
The previous behavior output this as a warning message, causing it to appear in red with the default configuration which is probably not desired since this is expected in normal conditions.

The new behavior use the same debug level to indicate the connection attempt and the connection terminaison.