### PR TITLE
(BKR-948) require ruby >= 2.2.5

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = Gem::Requirement.new('>= 2.2.5')
+
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'


### PR DESCRIPTION
In the release of beaker 3.0, we said that we gave up supporting
ruby 1.9, but we didn't actually stop anyone from using it. This
change will prevent anyone from using beaker 3.0 with any ruby
< 2.2.5