### PR TITLE
(BKR-965) Re-enable the prior way of setting hostnames but keep the new default

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -634,17 +634,33 @@ module Beaker
     # publicly. Then configure each ec2 machine to that dns_name, so that when facter
     # is installed the facts for hostname and domain match the dns_name.
     #
+    # if :use_beaker_hostnames: is true, set the :vmhostname and hostname of each ec2
+    # machine to the host[:name] from the beaker hosts file.
+    #
     # @return [@hosts]
     # @api private
     def set_hostnames
-      @hosts.each do |host|
-        host[:vmhostname] = host[:dns_name]
-        if host['platform'] =~ /el-7/
-          # on el-7 hosts, the hostname command doesn't "stick" randomly
-          host.exec(Command.new("hostnamectl set-hostname #{host.hostname}"))
-        else
-          next if host['platform'] =~ /netscaler/
-          host.exec(Command.new("hostname #{host.hostname}"))
+      if @options[:use_beaker_hostnames]
+        @hosts.each do |host|
+          host[:vmhostname] = host[:name]
+          if host['platform'] =~ /el-7/
+            # on el-7 hosts, the hostname command doesn't "stick" randomly
+            host.exec(Command.new("hostnamectl set-hostname #{host.name}"))
+          else
+            next if host['platform'] =~ /netscaler/
+            host.exec(Command.new("hostname #{host.name}"))
+          end
+        end
+      else
+        @hosts.each do |host|
+          host[:vmhostname] = host[:dns_name]
+          if host['platform'] =~ /el-7/
+            # on el-7 hosts, the hostname command doesn't "stick" randomly
+            host.exec(Command.new("hostnamectl set-hostname #{host.hostname}"))
+          else
+            next if host['platform'] =~ /netscaler/
+            host.exec(Command.new("hostname #{host.hostname}"))
+          end
         end
       end
     end

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -623,6 +623,19 @@ module Beaker
           end
         end
 
+        it 'sets the the vmhostname to the beaker config name for each host' do
+          options[:use_beaker_hostnames] = true
+	  @hosts.each do |host|
+            host[:name] = "prettyponyprincess"
+	  end
+          expect(set_hostnames).to eq(@hosts)
+          @hosts.each do |host|
+            puts host[:name]
+            expect(host[:vmhostname]).to eq(host[:name])
+            expect(host[:vmhostname]).to eq(host.hostname)
+          end
+        end
+
       end
     end
 


### PR DESCRIPTION
With Tony's [check-in](https://github.com/puppetlabs/beaker/commit/a5bbdab25281745e7ee053ffd8bc01dae1180f69) the default hostnames of ec2 VMs went from whatever was configured in the beaker hosts file, to the DNS-name given by the Amazon ec2 service. Unfortunately, this broke the pe_acceptance_tests tooling on ec2, which is used for release scale testing.

This check-in makes the old behavior available again, but only if you set :use_beaker_hostnames: true in the beaker hosts file. In other words, this should NOT break any testing that required Tony's original check-in.