### PR TITLE
(BKR-982) OpenStack Cinder V2

### DIFF
--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -123,3 +123,32 @@ user their own pool.  It's used in allocating new IPs.  It's an options
 parameter in the CONFIG section of the host file:
 
     floating_ip_pool: 'my_pool_name'
+
+### Volumes
+
+Attaching volumes to a VM is supported via the Cinder service.  All versions are transparently
+supported to cater for differences in the APIs.  To create and attach volumes simply add hash
+called 'volumes' to a host in the HOSTS section.  Each key is the name given to the volume upon
+resource creation.  The value is a hash with a single integer parameter 'size' which defines the
+volume size in MB.
+
+**Example OpenStack hosts file with volumes**
+
+    HOSTS:
+      ceph:
+        roles:
+          - master
+        platform: ubuntu-16.04-amd64
+        hypervisor: openstack
+        flavor: m1.large
+        image: xenial-server-cloudimg-amd64-scsi
+        user: ubuntu
+        volumes:
+          osd0:
+            size: 10000
+          osd1:
+            size: 10000
+          osd2:
+            size: 10000
+          journal:
+            size: 1000

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -104,5 +104,57 @@ module Beaker
       (1..3).each { openstack.get_ip }
     end
 
+    it 'creates volumes with cinder v1' do
+      # Mock a volume
+      allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
+
+      # Stub out the call to create the client and hard code the return value
+      allow(openstack).to receive(:volume_client_create).and_return(nil)
+      client = double().as_null_object
+      openstack.instance_variable_set(:@volume_client, client)
+      allow(openstack).to receive(:get_volume_api_version).and_return(1)
+
+      # Check the parameters are valid, correct 'name' parameter and correct size conversion
+      mock_volume = double().as_null_object
+      expect(client).to receive(:create).with(:display_name => 'volume1', :description => 'Beaker volume: host=alan volume=volume1', :size => 1000).and_return(mock_volume)
+      allow(mock_volume).to receive(:wait_for).and_return(nil)
+
+      # Perform the test!
+      mock_vm = double().as_null_object
+      allow(mock_volume).to receive(:id).and_return('Fake ID')
+      expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
+
+      mock_host = double().as_null_object
+      allow(mock_host).to receive(:name).and_return('alan')
+
+      openstack.provision_storage mock_host, mock_vm
+    end
+
+    it 'creates volumes with cinder v2' do
+      # Mock a volume
+      allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
+
+      # Stub out the call to create the client and hard code the return value
+      allow(openstack).to receive(:volume_client_create).and_return(nil)
+      client = double().as_null_object
+      openstack.instance_variable_set(:@volume_client, client)
+      allow(openstack).to receive(:get_volume_api_version).and_return(-1)
+
+      # Check the parameters are valid, correct 'name' parameter and correct size conversion
+      mock_volume = double().as_null_object
+      expect(client).to receive(:create).with(:name => 'volume1', :description => 'Beaker volume: host=alan volume=volume1', :size => 1000).and_return(mock_volume)
+      allow(mock_volume).to receive(:wait_for).and_return(nil)
+
+      # Perform the test!
+      mock_vm = double().as_null_object
+      allow(mock_volume).to receive(:id).and_return('Fake ID')
+      expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
+
+      mock_host = double().as_null_object
+      allow(mock_host).to receive(:name).and_return('alan')
+
+      openstack.provision_storage mock_host, mock_vm
+    end
+
   end
 end


### PR DESCRIPTION
Fog defaults to the V2 API on clouds that support it, but the parameters
have changed, in particular `display_name` becomes `name`.  This checks
the cinder client type and uses the old value for V1 and the new one for
newer versions.