### PR TITLE
Require beaker-pe if available

### DIFF
--- a/acceptance/pre_suite/pe/install.rb
+++ b/acceptance/pre_suite/pe/install.rb
@@ -1,1 +1,3 @@
+# require beaker-pe to load in the additional DSL methods
+require 'beaker-pe'
 install_pe

--- a/lib/beaker.rb
+++ b/lib/beaker.rb
@@ -46,4 +46,13 @@ module Beaker
     # do nothing
   end
 
+  # If beaker-pe is available, pull it in. The gem beaker-pe will need to be
+  # specified in the project Gemfile independent of beaker itself. If not available,
+  # catch LoadError and continue.
+  begin
+    require 'beaker-pe'
+  rescue LoadError
+    # do nothing
+  end
+
 end


### PR DESCRIPTION
This change pulls in beaker-pe if it is available in the ruby
$LOAD_PATH. This makes it so that project repos only have to specify
beaker-pe in their Gemfile, not require beaker-pe itself in their
test setup.