### PR TITLE
(BKR-952) Add PuppetVersion

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -64,4 +64,6 @@ Gem::Specification.new do |s|
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'
+
+  s.add_runtime_dependency 'semantic'
 end

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -65,5 +65,5 @@ Gem::Specification.new do |s|
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'
 
-  s.add_runtime_dependency 'semantic'
+  s.add_runtime_dependency 'semantic', '~> 1.4'
 end

--- a/lib/beaker/shared/semvar.rb
+++ b/lib/beaker/shared/semvar.rb
@@ -65,7 +65,7 @@ module Beaker
       #@note 3.0.0-160-gac44cfb is greater than 3.0.0, and 2.8.2
       #@note 3.0.0-rc-0-160-gac44cfb is less than 3.0.0, and greater 2.8.2
       class PuppetVersion < Semantic::Version
-        attr_reader :x, :y, :z, :rc, :build, :sha
+        attr_reader :major, :minor, :patch, :rc, :build, :sha
 
         def initialize(version)
           @ver_string = version
@@ -84,9 +84,9 @@ module Beaker
           end
 
           semver_split = semver.split('.').collect { |str| str.to_i }
-          @x = semver_split[0] || 0
-          @y = semver_split[1] || 0
-          @z = semver_split[2] || 0
+          x = semver_split[0] || 0
+          y = semver_split[1] || 0
+          z = semver_split[2] || 0
 
           if @build
             @build = @build.to_i
@@ -98,15 +98,23 @@ module Beaker
             @sha = nil
           end
 
-          @semver = super([@x, @y, @z].join('.'))
+          super([x, y, z].join('.'))
         end
 
+        # Overrides Semantic::Version::to_a
         def to_a
-          [@x, @y, @z, @rc, @build, @sha]
+          [@major, @minor, @patch, @rc, @build, @sha]
         end
 
+        # Overrides Semantic::Version::to_h
+        def to_h
+          keys = [:major, :minor, :patch, :rc, :build, :sha]
+          Hash[keys.zip(self.to_a)]
+        end
+
+        # Overrides Semantic::Version::to_s
         def to_s
-          str = [@x, @y, @z].join '.'
+          str = super.to_s
           str << ('-' << @rc unless @rc.nil? || @rc == 999)
           str << ('-' << @build unless @build.nil?)
           str << ('-g' << @sha unless @sha.nil?)
@@ -118,6 +126,7 @@ module Beaker
           @sha = sha
         end
 
+        # Overrides Semantic::Version::<=>
         def <=>(other_version)
           other_version = Beaker::Shared::Semvar::PuppetVersion.new(other_version) if other_version.is_a? String
 

--- a/lib/beaker/shared/semvar.rb
+++ b/lib/beaker/shared/semvar.rb
@@ -115,7 +115,7 @@ module Beaker
         # Overrides Semantic::Version::to_s
         def to_s
           str = super.to_s
-          str << ('-' << @rc unless @rc.nil? || @rc == 999)
+          str << ('-rc' << @rc unless @rc.nil? || @rc == 999)
           str << ('-' << @build unless @build.nil?)
           str << ('-g' << @sha unless @sha.nil?)
 

--- a/lib/beaker/shared/semvar.rb
+++ b/lib/beaker/shared/semvar.rb
@@ -38,38 +38,92 @@ module Beaker
         return false
       end
 
