### PR TITLE
(BKR-942) let beaker use either old pkg or new pkgng tools on FreeBSD

### DIFF
--- a/lib/beaker/host/freebsd/pkg.rb
+++ b/lib/beaker/host/freebsd/pkg.rb
@@ -1,13 +1,37 @@
 module FreeBSD::Pkg
   include Beaker::CommandFactory
 
-  def install_package(name, cmdline_args = nil, opts = {})
-    cmdline_args ||= '-y'
-    execute("pkg install #{cmdline_args} #{name}", opts) { |result| result }
+  def pkg_info_pattern(package)
+    # This seemingly restrictive pattern prevents false positives...
+    "^#{package}-[0-9][0-9a-zA-Z_\\.,]*$"
   end
 
-  def check_for_package(name, opts = {})
-    execute("pkg info #{name}", opts) { |result| result }
+  def check_pkgng_sh
+    'TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexist ' \
+    'pkg info -x "pkg(-devel)?\\$" > /dev/null 2>&1'
   end
 
+  def pkgng_active?(opts = {})
+    opts = {:accept_all_exit_codes => true}.merge(opts)
+    execute("/bin/sh -c '#{check_pkgng_sh}'", opts) { |r| r }.exit_code == 0
+  end
+
+  def install_package(package, cmdline_args = nil, opts = {})
+    cmd = if pkgng_active?
+            "pkg install #{cmdline_args || '-y'} #{package}"
+          else
+            "pkg_add #{cmdline_args || '-r'} #{package}"
+          end
+    execute(cmd, opts) { |result| result }
+  end
+
+  def check_for_package(package, opts = {})
+    opts = {:accept_all_exit_codes => true}.merge(opts)
+    cmd = if pkgng_active?
+            "pkg info #{package}"
+          else
+            "pkg_info -Ix '#{pkg_info_pattern(package)}'"
+          end
+    execute(cmd, opts) { |result| result }.exit_code == 0
+  end
 end

--- a/spec/beaker/host/freebsd/pkg_spec.rb
+++ b/spec/beaker/host/freebsd/pkg_spec.rb
@@ -27,25 +27,71 @@ module Beaker
     let (:opts)     { @opts || {} }
     let (:logger)   { double( 'logger' ).as_null_object }
     let (:instance) { FreeBSDPkgTest.new(opts, logger) }
+    let(:cond) do
+      'TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexist pkg info -x "pkg(-devel)?\\$" > /dev/null 2>&1'
+    end
+
+    context "pkg_info_patten" do
+      it "returns correct patterns" do
+        expect( instance.pkg_info_pattern('rsync') ).to eq '^rsync-[0-9][0-9a-zA-Z_\\.,]*$'
+      end
+    end
+
+    context "check_pkgng_sh" do
+      it { expect( instance.check_pkgng_sh ).to eq cond }
+    end
+
+    context "pkgng_active?" do
+      it "returns true if pkgng is available" do
+        expect( instance ).to receive(:check_pkgng_sh).once.and_return("do you have pkgng?")
+        expect( Beaker::Command ).to receive(:new).with("/bin/sh -c 'do you have pkgng?'", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('',{:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance.pkgng_active? ).to be true
+      end
+      it "returns false if pkgng is unavailable" do
+        expect( instance ).to receive(:check_pkgng_sh).once.and_return("do you have pkgng?")
+        expect( Beaker::Command ).to receive(:new).with("/bin/sh -c 'do you have pkgng?'", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+        expect( instance ).to receive(:exec).with('',{:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 127}))
+        expect( instance.pkgng_active? ).to be false
+      end
+    end
 
     context "install_package" do
-
-      it "runs the correct install command" do
-        expect( Beaker::Command ).to receive(:new).with('pkg install -y rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
-        instance.install_package('rsync')
+      context "without pkgng" do
+        it "runs the correct install command" do
+          expect( instance ).to receive(:pkgng_active?).once.and_return(false)
+          expect( Beaker::Command ).to receive(:new).with("pkg_add -r rsync", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+          expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+          instance.install_package('rsync')
+        end
       end
-
+      context "with pkgng" do
+        it "runs the correct install command" do
+          expect( instance ).to receive(:pkgng_active?).once.and_return(true)
+          expect( Beaker::Command ).to receive(:new).with("pkg install -y rsync", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+          expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
+          instance.install_package('rsync')
+        end
+      end
     end
 
     context "check_for_package" do
-
-      it "runs the correct checking command" do
-        expect( Beaker::Command ).to receive(:new).with('pkg info rsync', [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', {}).and_return(generate_result("hello", {:exit_code => 0}))
-        instance.check_for_package('rsync')
+      context "without pkgng" do
+        it "runs the correct checking command" do
+          expect( instance ).to receive(:pkgng_active?).once.and_return(false)
+          expect( Beaker::Command ).to receive(:new).with("pkg_info -Ix '^rsync-[0-9][0-9a-zA-Z_\\.,]*$'", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+          expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
+          instance.check_for_package('rsync')
+        end
       end
-
+      context "with pkgng" do
+        it "runs the correct checking command" do
+          expect( instance ).to receive(:pkgng_active?).once.and_return(true)
+          expect( Beaker::Command ).to receive(:new).with("pkg info rsync", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+          expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
+          instance.check_for_package('rsync')
+        end
+      end
     end
 
   end


### PR DESCRIPTION
This PR enables beaker to install and query packages on new (>=9.3) and old (<9.3) versions of FreeBSD. The proposed code was used by me as [a workaround](https://github.com/ptomulik/puppet-portsng/blob/master/spec/patches/lib/beaker/host/freebsd/pkg.rb) in [ptomulik/puppet-portsng](https://github.com/ptomulik/puppet-portsng/) puppet module and worked for all FreeBSD versions between 9.0 and 11.0, where the older versions (9.0 .. 9.2) used the old pkg toolstack and newer (9.3 ... 11.0) the new pkgng suite. A similar patch was proposed for specinfra as  PR [specinfra/581](https://github.com/mizzy/specinfra/pull/581).