### PR TITLE
(QA-2599) Allocate IP if none is available

### DIFF
--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -114,3 +114,12 @@ in the `CONFIG` section of your hosts file:
     security_group: ['my_sg', 'default']
 
 This is an optional config parameter.
+
+### Floating IP Pool
+
+The name of the floating IP pool that a VM can grab IPs from. This is useful
+if your organization doesn't have a public pool of floating IPs, or give each
+user their own pool.  It's used in allocating new IPs.  It's an options
+parameter in the CONFIG section of the host file:
+
+    floating_ip_pool: 'my_pool_name'

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -29,6 +29,7 @@ module Beaker
       expect(options['openstack_network']).to eq('testing')
       expect(options['openstack_keyname']).to eq('nopass')
       expect(options['security_group']).to eq(['my_sg', 'default'])
+      expect(options['floating_ip_pool']).to eq('my_pool')
     end
 
     it 'check hosts options during initialization' do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -70,6 +70,7 @@ module HostHelpers
                                                :openstack_tenant => "testing",
                                                :openstack_network => "testing",
                                                :openstack_keyname => "nopass", 
+                                               :floating_ip_pool => "my_pool",
                                                :security_group => ['my_sg', 'default'] } )
   end
 


### PR DESCRIPTION
This PR:
* Moves the logic of getting or allocating a floating IP to it's own function
* Adds allocation functionality for if no floating IPs are available

I realized that in my last PR, I bypassed the error handling for when no floating IPs are available. This puts it back in.