+      # Validates that the given version is a valid/expected PE version.
+      # Splits up a PE version string into a struct of all the elements of the version
+      #
+      # @param version [String] A PE version string
+      # @return [Struct] containing the elements of the version
+      def puppet_version_split(version)
+        version_struct = Struct.new("Version", :ver, :rc, :build, :sha, :x, :y, :z, :semver, :string) do
+          def to_s
+            "#{semver}-#{rc}-#{build}-g#{sha}"
+          end
+        end
+        v = version_struct.new
+
+        v[:string] = version
+
+        if version =~ /^\d+(\.\d+)?(\.\d)?+$/
+          v[:ver] = version
+          v[:rc] = 999
+        elsif version =~ /^\d+\.\d+\.\d+(-\d+-g[a-f0-9]+)?$/
+          v[:ver], v[:build], v[:sha] = version.split('-', 3)
+          v[:rc] = 999
+        elsif version =~ /^\d+\.\d+\.\d+(-rc\d+-\d+-g[a-f0-9]+)?$/
+          v[:ver], v[:rc], v[:build], v[:sha] = version.split('-', 4)
+          v[:rc] = v[:rc].tr('rc', '').to_i
+        else
+          raise "Unknown version format: #{version}"
+        end
+
+        v[:x], v[:y], v[:z] = v.ver.split('.').collect { |str| str.to_i }
+
+        if v[:build]
+          v[:build] = v[:build].to_i
+        end
+
+        if v[:sha]
+          v[:sha] = v[:sha][1..-1]
+        else
+          v[:sha] = 'none'
+        end
+
+        v.each_pair { |name, value| v[name] = 0 if value.nil? }
+
+        v[:semver] = Semantic::Version.new [v.x, v.y, v.z].join('.')
+
+        return v
+      end
+
       # Wrapper around semantic semver gem that supports our
       # semver-breaking version scheme in PE.
       #
-      #@param [String] a A version of the from '\d.\d.\d.*'
+      # Overview of how PE is versioned for the public:
+      # <year of release>.<release number in year>.<bug fix z>
+      # Ex. 2016.5.0, 2016.5.1, 2017.1.0, 2017.1.1
+      #
+      # Overview of how PE internal builds are versioned:
+      # year.release.bug_z(-rc[0-9])-<build number>-g<git SHA>
+      # Ex. 2016.5.0-rc0-100-gabcdef12
+      #
+      # This comparison method ignores the git SHA, because it cannot
+      # usefully be compared and no two builds should have the same
+      # SHA.
+      #
+      #@param [String] a A version of the from '\d.\d.\d-rc\d-\d.-g<sha>'
       #@param [String/Symbol] cmp A comparison operator such as <, >, or ==
-      #@param [String] b A version of the form '\d.\d.\d.*'
+      #@param [String] b A version of the form '\d.\d.\d-rc\d-\d.-g<sha>'
       #@return [Boolean] true if a <cmp> b
       #
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :>, '2016.2.1') returns true
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :>=, '2016.2.1') returns true
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :<, '2016.2.1') returns false
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :<=, '2016.2.1') returns false
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :==, '2016.2.1') returns false
+      #@example puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :!=, '2016.2.1') returns true
+      #@example See the semver_spec.rb for more examples
       #@note 3.0.0-160-gac44cfb is greater than 3.0.0, and 2.8.2
-      #@note -rc being less than final builds is not yet implemented.
+      #@note 3.0.0-rc-0-160-gac44cfb is less than 3.0.0, and greater 2.8.2
       def puppet_version_comparison a, cmp, b
-        ah = Hash.new(0)
-        bh = Hash.new(0)
+        as = puppet_version_split(a)
+        bs = puppet_version_split(b)
 
-        ah[:ver], ah[:rc], ah[:build] = a.split('-', 3)
-        bh[:ver], bh[:rc], bh[:build] = b.split('-', 3)
-
-        ah[:x], ah[:y], ah[:z] = ah[:ver].split('.')
-        bh[:x], bh[:y], bh[:z] = bh[:ver].split('.')
-
-        ah.each { |k, v| ah[k] = 0 if ah[k].nil? }
-        bh.each { |k, v| bh[k] = 0 if bh[k].nil? }
-
-        ah[:semver] = Semantic::Version.new [ah[:x], ah[:y], ah[:z]].join('.')
-        bh[:semver] = Semantic::Version.new [bh[:x], bh[:y], bh[:z]].join('.')
-
-        if ah[:semver] != bh[:semver]
-          return ah[:semver].send(cmp.to_sym, bh[:semver])
-        elsif ah[:rc] != bh[:rc]
-          return ah[:rc].to_s.send(cmp.to_sym, bh[:rc].to_s)
+        if as.semver != bs.semver
+          return as.semver.send(cmp.to_sym, bs.semver)
+        elsif as.rc != bs.rc
+          return as.rc.send(cmp.to_sym, bs.rc)
         else
