### PR TITLE
(BKR-914) Fix loose checking in add, get and clear env_var

### DIFF
--- a/acceptance/tests/base/host/host_test.rb
+++ b/acceptance/tests/base/host/host_test.rb
@@ -27,6 +27,112 @@ hosts.each do |host|
   end
 end
 
+step "#get_env_var : can get a specific environment variable"
+hosts.each do |host|
+  env_prefix = 'BEAKER' + SecureRandom.hex(4).upcase
+  env_param1 = "#{env_prefix}_p1"
+  env_value1 = "#{env_prefix}_v1"
+
+  host.clear_env_var(env_param1)
+  host.add_env_var(env_param1,env_value1)
+
+  val = host.get_env_var(env_param1)
+
+  assert_match(/^#{env_param1}=#{env_value1}$/, val, "get_env_var can get a specific environment variable")
+end
+
+step "#get_env_var : should not match a partial env key name"
+hosts.each do |host|
+  env_id = 'BEAKER' + SecureRandom.hex(4).upcase
+  # Used as a prefix
+  env_param1 = "#{env_id}_pre"
+  env_value1 = "#{env_id}_pre"
+  # Used as a suffix
+  env_param2 = "suf_#{env_id}"
+  env_value2 = "suf_#{env_id}"
+  # Used as a infix
+  env_param3 = "in_#{env_id}_in"
+  env_value3 = "in_#{env_id}_in"
+
+  host.clear_env_var(env_param1)
+  host.clear_env_var(env_param2)
+  host.clear_env_var(env_param3)
+  host.add_env_var(env_param1,env_value1)
+  host.add_env_var(env_param1,env_value2)
+  host.add_env_var(env_param1,env_value3)
+
+  val = host.get_env_var(env_id)
+  assert('' == val,'get_env_var should not match a partial env key name')
+end
+
+step "#get_env_var : should not return a match from a key\'s value"
+hosts.each do |host|
+  env_prefix = 'BEAKER' + SecureRandom.hex(4).upcase
+  env_param1 = "#{env_prefix}_p1"
+  env_value1 = "#{env_prefix}_v1"
+
+  host.clear_env_var(env_param1)
+  host.add_env_var(env_param1,env_value1)
+
+  val = host.get_env_var(env_value1)
+  assert('' == val,'get_env_var should not return a match from a key\'s value')
+end
+
+step "#clear_env_var : should only remove the specified key"
+hosts.each do |host|
+  # Note - Must depend on `SecureRandom.hex(4)` creating a unique key as unable to depend on the function under test `clear_env_var`
+  env_id = 'BEAKER' + SecureRandom.hex(4).upcase
+  # Use env_id as a suffix
+  env_param1 = "p1_#{env_id}"
+  env_value1 = "v1_#{env_id}"
+  # Use env_id as a prefix
+  env_param2 = "#{env_id}_p2"
+  env_value2 = "#{env_id}_v2"
+  # Use env_id a key to delete
+  env_param3 = "#{env_id}"
+  env_value3 = "#{env_id}"
+  
+  host.add_env_var(env_param1,env_value1)
+  host.add_env_var(env_param2,env_value2)
+  host.add_env_var(env_param3,env_value3)
+
+  host.clear_env_var(env_param3)
+
+  val = host.get_env_var(env_param1)
+  assert_match(/^#{env_param1}=#{env_value1}$/, val, "#{env_param1} should exist after calling clear_env_var")
+  val = host.get_env_var(env_param2)
+  assert_match(/^#{env_param2}=#{env_value2}$/, val, "#{env_param2} should exist after calling clear_env_var")
+  val = host.get_env_var(env_param3)
+  assert('' == val,"#{env_param3} should not exist after calling clear_env_var")
+end
+
+step "#add_env_var : can add a unique environment variable"
+hosts.each do |host|
+  env_id = 'BEAKER' + SecureRandom.hex(4).upcase
+  env_param1 = "#{env_id}"
+  env_value1 = "#{env_id}"
+  # Use env_id as a prefix
+  env_param2 = "#{env_id}_pre"
+  env_value2 = "#{env_id}_pre"
+  # Use env_id as a suffix
+  env_param3 = "suf_#{env_id}"
+  env_value3 = "suf_#{env_id}"
+
+  host.clear_env_var(env_param1)
+  host.clear_env_var(env_param2)
+  host.clear_env_var(env_param3)
+  host.add_env_var(env_param1,env_value1)
+  host.add_env_var(env_param2,env_value2)
+  host.add_env_var(env_param3,env_value3)
+
+  val = host.get_env_var(env_param1)
+  assert_match(/^#{env_param1}=#{env_value1}$/, val, "#{env_param1} should exist")
+  val = host.get_env_var(env_param2)
+  assert_match(/^#{env_param2}=#{env_value2}$/, val, "#{env_param2} should exist")
+  val = host.get_env_var(env_param3)
+  assert_match(/^#{env_param3}=#{env_value3}$/, val, "#{env_param3} should exist")
+end
+
 step "#add_env_var : can add an environment variable"
 hosts.each do |host|
   host.clear_env_var("test")

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -106,7 +106,7 @@ module Unix::Exec
     if exec(Beaker::Command.new("grep ^#{key}=.*#{escaped_val} #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
       return #nothing to do here, key value pair already exists
     #see if the key already exists
-    elsif exec(Beaker::Command.new("grep ^#{key} #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
+    elsif exec(Beaker::Command.new("grep ^#{key}= #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
       exec(Beaker::SedCommand.new(self['platform'], "s/^#{key}=/#{key}=#{escaped_val}:/", env_file))
     else
       exec(Beaker::Command.new("echo \"#{key}=#{val}\" >> #{env_file}"))
@@ -142,7 +142,7 @@ module Unix::Exec
   #  host.get_env_var('path')
   def get_env_var key
     key = key.to_s
-    exec(Beaker::Command.new("env | grep #{key}"), :accept_all_exit_codes => true).stdout.chomp
+    exec(Beaker::Command.new("env | grep ^#{key}="), :accept_all_exit_codes => true).stdout.chomp
   end
 
   #Delete the environment variable from the current ssh environment
@@ -153,7 +153,7 @@ module Unix::Exec
     key = key.to_s
     env_file = self[:ssh_env_file]
     #remove entire line
-    exec(Beaker::SedCommand.new(self['platform'], "/#{key}=.*$/d", env_file))
+    exec(Beaker::SedCommand.new(self['platform'], "/^#{key}=.*$/d", env_file))
     #update the profile.d to current state
     #match it to the contents of ssh_env_file
     mirror_env_to_profile_d(env_file)
@@ -296,7 +296,7 @@ module Unix::Exec
 
   # Checks if selinux is enabled
   #
-  # @return [Boolean] true if selinux is enabled, false otherwise 
+  # @return [Boolean] true if selinux is enabled, false otherwise
   def selinux_enabled?()
     exec(Beaker::Command.new("sudo selinuxenabled"), :accept_all_exit_codes => true).exit_code == 0
   end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -197,7 +197,7 @@ module Beaker
         result.exit_code = 1
         expect( Beaker::Command ).to receive(:new).with("grep ^key=.*\\/my\\/first\\/value ~/.ssh/environment")
         expect( host ).to receive(:exec).and_return(result)
-        expect( Beaker::Command ).to receive(:new).with(/grep \^key ~\/\.ssh\/environment/)
+        expect( Beaker::Command ).to receive(:new).with(/grep \^key= ~\/\.ssh\/environment/)
         expect( host ).to receive(:exec).and_return(result)
         expect( Beaker::Command ).to receive(:new).with("echo \"key=/my/first/value\" >> ~/.ssh/environment")
         host.add_env_var('key', '/my/first/value')
@@ -210,7 +210,7 @@ module Beaker
         expect( host ).to receive(:exec).and_return(result)
         result = Beaker::Result.new(host, '')
         result.exit_code = 0
-        expect( Beaker::Command ).to receive(:new).with(/grep \^key ~\/\.ssh\/environment/)
+        expect( Beaker::Command ).to receive(:new).with(/grep \^key= ~\/\.ssh\/environment/)
         expect( host ).to receive(:exec).and_return(result)
         expect( Beaker::SedCommand ).to receive(:new).with('unix', 's/^key=/key=\\/my\\/first\\/value:/', '~/.ssh/environment')
         host.add_env_var('key', '/my/first/value')


### PR DESCRIPTION
Previously the regular expression to add, get or clear an environment variable
were too loose, matching lines which were not intended e.g. `get_env_var("abc")`
would match `abc=123`, `xx_abc_xx=123` and `123=abc` however the intent of the
function would be to only match `abc=123` i.e. Get the env var called 'abc'.

This commit modifies the `add_env_var`, `get_env_var` and `clear_env_var` grep
statements to prefix `#{key}` with `^` and a trailing `=` to ensure that the
matches are as intended.  This commit also includes additional acceptance tests
for this behavior.