### PR TITLE
(MAINT) Remove alias_method statements

### DIFF
--- a/acceptance/pre_suite/puppet_gem/install.rb
+++ b/acceptance/pre_suite/puppet_gem/install.rb
@@ -1,7 +1,7 @@
 hosts.each do |host|
-  install_puppet_from_gem(host, {:version => '3.8.7'})
+  install_puppet_from_gem_on(host, {:version => '3.8.7'})
   unless host['platform'] =~ /windows/
-    on(host, "touch #{File.join(host.puppet['confdir'],'puppet.conf')}")
+    on(host, "touch #{File.join(host.puppet_configprint['confdir'],'puppet.conf')}")
     on(host, puppet('resource user puppet ensure=present'))
     on(host, puppet('resource group puppet ensure=present'))
   end

--- a/acceptance/pre_suite/puppet_git/install.rb
+++ b/acceptance/pre_suite/puppet_git/install.rb
@@ -63,9 +63,9 @@ hosts.each do |host|
 
     step "#{host} Install ruby from git using revision #{revision}"
     # TODO remove this step once we are installing puppet from msi packages
-    install_from_git(host, "/opt/puppet-git-repos",
+    install_from_git_on(host, "/opt/puppet-git-repos",
                      :name => 'puppet-win32-ruby',
-                     :path => build_giturl('puppet-win32-ruby'),
+                     :path => build_git_url('puppet-win32-ruby'),
                      :rev  => revision)
     on host, 'cd /opt/puppet-git-repos/puppet-win32-ruby; cp -r ruby/* /'
     on host, 'cd /lib; icacls ruby /grant "Everyone:(OI)(CI)(RX)"'
@@ -88,10 +88,10 @@ repos = order_packages(tmp_repos)
 
 hosts.each do |host|
   repos.each do |repo|
-    install_from_git(host, SourcePath, repo)
+    install_from_git_on(host, SourcePath, repo)
   end
   unless host['platform'] =~ /windows/
-    on(host, "touch #{File.join(host.puppet['confdir'],'puppet.conf')}")
+    on(host, "touch #{File.join(host.puppet_configprint['confdir'],'puppet.conf')}")
     on(host, puppet('resource user puppet ensure=present'))
     on(host, puppet('resource group puppet ensure=present'))
   end

--- a/acceptance/tests/puppet/install_smoke_test.rb
+++ b/acceptance/tests/puppet/install_smoke_test.rb
@@ -17,5 +17,5 @@ end
 
 step "puppet install smoketest: can get a configprint of the puppet server setting on all hosts"
 hosts.each do |host|
-  assert(!host.puppet['server'].empty?, "can get a configprint of the puppet server setting")
+  assert(!host.puppet_configprint['server'].empty?, "can get a configprint of the puppet server setting")
 end

--- a/lib/beaker/dsl/assertions.rb
+++ b/lib/beaker/dsl/assertions.rb
@@ -105,8 +105,6 @@ module Beaker
         assert(regexp !~ string, msg)
       end
 
-      alias_method :assert_not_match, :assert_no_match
-
     end
   end
 end

--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -159,7 +159,7 @@ module Beaker
             modify_tk_config(host, puppetserver_conf, puppetserver_opts)
           end
           begin
-            backup_file = backup_the_file(host, host.puppet('master')['confdir'], testdir, 'puppet.conf')
+            backup_file = backup_the_file(host, host.puppet_configprint('master')['confdir'], testdir, 'puppet.conf')
             lay_down_new_puppet_conf host, conf_opts, testdir
 
             if host.use_service_scripts? && !service_args[:bypass_service_script]
@@ -233,7 +233,7 @@ module Beaker
 
         # @!visibility private
         def restore_puppet_conf_from_backup( host, backup_file )
-          puppet_conf = host.puppet('master')['config']
+          puppet_conf = host.puppet_configprint('master')['config']
 
           if backup_file
             host.exec( Command.new( "if [ -f '#{backup_file}' ]; then " +
@@ -288,7 +288,7 @@ module Beaker
 
         # @!visibility private
         def lay_down_new_puppet_conf( host, configuration_options, testdir )
-          puppetconf_main = host.puppet('master')['config']
+          puppetconf_main = host.puppet_configprint('master')['config']
           puppetconf_filename = File.basename(puppetconf_main)
           puppetconf_test = File.join(testdir, puppetconf_filename)
 
@@ -304,7 +304,7 @@ module Beaker
 
         # @!visibility private
         def puppet_conf_for host, conf_opts
-          puppetconf = host.exec( Command.new( "cat #{host.puppet('master')['config']}" ) ).stdout
+          puppetconf = host.exec( Command.new( "cat #{host.puppet_configprint('master')['config']}" ) ).stdout
           new_conf   = IniFile.new( puppetconf ).merge( conf_opts )
 
           new_conf

--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -61,7 +61,6 @@ module Beaker
           repo = (git_server == 'github.com') ? "#{git_fork}/#{project_name}.git" : "#{git_fork}-#{project_name}.git"
           return git_protocol == 'git@' ? "#{git_protocol}#{git_server}:#{repo}" : "#{git_protocol}#{git_server}/#{repo}"
         end
-        alias_method :build_giturl, :build_git_url
 
         # @param [String] uri A uri in the format of <git uri>#<revision>
         #                     the `git://`, `http://`, `https://`, and ssh
@@ -199,7 +198,6 @@ module Beaker
                     "ruby ./install.rb #{install_opts}; " +
                     "else true; fi", opts
         end
-        alias_method :install_from_git, :install_from_git_on
 
         # @deprecated Use {#install_puppet_on} instead.
         def install_puppet(opts = {})
@@ -297,7 +295,7 @@ module Beaker
               if ((host['platform'] =~ /windows/) and not host.is_cygwin?)
                 # Do nothing
               else
-                on host, "echo '' >> #{host.puppet['hiera_config']}"
+                on host, "echo '' >> #{host.puppet_configprint['hiera_config']}"
               end
             end
           end
@@ -414,7 +412,7 @@ module Beaker
           end
           logger.debug( "setting config '#{puppet_conf_text}' on hosts #{hosts}" )
           block_on hosts, opts do |host|
-            puppet_conf_path = host.puppet['config']
+            puppet_conf_path = host.puppet_configprint['config']
             create_remote_file(host, puppet_conf_path, puppet_conf_text)
           end
         end
@@ -434,7 +432,7 @@ module Beaker
         # @api private
         def install_puppet_from_rpm_on( hosts, opts )
           block_on hosts do |host|
-            install_puppetlabs_release_repo(host)
+            install_puppetlabs_release_repo_on(host)
 
             if opts[:facter_version]
               host.install_package("facter-#{opts[:facter_version]}")
@@ -449,7 +447,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppet_from_rpm, :install_puppet_from_rpm_on
 
         # Installs Puppet and dependencies from deb on provided host(s).
         #
@@ -464,7 +461,7 @@ module Beaker
         # @api private
         def install_puppet_from_deb_on( hosts, opts )
           block_on hosts do |host|
-            install_puppetlabs_release_repo(host)
+            install_puppetlabs_release_repo_on(host)
 
             if opts[:facter_version]
               host.install_package("facter=#{opts[:facter_version]}-1puppetlabs1")
@@ -483,7 +480,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppet_from_deb, :install_puppet_from_deb_on
 
         # Installs Puppet and dependencies from msi on provided host(s).
         #
@@ -519,7 +515,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppet_from_msi, :install_puppet_from_msi_on
 
         # @api private
         def compute_puppet_msi_name(host, opts)
@@ -638,7 +633,6 @@ module Beaker
           end
 
         end
-        alias_method :install_puppet_from_freebsd_ports, :install_puppet_from_freebsd_ports_on
 
         # Installs Puppet and dependencies from dmg on provided host(s).
         #
@@ -686,7 +680,6 @@ module Beaker
             end
           end
         end
-        alias_method :install_puppet_from_dmg, :install_puppet_from_dmg_on
 
         # Installs puppet-agent and dependencies from dmg on provided host(s).
         #
@@ -856,14 +849,12 @@ module Beaker
 
             # A gem install might not necessarily create these
             ['confdir', 'logdir', 'codedir'].each do |key|
-              host.mkdir_p host.puppet[key] if host.puppet.has_key?(key)
+              host.mkdir_p host.puppet_configprint[key] if host.puppet_configprint.has_key?(key)
             end
 
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppet_from_gem,          :install_puppet_from_gem_on
-        alias_method :install_puppet_agent_from_gem_on, :install_puppet_from_gem_on
 
         # Install official puppetlabs release repository configuration on host(s).
         #
@@ -917,7 +908,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppetlabs_release_repo, :install_puppetlabs_release_repo_on
 
         # Installs the repo configs on a given host
         #
@@ -1127,7 +1117,6 @@ module Beaker
             configure_type_defaults_on( host )
           end
         end
-        alias_method :install_puppetagent_dev_repo, :install_puppet_agent_dev_repo_on
 
         # Install shared repo of the puppet-agent on the given host(s).  Downloaded from
         # location of the form PE_PROMOTED_BUILDS_URL/PE_VER/puppet-agent/AGENT_VERSION/repo

--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -13,7 +13,6 @@ module Beaker
         def get_system_temp_path(host)
           host.system_temp_path
         end
-        alias_method :get_temp_path, :get_system_temp_path
 
         # Generates commands to be inserted into a Windows batch file to launch an MSI install
         # @param [String] msi_path The path of the MSI - can be a local Windows style file path like

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -133,7 +133,6 @@ module Beaker
     def puppet_configprint(command='agent')
       PuppetConfigReader.new(self, command)
     end
-    alias_method :puppet, :puppet_configprint
 
     def []= k, v
       host_hash[k] = v

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -392,7 +392,7 @@ module Beaker
         exclude_roles = %w(master database dashboard)
         host_roles    = host_hash[:roles]
         unless (host_roles & exclude_roles).empty?
-          @validator.parser_error "#{host_hash[:platform].to_s} box '#{host_name}' may not have roles: #{exclude_roles.join(', ')}."
+          @validator.validator_error "#{host_hash[:platform].to_s} box '#{host_name}' may not have roles: #{exclude_roles.join(', ')}."
         end
       end
 

--- a/lib/beaker/options/validator.rb
+++ b/lib/beaker/options/validator.rb
@@ -28,9 +28,6 @@ module Beaker
         raise ArgumentError, msg.to_s
       end
 
-      # alias to keep old methods and functionality from throwing errors.
-      alias_method :parser_error, :validator_error
-
       # Raises an ArgumentError if more than one default exists,
       # otherwise returns true or false if default is set.
       #

--- a/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
@@ -917,16 +917,16 @@ describe ClassMixedWithDSLHelpers do
           mock_puppetconf_reader = Object.new
           allow( mock_puppetconf_reader ).to receive( :[] ).with( 'config' ).and_return( '/root/mock/puppet.conf' )
           allow( mock_puppetconf_reader ).to receive( :[] ).with( 'confdir' ).and_return( '/root/mock' )
-          allow( host ).to receive( :puppet ).with( any_args ).and_return( mock_puppetconf_reader )
+          allow( host ).to receive( :puppet_configprint ).with( any_args ).and_return( mock_puppetconf_reader )
         end
 
-        let(:original_location) { host.puppet['config'] }
+        let(:original_location) { host.puppet_configprint['config'] }
         let(:backup_location) {
-          filename = File.basename(host.puppet['config'])
+          filename = File.basename(host.puppet_configprint['config'])
           File.join(tmpdir_path, "#{filename}.bak")
         }
         let(:new_location) {
-          filename = File.basename(host.puppet['config'])
+          filename = File.basename(host.puppet_configprint['config'])
           File.join(tmpdir_path, filename)
         }
 

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -167,21 +167,21 @@ describe ClassMixedWithDSLInstallUtils do
       allow(ENV).to receive(:[]).with('FORK').and_return(nil)
       allow(ENV).to receive(:[]).with('PUPPET_FORK').and_return(nil)
       allow(ENV).to receive(:[]).with('PUPPET_SERVER').and_return(nil)
-      url = subject.build_giturl('puppet')
+      url = subject.build_git_url('puppet')
       expect(url).to be == 'https://github.com/puppetlabs/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck')
+      url = subject.build_git_url('puppet', 'er0ck')
       expect(url).to be == 'https://github.com/er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'bitbucket.com')
+      url = subject.build_git_url('puppet', 'er0ck', 'bitbucket.com')
       expect(url).to be == 'https://bitbucket.com/er0ck-puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https://')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'https://')
       expect(url).to be == 'https://github.com/er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'https')
       expect(url).to be == 'https://github.com/er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git@')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'git@')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'git')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'ssh')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'ssh')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
     end
 