-          return ah[:build].to_s.send(cmp.to_sym, bh[:build].to_s)
+          return as.build.send(cmp.to_sym, bs.build)
         end
       end
 

--- a/spec/beaker/shared/semvar_spec.rb
+++ b/spec/beaker/shared/semvar_spec.rb
@@ -43,6 +43,84 @@ module Beaker
         end
       end
 
+      describe 'puppet_version_comparison' do
+        it 'reports 2015.3.0-rc0-8-gf80879a is less than 2016' do
+          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '2016' ) ).to be === true
+        end
+
+        it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
+          expect( subject.puppet_version_comparison( '2016', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+        end
+
+        it 'reports 2015.3.0-rc0-8-gf80879a is equal to 2015.3.0-rc0-8-gf80879a' do
+          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '==', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+        end
+
+        it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
+          expect( subject.puppet_version_comparison( '2015.3.0-rc1-4-gabcdefg', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+        end
+
+        it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
+          expect( subject.puppet_version_comparison( '2015.2.0-rc1-9-gabcdefg', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === false
+        end
+
+        it 'reports 2015.3.0-rc0-8-gf80879a is not less than 2015.3.0' do
+          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '2015.3.0' ) ).to be === false
+        end
+
+        it 'reports 2015.3.0-rc0-8-gf80879a is not less than 3.0.0' do
+          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '3.0.0' ) ).to be === false
+        end
+
+        it 'reports 3.0.0-160-gac44cfb is not less than 3.0.0' do
+          expect( subject.puppet_version_comparison( '3.0.0-160-gac44cfb', '<', '3.0.0' ) ).to be === false
+        end
+
+        it 'reports 3.0.0-160-gac44cfb is not less than 2.8.2' do
+          expect( subject.puppet_version_comparison( '3.0.0-160-gac44cfb', '<', '2.8.2' ) ).to be === false
+        end
+
+        it 'reports 3.0.0 is less than 3.0.0-160-gac44cfb' do
+          expect( subject.puppet_version_comparison( '3.0.0', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+        end
+
+        it 'reports 2.8.2 is less than 3.0.0-160-gac44cfb' do
+          expect( subject.puppet_version_comparison( '2.8.2', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+        end
+
+        it 'reports 2.8.0 is less than 3.0.0-160-gac44cfb' do
+          expect( subject.puppet_version_comparison( '2.8.0', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+        end
+
+        it 'reports 2.8.0 is less than 2.9.0' do
+          expect( subject.puppet_version_comparison( '2.8.0', '<', '2.9.0' ) ).to be === true
+        end
+
+        it 'reports 2.9.0 is greater than 2.8.0' do
+          expect( subject.puppet_version_comparison( '2.9.0', '>', '2.8.0' ) ).to be === true
+        end
+
+        it 'reports 2.8 is less than 2.9' do
+          expect( subject.puppet_version_comparison( '2.8', '<', '2.9' ) ).to be === true
+        end
+
+        it 'reports 2.8.2 is less than 2.9' do
+          expect( subject.puppet_version_comparison( '2.8.2', '<', '2.9' ) ).to be === true
+        end
+
+        it 'blows up if you give it an invalid version' do
+          expect {
+            subject.puppet_version_comparison( 'a.banana.5', '<', '2.9' )
+          }.to raise_error(/is not a valid SemVer/)
+        end
+
+        it 'blows up if you give it an invalid version' do
+          expect {
+            subject.puppet_version_comparison( '1.2.beta', '<', '2.9' )
+          }.to raise_error(/is not a valid SemVer/)
+        end
+      end
+
       describe 'max_version' do
 
         it 'returns nil if versions isn\'t defined' do

--- a/spec/beaker/shared/semvar_spec.rb
+++ b/spec/beaker/shared/semvar_spec.rb
@@ -43,177 +43,181 @@ module Beaker
         end
       end
 
-      describe 'puppet_version_split' do
+      describe 'PuppetVersion' do
         it 'accepts valid PE non-final builds' do
           ver = '2015.3.0-rc0-8-gf80879a'
-          expect( subject.puppet_version_split(ver).x ).to be == 2015
-          expect( subject.puppet_version_split(ver).y ).to be == 3
-          expect( subject.puppet_version_split(ver).z ).to be == 0
-          expect( subject.puppet_version_split(ver).rc ).to be == 0
-          expect( subject.puppet_version_split(ver).build ).to be == 8
-          expect( subject.puppet_version_split(ver).sha ).to be == 'f80879a'
+          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).y ).to be == 3
+          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).rc ).to be == 0
+          expect( subject::PuppetVersion.new(ver).build ).to be == 8
+          expect( subject::PuppetVersion.new(ver).sha ).to be == 'f80879a'
         end
 
         it 'accepts valid PE final builds' do
           ver = '2015.3.0'
-          expect( subject.puppet_version_split(ver).x ).to be == 2015
-          expect( subject.puppet_version_split(ver).y ).to be == 3
-          expect( subject.puppet_version_split(ver).z ).to be == 0
-          expect( subject.puppet_version_split(ver).rc ).to be == 999
-          expect( subject.puppet_version_split(ver).build ).to be == 0
-          expect( subject.puppet_version_split(ver).sha ).to be == 'none'
+          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).y ).to be == 3
+          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).rc ).to be == 999
+          expect( subject::PuppetVersion.new(ver).build ).to be == 0
+          expect( subject::PuppetVersion.new(ver).sha ).to be == nil
         end
 
         it 'accepts valid PE post-final builds' do
           ver = '2015.3.0-8-gf80879a'
