### PR TITLE
(BKR-928) add hocon DSL helpers

### DIFF
--- a/acceptance/tests/base/dsl/helpers/hocon_helpers_test.rb
+++ b/acceptance/tests/base/dsl/helpers/hocon_helpers_test.rb
@@ -1,0 +1,94 @@
+require 'hocon/config_value_factory'
+
+test_name 'Hocon Helpers Test' do
+
+  hocon_filename = 'hocon.conf'
+  step 'setup : create hocon file to play with' do
+    hocon_content = <<-END
+      {
+        setting1 : "value1",
+        setting2 : 2,
+        setting3 : False
+      }
+    END
+    create_remote_file(hosts, hocon_filename, hocon_content)
+  end
+
+  step '#hocon_file_read : reads doc' do
+    doc = hocon_file_read_on(hosts[0], hocon_filename)
+    assert(doc.has_value?('setting2'))
+  end
+
+  step '#hocon_file_edit_on : set_value and verify it exists' do
+    hocon_file_edit_on(hosts, hocon_filename) do |host, doc|
+      doc2 = doc.set_value('c', '[4, 5]')
+
+      assert(doc2.has_value?('c'), 'Should have inserted "c" value!')
+    end
+  end
+
+  step '#hocon_file_edit_on : testing failure modes' do
+    def test_filename_failure(filename)
+      begin
+        hocon_file_edit_on(hosts, filename) do |_, _|
+          fail('block should not run in failure mode')
+        end
+        fail('execution should not continue in failure mode')
+      rescue ArgumentError => e
+        assert(e.to_s =~ /requires a filename/)
+      else
+        fail('No exception raised in failure mode')
+      end
+    end
+
+    step 'filename is nil' do
+      test_filename_failure(nil)
+    end
+
+    step 'filename is empty string' do
+      test_filename_failure('')
+    end
+
+    step 'no block given' do
+      begin
+        hocon_file_edit_on(hosts, hocon_filename)
+        fail('execution should not continue in failure mode')
+      rescue ArgumentError => e
+        assert(e.to_s =~ /No block was provided/)
+      else
+        fail('No exception raised in failure mode')
+      end
+    end
+  end
+
+  step '#hocon_file_edit_on : verify saving workflow' do
+    step '#hocon_file_edit_on : set_value and save' do
+      hocon_file_edit_on(hosts, hocon_filename) do |host, doc|
+        doc2 = doc.set_value('a.b', '[1, 2, 3, 4, 5]')
+        create_remote_file(host, hocon_filename, doc2.render)
+      end
+    end
+
+    step '#hocon_file_edit_on : independently read value to verify save' do
+      hocon_file_edit_on(hosts, hocon_filename) do |host, doc|
+        msg_fail = 'Should have saved "a.b" value inserted in previous step'
+        assert(doc.has_value?('a.b'), msg_fail)
+      end
+    end
+  end
+
+  step '#hocon_file_edit_in_place_on : verify auto-saving workflow' do
+    step '#hocon_file_edit_in_place_on : set_value and save' do
+      hocon_file_edit_in_place_on(hosts, hocon_filename) do |host, doc|
+        doc.set_value('c.d', '[6, 2, 73, 4, 45]')
+      end
+    end
+
+    step '#hocon_file_edit_in_place_on : verify save' do
+      hocon_file_edit_on(hosts, hocon_filename) do |host, doc|
+        msg_fail = 'Should have saved "c.d" value inserted in previous step'
+        assert(doc.has_value?('c.d'), msg_fail)
+      end
+    end
+  end
+end