@@ -190,21 +190,21 @@ describe ClassMixedWithDSLInstallUtils do
       allow(ENV).to receive(:[]).with('FORK').and_return(nil)
       allow(ENV).to receive(:[]).with('PUPPET_FORK').and_return('er0ck/repo')
       allow(ENV).to receive(:[]).with('PUPPET_SERVER').and_return('gitlab.com')
-      url = subject.build_giturl('puppet')
+      url = subject.build_git_url('puppet')
       expect(url).to be == 'https://gitlab.com/er0ck/repo-puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck')
+      url = subject.build_git_url('puppet', 'er0ck')
       expect(url).to be == 'https://gitlab.com/er0ck-puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'bitbucket.com')
+      url = subject.build_git_url('puppet', 'er0ck', 'bitbucket.com')
       expect(url).to be == 'https://bitbucket.com/er0ck-puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https://')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'https://')
       expect(url).to be == 'https://github.com/er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'https')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'https')
       expect(url).to be == 'https://github.com/er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git@')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'git@')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'git')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'git')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
-      url = subject.build_giturl('puppet', 'er0ck', 'github.com', 'ssh')
+      url = subject.build_git_url('puppet', 'er0ck', 'github.com', 'ssh')
       expect(url).to be == 'git@github.com:er0ck/puppet.git'
     end
   end
