### PR TITLE
(maint) add name and roles tags to vmpooler vms

### DIFF
--- a/lib/beaker/hypervisor/vmpooler.rb
+++ b/lib/beaker/hypervisor/vmpooler.rb
@@ -81,13 +81,14 @@ module Beaker
     # @return [Hash] Tag hash
     def add_tags(host)
       host[:host_tags].merge(
-          {
-              'beaker_version'    => Beaker::Version::STRING,
-              'jenkins_build_url' => @options[:jenkins_build_url],
-              'department'        => @options[:department],
-              'project'           => @options[:project],
-              'created_by'        => @options[:created_by]
-          })
+        'beaker_version'    => Beaker::Version::STRING,
+        'jenkins_build_url' => @options[:jenkins_build_url],
+        'department'        => @options[:department],
+        'project'           => @options[:project],
+        'created_by'        => @options[:created_by],
+        'name'              => host.name,
+        'roles'             => host.host_hash[:roles].join(', ')
+      )
     end
 
     # Get host info hash from parsed json response


### PR DESCRIPTION
Before this commit it was not possible to tell via [vmfloaty](https://github.com/briancain/vmfloaty) or [vmpooler-bitbar](https://github.com/johnmccabe/vmpooler-bitbar/) what a particular vmpooler vm was being used for when created by beaker.

This commit adds tags with the name and roles for vmpooler vms, for example via vmpooler-bitbar:

![screen shot 2016-09-22 at 7 19 27 pm](https://cloud.githubusercontent.com/assets/83862/18760615/bb85edd2-80f9-11e6-841a-292fb7880a8c.png)

