### PR TITLE
(BKR-978) Updates beaker to work with SLES

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -434,7 +434,11 @@ module Beaker
         # @api private
         def install_puppet_from_rpm_on( hosts, opts )
           block_on hosts do |host|
-            install_puppetlabs_release_repo(host)
+            if host[:type] == 'aio'
+              install_puppetlabs_release_repo(host,'pc1',opts)
+            else
+              install_puppetlabs_release_repo(host,nil,opts)
+            end
 
             if opts[:facter_version]
               host.install_package("facter-#{opts[:facter_version]}")

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -65,7 +65,7 @@ module Unix::Pkg
   def install_package(name, cmdline_args = '', version = nil, opts = {})
     case self['platform']
       when /sles-/
-        execute("zypper --non-interactive in #{name}", opts)
+        execute("zypper --no-gpg-checks --non-interactive in #{name}", opts)
       when /el-4/
         @logger.debug("Package installation not supported on rhel4")
       when /fedora-(2[2-9])/


### PR DESCRIPTION
Requires BKR-931 for AIO to work at all.

Tested against the following nodeset:

```

---
HOSTS:
   sles:
      roles:
         - default
         - master
      platform:   sles-12-x86_64
      box:        opensuse/openSUSE-Tumbleweed-x86_64
      hypervisor: vagrant
     
CONFIG:
  synced_folder : disabled
  log_level: verbose
  type: aio
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/puppetlabs/beaker/1277)
<!-- Reviewable:end -->