-          expect( subject.puppet_version_split(ver).x ).to be == 2015
-          expect( subject.puppet_version_split(ver).y ).to be == 3
-          expect( subject.puppet_version_split(ver).z ).to be == 0
-          expect( subject.puppet_version_split(ver).rc ).to be == 999
-          expect( subject.puppet_version_split(ver).build ).to be == 8
-          expect( subject.puppet_version_split(ver).sha ).to be == 'f80879a'
+          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).y ).to be == 3
+          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).rc ).to be == 999
+          expect( subject::PuppetVersion.new(ver).build ).to be == 8
+          expect( subject::PuppetVersion.new(ver).sha ).to be == 'f80879a'
         end
 
         it 'accepts valid PE year/release' do
           ver = '2015.3'
-          expect( subject.puppet_version_split(ver).x ).to be == 2015
-          expect( subject.puppet_version_split(ver).y ).to be == 3
-          expect( subject.puppet_version_split(ver).z ).to be == 0
-          expect( subject.puppet_version_split(ver).rc ).to be == 999
-          expect( subject.puppet_version_split(ver).build ).to be == 0
-          expect( subject.puppet_version_split(ver).sha ).to be == 'none'
+          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).y ).to be == 3
+          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).rc ).to be == 999
+          expect( subject::PuppetVersion.new(ver).build ).to be == 0
+          expect( subject::PuppetVersion.new(ver).sha ).to be == nil
         end
 
         it 'accepts valid PE year' do
           ver = '2015'
-          expect( subject.puppet_version_split(ver).x ).to be == 2015
-          expect( subject.puppet_version_split(ver).y ).to be == 0
-          expect( subject.puppet_version_split(ver).z ).to be == 0
-          expect( subject.puppet_version_split(ver).rc ).to be == 999
-          expect( subject.puppet_version_split(ver).build ).to be == 0
-          expect( subject.puppet_version_split(ver).sha ).to be == 'none'
+          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).y ).to be == 0
+          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).rc ).to be == 999
+          expect( subject::PuppetVersion.new(ver).build ).to be == 0
+          expect( subject::PuppetVersion.new(ver).sha ).to be == nil
         end
 
         it 'rejects an invalid semver' do
