### PR TITLE
Preventing SSH config to be overridden for custom vagrant boxes

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -70,6 +70,7 @@ module Beaker
       @logger = host_hash[:logger] || options[:logger]
       @name, @host_hash, @options = name.to_s, host_hash.dup, options.dup
 
+      @logger.info("initialize host with: #{host_hash.to_s}")
       @host_hash = self.platform_defaults.merge(@host_hash)
       pkg_initialize
     end

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -177,7 +177,13 @@ module Beaker
       @hosts.each do |host|
         default_user = host['user']
 
-        set_ssh_config host, 'vagrant'
+        override_ssh = host['vagrant_override_ssh'] ? host['vagrant_override_ssh'] : true
+
+        if(override_ssh)
+          set_ssh_config host, 'vagrant'
+        else
+          @logger.info("don't override ssh config")
+        end
 
         #copy vagrant's keys to roots home dir, to allow for login as root
         copy_ssh_to_root host, @options

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -121,8 +121,16 @@ module Beaker
         ssh_config = ssh_config.gsub(/User vagrant/, "User #{user}")
         f.write(ssh_config)
         f.rewind
-        host['ssh'] = {:config => f.path()}
-        host['user'] = user
+
+        override_ssh = !host['vagrant_override_ssh']  ? host['vagrant_override_ssh'] : true
+        if(override_ssh)
+          @logger.info("Set SSH Config (override existing config)")
+          host['ssh'] = {:config => f.path()}
+          host['user'] = user
+        else
+          @logger.info("don't override ssh config")
+        end
+
         @temp_files << f
     end
 
@@ -177,13 +185,9 @@ module Beaker
       @hosts.each do |host|
         default_user = host['user']
 
-        override_ssh = host['vagrant_override_ssh'] ? host['vagrant_override_ssh'] : true
 
-        if(override_ssh)
-          set_ssh_config host, 'vagrant'
-        else
-          @logger.info("don't override ssh config")
-        end
+        set_ssh_config host, 'vagrant'
+
 
         #copy vagrant's keys to roots home dir, to allow for login as root
         copy_ssh_to_root host, @options


### PR DESCRIPTION
When using custom vagrant boxes without a vagrant user, beaker won't work as the config get overridden by beaker.

I add a host parameter to prevent this.