--- a/docs/how_to/use_hocon_helpers.md
+++ b/docs/how_to/use_hocon_helpers.md
@@ -1,0 +1,37 @@
+# How-to Use Hocon Helpers
+
+Beaker provides a few convenience methods to help you use the
+[HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md)
+configuration file format in your testing. This doc will give you an overview of
+what each method does, but if you'd like more in-depth information, please
+checkout our
+[Hocon Helpers Rubydocs](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HoconHelpers).
+
+# #hocon_file_read_on
+
+If you'd just like to read the contents of a HOCON file from a System Under Test
+(SUT), this is the method for you. Note that you will get back a
+[ConfigValueFactory object](https://github.com/puppetlabs/ruby-hocon#basic-usage)
+like in the other helper methods here.
+
+# #hocon_file_edit_in_place_on
+
+This method is specifically for editing a file on a SUT and saving it in-place,
+meaning it'll save your changes in the place of the original file you read from.
+
+The special thing to take note of here is that the Proc you pass to this method
+will need to return the doc that you'd like saved in order for saving to work as
+specified.
+
+# #hocon_file_edit_on
+
+This method is our generic open-ended method for editing a file from a SUT. This
+is the most flexible method, doing nothing but providing you with the contents
+of the file to edit yourself.
+
+This does not save the file edited. Our recommendation is to use the
+[`create_remote_file` method](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#create_remote_file-instance_method),
+as shown in the
+[Rubydocs example](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HoconHelpers#hocon_file_edit_on-instance_method)
+if you'd like to save. This allows us to have more flexibility to do things such
+as moving the edited file to back up or version your changes.

--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-[ 'facter', 'host', 'puppet', 'test', 'tk', 'web' ].each do |lib|
+[ 'facter', 'host', 'puppet', 'test', 'tk', 'web', 'hocon' ].each do |lib|
       require "beaker/dsl/helpers/#{lib}_helpers"
 end
 
@@ -29,6 +29,7 @@ module Beaker
       include Beaker::DSL::Helpers::TestHelpers
       include Beaker::DSL::Helpers::TKHelpers
       include Beaker::DSL::Helpers::WebHelpers
+      include Beaker::DSL::Helpers::HoconHelpers
       include Beaker::DSL::Helpers::Hiera
     end
   end

--- a/lib/beaker/dsl/helpers/hocon_helpers.rb
+++ b/lib/beaker/dsl/helpers/hocon_helpers.rb
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+require 'hocon/parser/config_document_factory'
+require 'hocon/config_value_factory'
+
+module Beaker
+  module DSL
+    module Helpers
+      # Convenience methods for modifying and reading Hocon configs
+      #
+      # @note For usage guides for these methods, check these sources:
+      #   - {https://github.com/puppetlabs/beaker/tree/master/docs/how_to/use_hocon_helpers.md Beaker docs}.
+      #   - Beaker acceptance tests in +acceptance/tests/base/dsl/helpers/hocon_helpers_test.rb+
+      module HoconHelpers
+
+        # Reads the given hocon file from a SUT
+        #
+        # @param [Host] host Host to get hocon file from.
+        # @param [String] filename Name of the hocon file to get
+        #
+        # @raise ArgumentError if arguments are missing or incorrect
+        # @return [Hocon::ConfigValueFactory] parsed hocon file
+        def hocon_file_read_on(host, filename)
+          if filename.nil? || filename.empty?
+            raise ArgumentError, '#hocon_file_edit_on requires a filename'
+          end
+          file_contents = on(host, "cat #{filename}").stdout
+          Hocon::Parser::ConfigDocumentFactory.parse_string(file_contents)
+        end
+
+        # Grabs the given hocon file from a SUT, allowing you to edit the file
+        # just like you would a local one in the passed block.
+        #
+        # @note This method does not save the hocon file after editing. Our
+        #   recommended workflow for that is included in our example. If you'd
+        #   rather just save a file in-place on a SUT, then
+        #   {#hocon_file_edit_in_place_on} is a better method to use.
+        #
+        # @example Editing a value & saving as a new file
+        #   hocon_file_edit_on(hosts, 'hocon.conf') do |host, doc|
+        #     doc2 = doc.set_value('a.b', '[1, 2, 3, 4, 5]')
+        #     create_remote_file(host, 'hocon_latest.conf', doc2.render)
+        #   end
+        #
+        # @param [Host,Array<Host>] hosts Host (or an array of hosts) to
+        #   edit the hocon file on.
+        # @param [String] filename Name of the file to edit.
+        # @param [Proc] block Code to edit the hocon file.
+        #
+        # @yield [Host] Currently executing host.
+        # @yield [Hocon::ConfigValueFactory] Doc to edit. Refer to
+        #   {https://github.com/puppetlabs/ruby-hocon#basic-usage Hocon's basic usage doc}
+        #   for info on how to use this object.
+        #
+        # @raise ArgumentError if arguments are missing or incorrect.
+        # @return nil
+        def hocon_file_edit_on(hosts, filename, &block)
+          if not block_given?
+            msg = 'DSL method `hocon_file_edit_on` provides a given block'
+            msg << ' a hocon file to edit. No block was provided.'
+            raise ArgumentError, msg
+          end
+          block_on hosts, {} do | host |
+            doc = hocon_file_read_on(host, filename)
+            yield host, doc
+          end
+        end
+
+        # Grabs the given hocon file from a SUT, allowing you to edit the file
+        # and have those edits saved in-place of the file on the SUT.
+        #
+        # @note that a the crucial difference between this & {#hocon_file_edit_on}
+        #   is that your Proc will need to return the
+        #   {#hocon_file_edit_on Hocon::ConfigValueFactory doc}
+        #   you want saved for the in-place save to work correctly.
+        #
+        # @note for info about parameters, please checkout {#hocon_file_edit_on}.
+        #
+        # @example setting an attribute & saving
+        #   hocon_file_edit_in_place_on(hosts, hocon_filename) do |host, doc|
+        #     doc.set_value('c.d', '[6, 2, 73, 4, 45]')
+        #   end
+        #
+        def hocon_file_edit_in_place_on(hosts, filename, &block)
+          hocon_file_edit_on(hosts, filename) do |host, doc|
+            content_doc = yield host, doc
+            create_remote_file(host, filename, content_doc.render)
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Everett, PE will be moving away from using the node classifier
to classify nodes, and instead relying on pe.conf HOCON files. This
change introduces basic CRUD style interactions with HOCON files
for beaker testing.