### PR TITLE
(BKR-904) Provide A Way To Wait For A Host Reboot

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -239,6 +239,9 @@ module Beaker
                             :project           => @options[:project].to_s })
         @vms << vm
 
+        # Wait for the host to accept ssh logins
+        host.wait_for_port(22)
+
         #enable root if user is not root
         enable_root(host)
 

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -740,5 +740,17 @@ module Beaker
         expect(host.ip).to eq('127.0.0.1')
       end
     end
+
+    describe "#wait_for_port" do
+      it 'returns true when port is open' do
+        allow(host).to receive(:repeat_fibonacci_style_for).and_return(true)
+        expect(host.wait_for_port(22, 0)).to be true
+      end
+
+      it 'returns false when port is not open' do
+        allow(host).to receive(:repeat_fibonacci_style_for).and_return(false)
+        expect(host.wait_for_port(22, 0)).to be false
+      end
+    end
   end
 end

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -59,6 +59,10 @@ module Beaker
         :image_ref => 54321)
       )
 
+      @hosts.each do |host|
+        allow(host).to receive(:wait_for_port).and_return(true)
+      end
+
       openstack.provision
     end
 


### PR DESCRIPTION
Fixes in issue in Host.port_open? where an exception Errno::EHOSTUNREACH is
raised but not rescued.  Creates a wait_for_port wrapper around this function
to wait upon a specific port for a specific time.  Also allows the interval
between checks to be specified to prevent spamming the host.