### PR TITLE
(BKR-40) Pin net-ssh gem to 3.3.0beta1

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   ## aws-sdk-2 doesn't require json, so we can give this up when we move
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
-  s.add_runtime_dependency 'net-ssh', '~> 3.2'
+  s.add_runtime_dependency 'net-ssh', '3.3.0.beta1'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 2.0'
   ## inifile: keep <3.0, breaks puppet_helpers.rb:puppet_conf_for when updated


### PR DESCRIPTION
 - This version of net-ssh includes UTF-8 related fixes when commands or paths exceed 127 characters.
   Unfortunately the author is discontinuing any releases in the 2.* or 3.* series, hasn't yet released any non-alpha or beta
   4.* releases, and has versioned this last release in the 3 series with a beta1 name, so it must be referenced explicitly.