### PR TITLE
(maint) Add security group option to openstack hypervisor initialization

### DIFF
--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -16,7 +16,6 @@ Get openstack Access & Security credentials:
 - "openstack_tenant"
 - "openstack_network"
 - "openstack_keyname"
-- "security_group" (optional)
 
 If you are using [OpenStack Dashboard "Horizon"] (https://wiki.openstack.org/wiki/Horizon) 
 you can find these keys in next places:
@@ -28,8 +27,6 @@ you can find these keys in next places:
 2. "openstack_network": in "project" -> "Networks"
 3. "openstack_keyname": in "project" -> "Compute" -> "Access & Security" -> tab "Key Pairs"
 4. "openstack_api_key": Your user Password
-5. "security_group": in "project" -> "Compute" -> "Access & Security"
--> tab "Security Groups"
 
 ### Setup a Openstack Hosts File
 
@@ -60,7 +57,6 @@ in order for the Openstack hypervisor to provision hosts properly.
       openstack_tenant: testing
       openstack_network : testing
       openstack_keyname : nopass
-      security_group    : ['sg0', 'default']
 
 The `image` - image name.
 
@@ -108,5 +104,13 @@ Also if you plan use `user-data` make sure that 'cloud-init' package installed i
       openstack_tenant: testing
       openstack_network : testing
       openstack_keyname : nopass
-      security_group    : ['sg0', 'default']
 
+### Security groups
+
+A security group is a set of rules for incoming and outgoing traffic to 
+an instance.  You can associate a host with one or many security groups
+in the `CONFIG` section of your hosts file:
+
+    security_group: ['my_sg', 'default']
+
+This is an optional config parameter.

--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -16,6 +16,7 @@ Get openstack Access & Security credentials:
 - "openstack_tenant"
 - "openstack_network"
 - "openstack_keyname"
+- "security_group" (optional)
 
 If you are using [OpenStack Dashboard "Horizon"] (https://wiki.openstack.org/wiki/Horizon) 
 you can find these keys in next places:
@@ -27,6 +28,8 @@ you can find these keys in next places:
 2. "openstack_network": in "project" -> "Networks"
 3. "openstack_keyname": in "project" -> "Compute" -> "Access & Security" -> tab "Key Pairs"
 4. "openstack_api_key": Your user Password
+5. "security_group": in "project" -> "Compute" -> "Access & Security"
+-> tab "Security Groups"
 
 ### Setup a Openstack Hosts File
 
@@ -57,6 +60,7 @@ in order for the Openstack hypervisor to provision hosts properly.
       openstack_tenant: testing
       openstack_network : testing
       openstack_keyname : nopass
+      security_group    : ['sg0', 'default']
 
 The `image` - image name.
 
@@ -104,5 +108,5 @@ Also if you plan use `user-data` make sure that 'cloud-init' package installed i
       openstack_tenant: testing
       openstack_network : testing
       openstack_keyname : nopass
-
+      security_group    : ['sg0', 'default']
 

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -28,6 +28,7 @@ module Beaker
       expect(options['openstack_tenant']).to eq('testing')
       expect(options['openstack_network']).to eq('testing')
       expect(options['openstack_keyname']).to eq('nopass')
+      expect(options['security_group']).to eq(['my_sg', 'default'])
     end
 
     it 'check hosts options during initialization' do
@@ -53,6 +54,7 @@ module Beaker
 
       mock_servers = double().as_null_object
       allow( @compute_client ).to receive( :servers ).and_return( mock_servers )
+
       expect(mock_servers).to receive(:create).with(hash_including(
         :user_data => '#cloud-config\nmanage_etc_hosts: true\nfinal_message: "The host is finally up!"',
         :flavor_ref => 12345,

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -69,7 +69,8 @@ module HostHelpers
                                                :openstack_auth_url => "http://openstack_hypervisor.labs.net:5000/v2.0/tokens",
                                                :openstack_tenant => "testing",
                                                :openstack_network => "testing",
-                                               :openstack_keyname => "nopass" } )
+                                               :openstack_keyname => "nopass", 
+                                               :security_group => ['my_sg', 'default'] } )
   end
 
   def generate_result (name, opts )


### PR DESCRIPTION
Because Puppet has it's own security group that is not default but is necessary to connect to an openstack instance, I'd like to add a security group option to the hosts config file so that the user can specify security group(s) to add to an instance on creation.

This is just an initial commit. I'm not sure how to test or verify the work I've done, so any help in that area would be excellent!