@@ -284,7 +284,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
 
-      subject.install_puppet_from_msi( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}  )
+      subject.install_puppet_from_msi_on( winhost, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}  )
     end
 
     it 'installs puppet on non-cygwin windows' do
@@ -299,7 +299,7 @@ describe ClassMixedWithDSLInstallUtils do
 
       expect(subject).to receive(:install_msi_on).with(winhost_non_cygwin, "#{win_temp}\\puppet-3.7.1.msi", {}, {:debug => nil})
 
-      subject.install_puppet_from_msi( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}   )
+      subject.install_puppet_from_msi_on( winhost_non_cygwin, {:version => '3.7.1', :win_download_url => 'http://downloads.puppetlabs.com/windows'}   )
     end
   end
 
@@ -368,7 +368,7 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
-  context 'install_from_git' do
+  context 'install_from_git_on' do
     it 'does a ton of stuff it probably shouldnt' do
       repo = { :name => 'puppet',
                :path => 'git://my.server.net/puppet.git',
@@ -384,7 +384,7 @@ describe ClassMixedWithDSLInstallUtils do
       expect( subject ).to receive( :on ).exactly( 4 ).times
 
       subject.instance_variable_set( :@metadata, {} )
-      subject.install_from_git( host, path, repo )
+      subject.install_from_git_on( host, path, repo )
     end
 
     it 'should attempt to install ruby code' do
@@ -471,7 +471,7 @@ describe ClassMixedWithDSLInstallUtils do
         let(:platform) { Beaker::Platform.new("#{platform}-ver-arch") }
         it "installs latest on #{platform} if given no version info" do
           hosts.each do |host|
-            expect(subject).to receive(:install_puppetlabs_release_repo).with(host)
+            expect(subject).to receive(:install_puppetlabs_release_repo_on).with(host)
           end
           expect(hosts[0]).to receive(:install_package).with('puppet')
           subject.install_puppet
@@ -627,7 +627,7 @@ describe ClassMixedWithDSLInstallUtils do
 
       it "raises an exception." do
         expect{
-          subject.install_puppetlabs_release_repo host
+          subject.install_puppetlabs_release_repo_on host
         }.to raise_error(RuntimeError, /No repository installation step for/)
       end
     end
@@ -639,7 +639,7 @@ describe ClassMixedWithDSLInstallUtils do
         expect(subject).to receive(:on).with( host, /wget .*/ ).ordered
         expect(subject).to receive(:on).with( host, /dpkg .*/ ).ordered
         expect(subject).to receive(:on).with( host, "apt-get update" ).ordered
-        subject.install_puppetlabs_release_repo host
+        subject.install_puppetlabs_release_repo_on host
       end
 
     end


### PR DESCRIPTION
Note: This is not finished, there needs to be doc updates for it.

I'm submitting this now because I'd like to get a look at how our tests behave after I pull out the `alias_method` statements, so I can get an 👀 on what needs to happen to finish this.