### PR TITLE
(BKR-916) Use dns_name for ec2 hostnames

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -630,19 +630,21 @@ module Beaker
       @logger.notify("netscaler: nsroot password is #{host['instance'].id}")
     end
 
-    # Set the hostname of all instances to be the hostname defined in the
-    # beaker configuration.
+    # Set the :vmhostname for each host object to be the dns_name, which is accessible
+    # publicly. Then configure each ec2 machine to that dns_name, so that when facter
+    # is installed the facts for hostname and domain match the dns_name.
     #
-    # @return [void]
+    # @return [@hosts]
     # @api private
     def set_hostnames
       @hosts.each do |host|
+        host[:vmhostname] = host[:dns_name]
         if host['platform'] =~ /el-7/
           # on el-7 hosts, the hostname command doesn't "stick" randomly
-          host.exec(Command.new("hostnamectl set-hostname #{host.name}"))
+          host.exec(Command.new("hostnamectl set-hostname #{host.hostname}"))
         else
           next if host['platform'] =~ /netscaler/
-          host.exec(Command.new("hostname #{host.name}"))
+          host.exec(Command.new("hostname #{host.hostname}"))
         end
       end
     end

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -602,7 +602,7 @@ module Beaker
 
       context 'for each host' do
         it 'calls exec' do
-          @hosts.each do |host| 
+          @hosts.each do |host|
             expect(host).to receive(:exec).once unless host['platform'] =~ /netscaler/
           end
           expect(set_hostnames).to eq(@hosts)
@@ -614,6 +614,15 @@ module Beaker
           end
           expect(set_hostnames).to eq(@hosts)
         end
+
+        it 'sets the the vmhostname to the dns_name for each host' do
+          expect(set_hostnames).to eq(@hosts)
+          @hosts.each do |host|
+            expect(host[:vmhostname]).to eq(host[:dns_name])
+            expect(host[:vmhostname]).to eq(host.hostname)
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
Prior to this change, provisioning in ec2 would set each host's hostname
to the `name` attribute of the host. This change removes that behavior
and sets each host's hostname to be the public facing `dns_name`
provided by ec2 to allow traffic from outside ec2 to route correctly to
that host.