### PR TITLE
(MAINT) Allow no hosts option to be passed

### DIFF
--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -224,7 +224,7 @@ module Beaker
       # @raise [ArgumentError] if a hosts file is generated, but it can't
       #   be read by the HostsFileParser
       def parse_hosts_options
-        if File.exists?(@options[:hosts_file])
+        if @options[:hosts_file].nil? || File.exists?(@options[:hosts_file])
           #read the hosts file that contains the node configuration and hypervisor info
           return Beaker::Options::HostsFileParser.parse_hosts_file(@options[:hosts_file])
         end

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -246,7 +246,9 @@ module Beaker
           end
 
           it 'calls beaker-hostgenerator to get hosts information' do
-            parser.instance_variable_set( :@options, {} )
+            parser.instance_variable_set( :@options, {
+              :hosts_file => 'notafile.yml'
+            } )
             allow( Beaker::Options::HostsFileParser ).to receive(
               :parse_hosts_file
             ).and_raise( Errno::ENOENT )
@@ -266,7 +268,9 @@ module Beaker
           end
 
           it 'sets the :hosts_file_generated flag to signal others when needed' do
-            options_test = {}
+            options_test = {
+              :hosts_file => 'not_a_file.yml'
+            }
             parser.instance_variable_set( :@options, options_test )
             allow( Beaker::Options::HostsFileParser ).to receive(
               :parse_hosts_file
@@ -284,7 +288,9 @@ module Beaker
           end
 
           it 'beaker-hostgenerator failures trigger nice prints & a rethrow' do
-            options_test = {}
+            options_test = {
+              :hosts_file => 'not_a_file.yml'
+            }
             parser.instance_variable_set( :@options, options_test )
             allow( Beaker::Options::HostsFileParser ).to receive(
               :parse_hosts_file
@@ -308,6 +314,14 @@ module Beaker
             expect {
               parser.parse_hosts_options
             }.to raise_error( BeakerHostGenerator::Exceptions::InvalidNodeSpecError )
+          end
+
+          it 'can be passed a nil hosts file and get the default hash back' do
+            parser.instance_variable_set( :@options, {} )
+
+            host_options = parser.parse_hosts_options
+            expect(host_options[:HOSTS]).to be === {}
+
           end
         end
 


### PR DESCRIPTION
In previous versions (such as 2.14.1, which was previously
used to run our ec2 zombie killer), beaker could be run
without a hosts file argument. This would allow beaker test
logic to be run without needing to stand up SUTs. During the
time where beaker-hostgenerator support was added, this
ability was removed. This change allows us to run without
the hosts file argument, as was previously done.