-          expect { subject.puppet_version_split('2015.0-3') }.to raise_error(/Unknown version format/)
+          expect { subject::PuppetVersion.new('2015.0-3') }.to raise_error(/Unknown format/)
         end
 
         it 'rejects an invalid PE version' do
-          expect { subject.puppet_version_split('2015.1.0-rc5-300-null') }.to raise_error(/Unknown version format/)
+          expect { subject::PuppetVersion.new('2015.1.0-rc5-300-null') }.to raise_error(/Unknown format/)
         end
 
         it 'rejects a non version string' do
-          expect { subject.puppet_version_split('banana') }.to raise_error(/Unknown version format/)
+          expect { subject::PuppetVersion.new('banana') }.to raise_error(/Unknown format/)
         end
       end
 
       describe 'puppet_version_comparison' do
         it 'reports 2015.3.0-rc0-8-gf80879a is less than 2016' do
-          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '2016' ) ).to be === true
+          expect( subject::PuppetVersion.new('2015.3.0-rc0-8-gf80879a') < '2016' ).to be === true
         end
 
         it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
-          expect( subject.puppet_version_comparison( '2016', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+          expect( subject::PuppetVersion.new('2016') > '2015.3.0-rc0-8-gf80879a' ).to be === true
         end
 
         it 'reports 2015.3.0-rc0-8-gf80879a is equal to 2015.3.0-rc0-8-gf80879a' do
-          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '==', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+          expect( subject::PuppetVersion.new('2015.3.0-rc0-8-gf80879a') == '2015.3.0-rc0-8-gf80879a' ).to be === true
         end
 
         it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
-          expect( subject.puppet_version_comparison( '2015.3.0-rc1-4-gabcdef1', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === true
+          expect( subject::PuppetVersion.new('2015.3.0-rc1-4-gabcdef1') > '2015.3.0-rc0-8-gf80879a' ).to be === true
         end
 
         it 'reports 2016 is greater than 2015.3.0-rc0-8-gf80879a' do
-          expect( subject.puppet_version_comparison( '2015.2.0-rc1-9-gabcdef1', '>', '2015.3.0-rc0-8-gf80879a' ) ).to be === false
+          expect( subject::PuppetVersion.new('2015.2.0-rc1-9-gabcdef1') > '2015.3.0-rc0-8-gf80879a' ).to be === false
         end
 
         it 'reports 2015.3.0-rc0-8-gf80879a is less than 2015.3.0' do
-          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '2015.3.0' ) ).to be === true
+          expect( subject::PuppetVersion.new('2015.3.0-rc0-8-gf80879a') < '2015.3.0' ).to be === true
         end
 
         it 'reports 2015.3.0-rc0-8-gf80879a is not less than 3.0.0' do
-          expect( subject.puppet_version_comparison( '2015.3.0-rc0-8-gf80879a', '<', '3.0.0' ) ).to be === false
+          expect( subject::PuppetVersion.new('2015.3.0-rc0-8-gf80879a') < '3.0.0' ).to be === false
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :>, '2016.2.1')).to be === true
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') > '2016.2.1' ).to be === true
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :>=, '2016.2.1')).to be === true
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') >= '2016.2.1' ).to be === true
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :<, '2016.2.1')).to be === false
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') < '2016.2.1' ).to be === false
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :<=, '2016.2.1')).to be === false
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') <= '2016.2.1' ).to be === false
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :!=, '2016.2.1')).to be === true
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') != '2016.2.1' ).to be === true
         end
 
         it 'can compare 2017.1.0-rc9-100-gabcdef and 2016.2.1' do
-          expect( subject.puppet_version_comparison('2017.1.0-rc9-100-gabcdef', :==, '2016.2.1')).to be === false
+          expect( subject::PuppetVersion.new('2017.1.0-rc9-100-gabcdef') == '2016.2.1' ).to be === false
         end
 
         it 'reports 3.0.0-160-gac44cfb is not less than 3.0.0' do
