### PR TITLE
(BKR-983) OpenStack Must Allocate New Floating IP

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -171,21 +171,17 @@ module Beaker
       end
     end
 
-    # Get a floating IP address to associate with the instance, and
-    # allocate a new one if none are available
+    # Get a floating IP address to associate with the instance, try
+    # to allocate a new one from the specified pool if none are available
     def get_ip
-      @logger.debug "Finding IP"
-      ip = @compute_client.addresses.find { |ip| ip.instance_id.nil? }
-      if ip.nil?
-        begin
-          @logger.debug "Creating IP"
-          ip = @compute_client.addresses.create
-        rescue Fog::Compute::OpenStack::NotFound
-          # If there are no more floating IP addresses, allocate a
-          # new one and try again. 
-          @compute_client.allocate_address(@options[:floating_ip_pool])
-          ip = @compute_client.addresses.find { |ip| ip.instance_id.nil? }
-        end
+      begin
+        @logger.debug "Creating IP"
+        ip = @compute_client.addresses.create
+      rescue Fog::Compute::OpenStack::NotFound
+        # If there are no more floating IP addresses, allocate a
+        # new one and try again. 
+        @compute_client.allocate_address(@options[:floating_ip_pool])
+        ip = @compute_client.addresses.find { |ip| ip.instance_id.nil? }
       end
       raise 'Could not find or allocate an address' if not ip
       ip


### PR DESCRIPTION
Fixes a race where one instance would allocate a floating IP and while
creating the server other instances (e.g. parallel invokations in travis)
would try to use the allocated but unassociated address and fail in
all manner of ways.  This enforces aloocation of a new floating IP each
and every time.