### PR TITLE
(maint) Fix typo to how_to document

### DIFF
--- a/docs/concepts/shared_options_for_executing_beaker_commands.md
+++ b/docs/concepts/shared_options_for_executing_beaker_commands.md
@@ -42,7 +42,7 @@ Specifies standard input to be provided to the command post execution.  Defaults
 
     on host, "this command takes input", {:stdin => "hiya"}
 
-## [:run_in_parallel](how_to/run_in_parallel.md)
+## [:run_in_parallel](../how_to/run_in_parallel.md)
 
 Execute the command against all hosts in parallel
 


### PR DESCRIPTION
This commit updates the reference to a document that exists.