### PR TITLE
(BKR-976) Finalize 2.x dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,269 @@
+PATH
+  remote: .
+  specs:
+    beaker (2.51.0)
+      aws-sdk-v1 (~> 1.57)
+      beaker-answers (~> 0.0)
+      beaker-hiera (~> 0.0)
+      beaker-hostgenerator
+      beaker-pe (~> 0.0)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25, < 1.35.0)
+      fog-google (~> 0.0.9)
+      google-api-client (~> 0.8, < 0.9.5)
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      mime-types (~> 2.99)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      open_uri_redirections (~> 0.2.1)
+      public_suffix (< 1.5.0)
+      rbvmomi (~> 1.8, < 1.9.0)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      unf (~> 0.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.3)
+    addressable (2.4.0)
+    aws-sdk-v1 (1.66.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    beaker-answers (0.13.0)
+      hocon (~> 1.0)
+      require_all (~> 1.3.2)
+      stringify-hash (~> 0.0.0)
+    beaker-hiera (0.1.1)
+      stringify-hash (~> 0.0.0)
+    beaker-hostgenerator (0.8.0)
+      deep_merge (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-pe (0.12.1)
+      stringify-hash (~> 0.0.0)
+    builder (3.2.2)
+    coderay (1.1.1)
+    deep_merge (1.1.1)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    docker-api (1.32.1)
+      excon (>= 0.38.0)
+      json
+    excon (0.54.0)
+    fakefs (0.10.0)
+    faraday (0.10.0)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.34.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.12.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.11.0)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
+      fog-core
+      fog-xml
+    fog-google (0.0.9)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-radosgw (0.0.5)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.7.5)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (1.1.4)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    google-api-client (0.9.4)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+      thor (~> 0.19)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    hocon (1.2.4)
+    httpclient (2.8.2.4)
+    hurley (0.2)
+    in-parallel (0.1.15)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.3)
+    json (1.8.3)
+    jwt (1.5.6)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    memoist (0.15.0)
+    method_source (0.8.2)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    minitest (5.9.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.4)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    open_uri_redirections (0.2.1)
+    os (0.9.6)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (1.4.6)
+    rake (10.5.0)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    require_all (1.3.3)
+    retriable (2.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    rsync (1.0.9)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    slop (3.6.0)
+    stringify-hash (0.0.2)
+    thor (0.19.1)
+    trollop (2.1.2)
+    uber (0.0.15)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+    yard (0.9.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  beaker!
+  fakefs (~> 0.6)
+  pry (~> 0.10)
+  rake (~> 10.1)
+  rspec (~> 3.0)
+  rspec-its
+  simplecov
+  yard
+
+BUNDLED WITH
+   1.12.5

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -58,4 +58,7 @@ Gem::Specification.new do |s|
 
   # So fog doesn't always complain of unmet AWS dependencies
   s.add_runtime_dependency 'unf', '~> 0.1'
+  # public_suffix is required by addressable, so make sure it pulls a version
+  # that still supports ruby 1.9.3
+  s.add_runtime_dependency 'public_suffix', ' < 1.5.0'
 end


### PR DESCRIPTION
In order to keep ruby dependencies from breaking the last 2.x version of
beaker, we can add a Gemfile.lock file to the release so that all
versions are pinned exactly and ranged versions cannot introduce
failures to bundle install.