### PR TITLE
(maint) Improve beaker vmpooler error response

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -163,7 +163,11 @@ module Beaker
             raise "Vmpooler.provision - requested VM templates #{request_payload.keys} not available"
           end
         else
-          raise "Vmpooler.provision - response from pooler not ok. Requested host set #{request_payload.keys} not available in pooler.\n#{parsed_response}"
+          if response.code == '401'
+            raise "Vmpooler.provision - response from pooler not ok. Vmpooler token not authorized to make request.\n#{parsed_response}"
+          else
+            raise "Vmpooler.provision - response from pooler not ok. Requested host set #{request_payload.keys} not available in pooler.\n#{parsed_response}"
+          end
         end
       rescue JSON::ParserError, RuntimeError, *SSH_EXCEPTIONS => e
         @logger.debug "Failed vmpooler provision: #{e.class} : #{e.message}"


### PR DESCRIPTION
Prior this commit, if a user had an old token and attempted to run
beaker to request vms, it would claim that the requested hosts were not
available in the pooler when in reality their token was invalid and not
authorized to make the request. This commit updates that to check the
status code of the request and print the appropriate error message.