### PR TITLE
(BKR-911) Add OSX Sierra (10.12) support

### DIFF
--- a/lib/beaker/host/mac/exec.rb
+++ b/lib/beaker/host/mac/exec.rb
@@ -21,7 +21,7 @@ module Mac::Exec
   #   (from {#ssh_service_restart})
   def ssh_permit_user_environment
     ssh_config_file = '/etc/sshd_config'
-    ssh_config_file = '/private/etc/ssh/sshd_config' if self['platform'] =~ /osx-10\.*11/
+    ssh_config_file = '/private/etc/ssh/sshd_config' if self['platform'] =~ /osx-10\.*(11|12)/
 
     exec(Beaker::Command.new("echo '\nPermitUserEnvironment yes' >> #{ssh_config_file}"))
     ssh_service_restart()

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -21,7 +21,8 @@ module Beaker
                      "precise" => "1204",
                      "lucid"   => "1004",
                    },
-        :osx =>    { "elcapitan" => "1011",
+        :osx =>    { "sierra"    => "1012",
+                     "elcapitan" => "1011",
                      "yosemite"  => "1010",
                      "mavericks" => "109",
                    }


### PR DESCRIPTION
Add the osx 10.12 entry to the platform config, and update the
ssh_permit_user_environment function to also use /private/etc/sshd_config
instead of /etc/sshd_config for osx-10.12.

osx-10.11 and 10.12 both need that location to be updated (with the addition
of /private) in order for the ssh environment to work correctly.