### PR TITLE
(PE-17093) Solaris 10/11 pkg/pkgutil fixes

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -100,7 +100,7 @@ module Unix::Pkg
           execute('/opt/csw/bin/pkgutil -U', opts)
           execute('/opt/csw/bin/pkgutil -y -i pkgutil', opts)
         end
-        execute("/opt/csw/bin/pkgutil -i -y #{cmdline_args} #{name}", opts)
+        execute("pkgutil -i -y #{cmdline_args} #{name}", opts)
       when /openbsd/
         begin
           execute("pkg_add -I #{cmdline_args} #{name}", opts) do |command|

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -92,7 +92,15 @@ module Unix::Pkg
         end
         execute("pkg #{cmdline_args} install #{name}", opts)
       when /solaris-10/
-        execute("pkgutil -i -y #{cmdline_args} #{name}", opts)
+        if ! check_for_command('pkgutil')
+          # https://www.opencsw.org/package/pkgutil/
+          noask_text = self.noask_file_text
+          create_remote_file self, File.join(noask_directory, 'noask'), noask_text
+          execute('pkgadd -d http://get.opencsw.org/now -a noask -n all', opts)
+          execute('/opt/csw/bin/pkgutil -U', opts)
+          execute('/opt/csw/bin/pkgutil -y -i pkgutil', opts)
+        end
+        execute("/opt/csw/bin/pkgutil -i -y #{cmdline_args} #{name}", opts)
       when /openbsd/
         begin
           execute("pkg_add -I #{cmdline_args} #{name}", opts) do |command|
@@ -131,7 +139,7 @@ module Unix::Pkg
   # @param [String] cmdline_args  Additional command line arguments for
   #                               the package manager.
   # @option opts [String] :package_proxy  A proxy of form http://host:port
-  # 
+  #
   # @return nil
   # @api public
   def install_package_with_rpm(name, cmdline_args = '', opts = {})
@@ -284,7 +292,7 @@ module Unix::Pkg
   # @param [String] url  A URL of form http://host:port
   # @return [String]     httpproxy and httport options for rpm
   #
-  # @raise [StandardError] When encountering a string that 
+  # @raise [StandardError] When encountering a string that
   #                        cannot be parsed
   # @api private
   def extract_rpm_proxy_options(url)

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -22,6 +22,7 @@ module Beaker
     DEBIAN_PACKAGES = ['curl', 'ntpdate', 'lsb-release']
     CUMULUS_PACKAGES = ['curl', 'ntpdate']
     SOLARIS10_PACKAGES = ['CSWcurl', 'CSWntp']
+    SOLARIS11_PACKAGES = ['curl', 'ntp']
     ETC_HOSTS_PATH = "/etc/hosts"
     ETC_HOSTS_PATH_SOLARIS = "/etc/inet/hosts"
     ROOT_KEYS_SCRIPT = "https://raw.githubusercontent.com/puppetlabs/puppetlabs-sshkeys/master/templates/scripts/manage_root_authorized_keys"
@@ -111,6 +112,8 @@ module Beaker
           check_and_install_packages_if_needed(host, OPENBSD_PACKAGES)
         when host['platform'] =~ /solaris-10/
           check_and_install_packages_if_needed(host, SOLARIS10_PACKAGES)
+        when host['platform'] =~ /solaris-1[1-9]/
+          check_and_install_packages_if_needed(host, SOLARIS11_PACKAGES)
         when host['platform'] !~ /debian|aix|solaris|windows|sles-|osx-|cumulus|f5-|netscaler|cisco_/
           check_and_install_packages_if_needed(host, UNIX_PACKAGES)
         end


### PR DESCRIPTION
Prior to this commit Solaris 10 would blow up if pkgutil wasn't
installed. Solaris 11 was not verifying that curl/ntp were installed.

This commit adds logic to install pkgutil if it isn't found on
Solaris 11, as well as adding package checks for Solaris 11 so that
it actually verifies that ntp/curl are installed.