### PR TITLE
(PE-17093) Fix noask directory path

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -95,8 +95,9 @@ module Unix::Pkg
         if ! check_for_command('pkgutil')
           # https://www.opencsw.org/package/pkgutil/
           noask_text = self.noask_file_text
-          create_remote_file self, File.join(noask_directory, 'noask'), noask_text
-          execute('pkgadd -d http://get.opencsw.org/now -a noask -n all', opts)
+          noask_file = File.join(external_copy_base, 'noask')
+          create_remote_file(self, noask_file, noask_text)
+          execute("pkgadd -d http://get.opencsw.org/now -a #{noask_file} -n all", opts)
           execute('/opt/csw/bin/pkgutil -U', opts)
           execute('/opt/csw/bin/pkgutil -y -i pkgutil', opts)
         end

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -341,6 +341,7 @@ module Beaker
                 if version == 10
                   allow( instance ).to receive( :noask_file_text )
                   allow( instance ).to receive( :create_remote_file )
+                  allow( instance ).to receive( :execute ).with('/opt/csw/bin/pkgutil -y -i pkgutil')
                 end
                 # only expect diff in the last line: .not_to vs .to raise_error
                 expect{


### PR DESCRIPTION
Prior to this commit I attempted to use a variable that doesn't exist
`noask_directory`.
This commit uses the `opts[:copy_dir_external]` varible instead, which
should be provided by beaker, and default to `/root`

Added typo fix to @highb's PR here since I don't have write permissions to his fork.