### PR TITLE
(PE-17093) Fix noask directory path

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -95,8 +95,9 @@ module Unix::Pkg
         if ! check_for_command('pkgutil')
           # https://www.opencsw.org/package/pkgutil/
           noask_text = self.noask_file_text
-          create_remote_file self, File.join(noask_directory, 'noask'), noask_text
-          execute('pkgadd -d http://get.opencsw.org/now -a noask -n all', opts)
+          noask_file = File.join(opts[:copy_dir_external], 'noask')
+          create_remote_file(self, noask_file, noask_text)
+          execute("pkgadd -d http://get.opencsw.org/now -a #{noask_file} -n all", hpts)
           execute('/opt/csw/bin/pkgutil -U', opts)
           execute('/opt/csw/bin/pkgutil -y -i pkgutil', opts)
         end


### PR DESCRIPTION
Prior to this commit I attempted to use a variable that doesn't exist
`noask_directory`.
This commit uses the `opts[:copy_dir_external]` varible instead, which
should be provided by beaker, and default to `/root`