### PR TITLE
(PA-514) Ensure windows reg value & startup type

### DIFF
--- a/lib/beaker/dsl/install_utils/windows_utils.rb
+++ b/lib/beaker/dsl/install_utils/windows_utils.rb
@@ -141,6 +141,16 @@ exit /B %errorlevel%
             # therefore, this command will always exit 0 if either service is installed
             on host, Command.new("sc query puppet || sc query pe-puppet", [], { :cmdexe => true })
 
+            # (PA-514) value for PUPPET_AGENT_STARTUP_MODE should be present in
+            # registry and honored after install/upgrade.
+            reg_query_command = %Q(reg query "HKLM\\SOFTWARE\\Wow6432Node\\Puppet Labs\\PuppetInstaller" /v "RememberedPuppetAgentStartupMode" | findstr #{msi_opts['PUPPET_AGENT_STARTUP_MODE']})
+            on host, Command.new(reg_query_command, [], { :cmdexe => true })
+
+            start_mode = msi_opts['PUPPET_AGENT_STARTUP_MODE'] == "Automatic" ? "Auto" : msi_opts['PUPPET_AGENT_STARTUP_MODE']
+            service_query_command = %Q('WMIC SERVICE where (Name like "%Puppet" AND StartMode="#{start_mode}") | findstr Puppet')
+
+            on host, Command.new(service_query_command, [], { :cmdexe => true })
+
             # emit the misc/versions.txt file which contains component versions for
             # puppet, facter, hiera, pxp-agent, packaging and vendored Ruby
             [


### PR DESCRIPTION
This commit adds two checks to make sure that after install our Windows agents
still have the appropriate registry value setting & location for
RememberedPuppetAgentStartupMode (which is Disabled) and that the service does
in fact have a startup type of Disabled. This is after a regression was
introduced in the MSI packaging which wrote these values to the wrong location
and then they were not retained/honored after upgrade.

The MSI flag for setting startup mode is PUPPET_AGENT_STARTUP_MODE, and it
accepts three values:

* Automatic
* Manual
* Disabled

Of these three, "Automatic" is the only on that does not correspond directly to
the equivalent value returned by `WMIC SERVICE` - for this case, `WMIC SERVICE`
returns "Auto" and not "Automatic. "Manual" and "Disabled" are both returned
as-is. For this reason, Automatic is treated as a special case in this commit.

This location (beaker) is chosen for this test because the puppet
agent testing pipeline does not include its own testing for package-based
upgrades, and at this time all systems that install MSIs will use this util. At
such time as package acceptance testing of upgrades is added to puppet-agent,
these checks should be moved there.

Paired with: Sean McDonald

Signed-off-by: Moses Mendoza moses@puppet.com