### PR TITLE
Bkr 915

### DIFF
--- a/docs/how_to/hypervisors/vagrant.md
+++ b/docs/how_to/hypervisors/vagrant.md
@@ -157,3 +157,9 @@ When using the Vagrant Hypervisor, beaker can create the Vagrantfile to forward 
             to_ip: '0.0.0.0'
 
 In the above, beaker will forward port 10080 and 8080 on the Host to port 80 and 8080 (respectively) on the Agent guest.
+
+# vagrant plugins #
+
+You can check more information for some suported vagrant plugins:
+
+ - [vagrant-libvirt](vagrant_libvirt.md)

--- a/docs/how_to/hypervisors/vagrant_libvirt.md
+++ b/docs/how_to/hypervisors/vagrant_libvirt.md
@@ -1,0 +1,58 @@
+# Vagrant Libvirt #
+
+This driver enabled a tester to trigger tests using libvirtd daemon.
+It is based
+on [libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt)'s
+plugin for vagrant.
+
+## Basic Options ##
+
+Once you've setup the libvirt daemon on your beaker coordinator, you
+can use the vagrant_libvirt hypervisor by providing beaker with a
+configuration similar to this:
+
+```yaml
+HOSTS
+  centos-puppet-keystone:
+    hostname: puppet-keystone.example.net
+    roles:
+      - master
+    platform: el-7-x86_64
+    box: centos/7
+    box_url:  http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7.LibVirt.box
+    hypervisor: vagrant_libvirt
+    vagrant_memsize: 4096
+    vagrant_cpus: 2
+```
+
+Those are the usual beaker parameters. Note the `hypervisor`
+parameter. Multiple VMs is supported.
+
+
+## Advanced Options and remote libvirt daemon ##
+
+This driver gives the tester access to all available parameters from
+the vagrant-libvirt plugin. Beware there could be dragons here as
+beaker has some expectations about the created VMs.
+
+To pass them down the operator adds them in the config section, here
+is a example.
+
+```yaml
+CONFIG:
+  libvirt:
+    uri: qemu+ssh://root@libvirt.system.com/system
+```
+
+The `uri` parameter is one of the most useful. The user can have its
+test done on a remote libvirt daemon. The network setup between the
+VMs and the host running beaker will have to be done manually though.
+`management_network_name` and `management_network_address` parameters
+can be useful here.
+
+Another good cadidate is `volume_cache: unsafe`.
+
+A complete list of options is available in
+the
+[vagrant plugin](https://github.com/vagrant-libvirt/vagrant-libvirt)
+repository.

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -2,6 +2,7 @@ require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantLibvirt < Beaker::Vagrant
   @memory = nil
+  @cpu    = nil
 
   class << self
     attr_reader :memory
@@ -13,8 +14,21 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
 
   def self.provider_vfile_section(host, options)
     "    v.vm.provider :libvirt do |node|\n" +
+      "      node.cpus = #{cpu(host, options)}\n" +
       "      node.memory = #{memory(host, options)}\n" +
       "    end\n"
+  end
+
+  def self.cpu(host, options)
+    return @cpu unless @cpu.nil?
+    @cpu = case
+    when host['vagrant_cpus']
+      host['vagrant_cpus']
+    when options['vagrant_cpus']
+      options['vagrant_cpus']
+    else
+      '1'
+    end
   end
 
   def self.memory(host, options)

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -16,6 +16,7 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     "    v.vm.provider :libvirt do |node|\n" +
       "      node.cpus = #{cpu(host, options)}\n" +
       "      node.memory = #{memory(host, options)}\n" +
+      build_options_str(options) +
       "    end\n"
   end
 
@@ -41,5 +42,17 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     else
       '512'
     end
+  end
+
+  def self.build_options_str(options)
+    other_options_str = ''
+    if options['libvirt']
+      other_options = []
+      options['libvirt'].each do |k, v|
+        other_options << "      node.#{k} = '#{v}'"
+      end
+      other_options_str = other_options.join("\n")
+    end
+    "#{other_options_str}\n"
   end
 end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -1,7 +1,11 @@
 require 'spec_helper'
 
 describe Beaker::VagrantLibvirt do
-  let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
+  let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg',
+                                      'logger' => double().as_null_object,
+                                      'libvirt' => { 'uri' => 'qemu+ssh://root@host/system'},
+                                      'vagrant_cpus' => 2,
+                                    }) }
   let( :vagrant ) { Beaker::VagrantLibvirt.new( @hosts, options ) }
 
   before :each do
@@ -27,7 +31,7 @@ describe Beaker::VagrantLibvirt do
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
 
-      vagrant.make_vfile( @hosts )
+      vagrant.make_vfile( @hosts, options )
       @vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
     end
 
@@ -38,6 +42,16 @@ describe Beaker::VagrantLibvirt do
     it "can specify the memory as an integer" do
       expect( @vagrantfile.split("\n").map(&:strip) )
         .to include('node.memory = 512')
+    end
+
+    it "can specify the number of cpus" do
+      expect( @vagrantfile.split("\n").map(&:strip) )
+        .to include("node.cpus = 2")
+    end
+
+    it "can specify any libvirt option" do
+      expect( @vagrantfile.split("\n").map(&:strip) )
+        .to include("node.uri = 'qemu+ssh://root@host/system'")
     end
   end
 end


### PR DESCRIPTION
Those patches enable one to specify:

```
vagrant_cpus: 2

libvirt:
  uri: qemu+ssh://root@blah/system
  management_network_name: my_vagrant
```
