### PR TITLE
(BKR-971) Ensure scp errors close ssh connections

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -273,9 +273,17 @@ module Beaker
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
 
-      @ssh.scp.upload! source, target, local_opts do |ch, name, sent, total|
-        result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
+      begin
+        @ssh.scp.upload! source, target, local_opts do |ch, name, sent, total|
+          result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
+        end
+      rescue => e
+        logger.warn "#{e.class} error in scp'ing. Forcing the connection to close, which should " <<
+          "raise an error."
+        close
       end
+
+
       # Setting these values allows reporting via result.log(test_name)
       result.stdout << "  SCP'ed file #{source} to #{@hostname}:#{target}"
 
@@ -297,9 +305,16 @@ module Beaker
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
 
-      @ssh.scp.download! source, target, local_opts do |ch, name, sent, total|
-        result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
+      begin
+        @ssh.scp.download! source, target, local_opts do |ch, name, sent, total|
+          result.stdout << "\tcopying %s: %10d/%d\n" % [name, sent, total]
+        end
+      rescue => e
+        logger.warn "#{e.class} error in scp'ing. Forcing the connection to close, which should " <<
+          "raise an error."
+        close
       end
+
       # Setting these values allows reporting via result.log(test_name)
       result.stdout << "  SCP'ed file #{@hostname}:#{source} to #{target}"
 

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -245,6 +245,12 @@ module Beaker
         connection.scp_to '', ''
       end
 
+      it 'ensures the connection closes when scp.upload! errors' do
+        expect( @mock_scp ).to receive( :upload! ).once.and_raise(RuntimeError)
+        expect(connection).to receive(:close).once
+        connection.scp_to '', ''
+      end
+
       it 'returns a result object' do
         expect( connection.scp_to '', '' ).to be_a_kind_of Beaker::Result
       end
@@ -263,6 +269,12 @@ module Beaker
 
       it 'calls scp.download!' do
         expect( @mock_scp ).to receive( :download! ).once
+        connection.scp_from '', ''
+      end
+
+      it 'ensures the connection closes when scp.download! errors' do
+        expect( @mock_scp ).to receive( :download! ).once.and_raise(RuntimeError)
+        expect(connection).to receive(:close).once
         connection.scp_from '', ''
       end
 


### PR DESCRIPTION
Previous to this commit, beaker scp errors would leave the ssh
connection in a dangling state because of Exceptions that would bubble
up without closing out the ssh connection. This change ensures that when
errors are raised, the #close method is called. While the exceptions are
swallowed, the #close methods called end up raising errors from the
state of the connection object, thus not requiring that the original
asserts be raised.