-          expect( subject.puppet_version_comparison( '3.0.0-160-gac44cfb', '<', '3.0.0' ) ).to be === false
+          expect( subject::PuppetVersion.new('3.0.0-160-gac44cfb') < '3.0.0' ).to be === false
         end
 
         it 'reports 3.0.0-160-gac44cfb is not less than 2.8.2' do
-          expect( subject.puppet_version_comparison( '3.0.0-160-gac44cfb', '<', '2.8.2' ) ).to be === false
+          expect( subject::PuppetVersion.new('3.0.0-160-gac44cfb') < '2.8.2' ).to be === false
         end
 
         it 'reports 3.0.0-rc0-160-gac44cfb is less than 3.0.0' do
-          expect( subject.puppet_version_comparison( '3.0.0-rc0-160-gac44cfb', '<', '3.0.0' ) ).to be === true
+          expect( subject::PuppetVersion.new('3.0.0-rc0-160-gac44cfb') < '3.0.0' ).to be === true
         end
 
         it 'reports 3.0.0-rc0-160-gac44cfb is greater than 2.8.0' do
-          expect( subject.puppet_version_comparison( '3.0.0-rc0-160-gac44cfb', '>', '2.8.0' ) ).to be === true
+          expect( subject::PuppetVersion.new('3.0.0-rc0-160-gac44cfb') > '2.8.0' ).to be === true
         end
 
         it 'reports 3.0.0 is less than 3.0.0-160-gac44cfb' do
-          expect( subject.puppet_version_comparison( '3.0.0', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+          expect( subject::PuppetVersion.new('3.0.0') < '3.0.0-160-gac44cfb' ).to be === true
         end
 
         it 'reports 2.8.2 is less than 3.0.0-160-gac44cfb' do
-          expect( subject.puppet_version_comparison( '2.8.2', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+          expect( subject::PuppetVersion.new('2.8.2') < '3.0.0-160-gac44cfb' ).to be === true
         end
 
         it 'reports 2.8.0 is less than 3.0.0-160-gac44cfb' do
-          expect( subject.puppet_version_comparison( '2.8.0', '<', '3.0.0-160-gac44cfb' ) ).to be === true
+          expect( subject::PuppetVersion.new('2.8.0') < '3.0.0-160-gac44cfb' ).to be === true
         end
 
         it 'reports 2.8.0 is less than 2.9.0' do
-          expect( subject.puppet_version_comparison( '2.8.0', '<', '2.9.0' ) ).to be === true
+          expect( subject::PuppetVersion.new('2.8.0') < '2.9.0' ).to be === true
         end
 
         it 'reports 2.9.0 is greater than 2.8.0' do
-          expect( subject.puppet_version_comparison( '2.9.0', '>', '2.8.0' ) ).to be === true
+          expect( subject::PuppetVersion.new('2.9.0') > '2.8.0' ).to be === true
         end
 
         it 'reports 2.8 is less than 2.9' do
-          expect( subject.puppet_version_comparison( '2.8', '<', '2.9' ) ).to be === true
+          expect( subject::PuppetVersion.new('2.8') < '2.9' ).to be === true
         end
 
         it 'reports 2.8.2 is less than 2.9' do
-          expect( subject.puppet_version_comparison( '2.8.2', '<', '2.9' ) ).to be === true
+          expect(subject::PuppetVersion.new('2.8.2') < '2.9').to be === true
+        end
+
+        it 'compares two PuppetVersions' do
+          expect(subject::PuppetVersion.new('2.8.2') < subject::PuppetVersion.new('2.9')).to be === true
         end
 
         it 'blows up if you give it an invalid version' do
           expect {
-            subject.puppet_version_comparison( 'a.banana.5', '<', '2.9' )
-          }.to raise_error(/Unknown version format/)
+            subject::PuppetVersion.new('a.banana.5') < '2.9'
+          }.to raise_error(/Unknown format/)
         end
 
         it 'blows up if you give it an invalid version' do
           expect {
-            subject.puppet_version_comparison( '1.2.beta', '<', '2.9' )
-          }.to raise_error(/Unknown version format/)
+            subject::PuppetVersion.new('1.2.beta') < '2.9'
+          }.to raise_error(/Unknown format/)
         end
       end
 

--- a/spec/beaker/shared/semvar_spec.rb
+++ b/spec/beaker/shared/semvar_spec.rb
@@ -46,9 +46,9 @@ module Beaker
       describe 'PuppetVersion' do
         it 'accepts valid PE non-final builds' do
           ver = '2015.3.0-rc0-8-gf80879a'
-          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
-          expect( subject::PuppetVersion.new(ver).y ).to be == 3
-          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).major ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).minor ).to be == 3
+          expect( subject::PuppetVersion.new(ver).patch ).to be == 0
           expect( subject::PuppetVersion.new(ver).rc ).to be == 0
           expect( subject::PuppetVersion.new(ver).build ).to be == 8
           expect( subject::PuppetVersion.new(ver).sha ).to be == 'f80879a'
