### PR TITLE
(BKR-987) Remove explicit json gem dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -33,9 +33,6 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'minitar', '~> 0.5.4'
-  s.add_runtime_dependency 'json', '~> 1.8'
-  ## json: will stay <2.0 while aws-sdk-v1 is in use
-  ## aws-sdk-2 doesn't require json, so we can give this up when we move
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '3.3.0.beta1'


### PR DESCRIPTION
 - aws-sdk-v1 transitively requires the `json` gem, which was added to
   the Gemfile in 8c76afcce87cf7c23adaa6d7c76f00b7040a2e54

   However, it doesn't appear that the `json` version for Beaker was
   specified for any compelling reason, and can cause issues on Windows
   systems when other gems requiring `json` are added to a Gemfile that
   also references Beaker, for instance with puppet modules like
   Registry or ACL.

   Even in Puppet modules, where `bundle install --without system_tests`
   is specified to prevent Beaker installation, if other gems require the
   `json` gem as a dependency, Bundler looks at the requirements of the
   `beaker` gem and its dependencies when determining which `json` gem
   version satisfies the requirement.

   This can lead to Bundler attempting to install a newer `json` gem
   than the one that is Bundled with the Ruby distribution.
   Attempting to install the `json` gem requires the DevKit be installed
   on Windows, as it includes native code that needs to be compiled -
   and therefore is inappropriate for many CI testing scenarios.

 - Realistically `json` should no longer even require being explicitly
   referenced given it ships with Ruby based on the following info:

   - JSON 1.4.2 with 1.9.2 -
     https://github.com/ruby/ruby/blob/ruby_1_9_2/ext/json/lib/json/version.rb
   - JSON 1.5.5 with 1.9.3 -
     https://github.com/ruby/ruby/blob/ruby_1_9_3/ext/json/lib/json/version.rb
   - JSON 1.7.7 with 2.0.0 series -
     https://github.com/ruby/ruby/blob/ruby_2_0_0/ext/json/lib/json/version.rb
   - JSON 1.8.1 with 2.1.0 - through 2.1.7 -
     https://github.com/ruby/ruby/blob/v2_1_7/ext/json/lib/json/version.rb
   - JSON 1.8.1 with 2.2.0 - through 2.2.3 -
     https://github.com/ruby/ruby/blob/v2_2_3/ext/json/lib/json/version.rb

 - Unfortunately, this solution only appears to fix `gem install` type
   workflows, but does not fix `bundler` based workflows when using a
   local gem cache specified with `--path`. While Bundler claims to
   support using both system gems (like the `json` gem shipped with
   Ruby) AND gems specified in the local `Gemfile`, when `--path` is
   specified, Bundler sets its `BUNDLE_DISABLE_SHARED_GEMS: 1` in the
   local .bundle/config, preventing the system `json` from being used.
   In testing, it seemed that there was no way to override this
   behavior.

   That said, should other gem dependencies later remove their explicit
   `json` requirements, at least removing the `json` gem as a Beaker
   dependency will prevent Beaker itself from causing installations.

 - Note Beaker 3 only runs atop Ruby 2, which always includes at least
   `json` 1.7.7.