### PR TITLE
(BKR-949) Fix Keypair Generation on OpenStack

### DIFF
--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -69,5 +69,24 @@ module Beaker
       openstack.provision
     end
 
+    it 'generates valid keynames during server creation' do
+      # Simulate getting a dynamic IP from OpenStack to test key generation code
+      # after provisioning. See _validate_new_key_pair in openstack/nova for reference
+      mock_ip = double().as_null_object
+      allow( openstack ).to receive( :get_ip ).and_return( mock_ip )
+      allow( mock_ip ).to receive( :ip ).and_return( '172.16.0.1' )
+      openstack.instance_eval('@options')['openstack_keyname'] = nil
+
+      @hosts.each do |host|
+        allow(host).to receive(:wait_for_port).and_return(true)
+      end
+
+      openstack.provision
+
+      @hosts.each do |host|
+        expect(host[:keyname]).to match(/[_\-0-9a-zA-Z]+/)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixes a regression in 2.51.0 whereby the hostname was updated to be based upon the
server IP, and get a domain.  Random keypair generation is based upon this hostname
however OpenStack deems the period character unsafe, therefore this functionality
got broken.  This commit attaches both the hostname and fqdn to the host object.  To
maintain backwards compatibility all references to vmhostname now refer to vmfqdn.
Key generation now uses the safe vmhostname variable, and clean up uses vm.key_name
cached in the Fog Server object.
