### PR TITLE
(BKR-954) Add Ability to Disable Openstack Volume Management

### DIFF
--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -123,3 +123,17 @@ user their own pool.  It's used in allocating new IPs.  It's an options
 parameter in the CONFIG section of the host file:
 
     floating_ip_pool: 'my_pool_name'
+
+### Volume Support
+
+In the event your using an OpenStack instance that does not deploy the volume service you can disable that functionality to prevent beaker runs from failing.  Either using an ENV variable or setting the following value in the `CONFIG` section of your hosts file(valid values are `true` or `false`):
+
+```
+openstack_volume_support: false
+```
+
+You can also configure this setting via an environment variable:
+
+```
+export OS_VOL_SUPPORT=false
+```

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -63,6 +63,17 @@ module Beaker
         raise "Unable to create OpenStack Network instance (api_key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]})"
       end
 
+      # Validate openstack_volume_support setting value, reset to boolean if passed via ENV value string
+      if not @options[:openstack_volume_support].is_a?(TrueClass) || @options[:openstack_volume_support].is_a?(FalseClass)
+        if @options[:openstack_volume_support].match(/\btrue\b/i)
+          @options[:openstack_volume_support] = true
+        elsif @options[:openstack_volume_support].match(/\bfalse\b/i)
+          @options[:openstack_volume_support] = false
+        else
+          raise "Invalid value provided for CONFIG setting openstack_volume_support, current value #{@options[:openstack_volume_support]}"
+        end
+      end
+
     end
 
     #Provided a flavor name return the OpenStack id for that flavor
@@ -250,7 +261,8 @@ module Beaker
         #enable root if user is not root
         enable_root(host)
 
-        provision_storage(host, vm)
+        provision_storage(host, vm) if @options[:openstack_volume_support]
+        @logger.notify "OpenStack Volume Support Disabled, can't provision volumes" if not @options[:openstack_volume_support]
       end
 
       hack_etc_hosts @hosts, @options
@@ -261,7 +273,7 @@ module Beaker
     def cleanup
       @logger.notify "Cleaning up OpenStack"
       @vms.each do |vm|
-        cleanup_storage(vm)
+        cleanup_storage(vm) if @options[:openstack_volume_support]
         @logger.debug "Release floating IPs for OpenStack host #{vm.name}"
         floating_ips = vm.all_addresses # fetch and release its floating IPs
         floating_ips.each do |address|

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -133,6 +133,7 @@ module Beaker
           :openstack_keyname      => ENV['OS_KEYNAME'],
           :openstack_network      => ENV['OS_NETWORK'],
           :openstack_region       => ENV['OS_REGION'],
+          :openstack_volume_support => ENV['OS_VOL_SUPPORT'] || true,
           :jenkins_build_url      => nil,
           :validate               => true,
           :configure              => true,


### PR DESCRIPTION
Prior to this commit beaker openstack support assumed that the
`volumes` service was provisioned.  This service is not always
available in an Openstack deployment.  If you do not disable it
on an instance that does not publish this functionality, even if
you don't configure the volumes setting in `CONFIG`, beaker runs
will fail.  This commit gives you the option to disable that functionality.