@@ -56,9 +56,9 @@ module Beaker
 
         it 'accepts valid PE final builds' do
           ver = '2015.3.0'
-          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
-          expect( subject::PuppetVersion.new(ver).y ).to be == 3
-          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).major ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).minor ).to be == 3
+          expect( subject::PuppetVersion.new(ver).patch ).to be == 0
           expect( subject::PuppetVersion.new(ver).rc ).to be == 999
           expect( subject::PuppetVersion.new(ver).build ).to be == 0
           expect( subject::PuppetVersion.new(ver).sha ).to be == nil
@@ -66,9 +66,9 @@ module Beaker
 
         it 'accepts valid PE post-final builds' do
           ver = '2015.3.0-8-gf80879a'
-          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
-          expect( subject::PuppetVersion.new(ver).y ).to be == 3
-          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).major ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).minor ).to be == 3
+          expect( subject::PuppetVersion.new(ver).patch ).to be == 0
           expect( subject::PuppetVersion.new(ver).rc ).to be == 999
           expect( subject::PuppetVersion.new(ver).build ).to be == 8
           expect( subject::PuppetVersion.new(ver).sha ).to be == 'f80879a'
@@ -76,9 +76,9 @@ module Beaker
 
         it 'accepts valid PE year/release' do
           ver = '2015.3'
-          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
-          expect( subject::PuppetVersion.new(ver).y ).to be == 3
-          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).major ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).minor ).to be == 3
+          expect( subject::PuppetVersion.new(ver).patch ).to be == 0
           expect( subject::PuppetVersion.new(ver).rc ).to be == 999
           expect( subject::PuppetVersion.new(ver).build ).to be == 0
           expect( subject::PuppetVersion.new(ver).sha ).to be == nil
@@ -86,9 +86,9 @@ module Beaker
 
         it 'accepts valid PE year' do
           ver = '2015'
-          expect( subject::PuppetVersion.new(ver).x ).to be == 2015
-          expect( subject::PuppetVersion.new(ver).y ).to be == 0
-          expect( subject::PuppetVersion.new(ver).z ).to be == 0
+          expect( subject::PuppetVersion.new(ver).major ).to be == 2015
+          expect( subject::PuppetVersion.new(ver).minor ).to be == 0
+          expect( subject::PuppetVersion.new(ver).patch ).to be == 0
           expect( subject::PuppetVersion.new(ver).rc ).to be == 999
           expect( subject::PuppetVersion.new(ver).build ).to be == 0
           expect( subject::PuppetVersion.new(ver).sha ).to be == nil


### PR DESCRIPTION
The `version_is_less` method is widely used for comparing PE and Puppet
version across all of the acceptance tests. But only being able to
perform a less than comparison is limiting and hard to read since
you must check `!version_is_less` to determine if versions are
greater than.

This commit adds a `PuppetVersion` class that extends `Semantic::Version`
which should allow any standard ruby comparison operators to be used with
it.
