### PR TITLE
(MAINT) Update CLI hosts option help text

### DIFF
--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -16,7 +16,10 @@ module Beaker
 
           opts.on '-h', '--hosts FILE',
                   'Use host configuration FILE',
-                  '(default sample.cfg)'  do |file|
+                  'Possible FILE values:',
+                  'a file path (beaker will parse file directly)',
+                  'a beaker-hostgenerator string (BHG generates hosts file)',
+                  'omitted (coordinator-only run; no SUTs provisioned)' do |file|
             @cmd_options[:hosts_file] = file
           end
 


### PR DESCRIPTION
In #1266, we added the ability to have the  CLI
argument be omitted for a beaker run. This was restoring
old behavior, but there was no guide on what values could
be passed. This change sets the CLI help text to explain
the possibilities to the user, clearing up the ways we
intend the  argument to work.