### PR TITLE
(MAINT) assert on OSX pkg info requirement

### DIFF
--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -65,8 +65,8 @@ module Mac::Pkg
   # @param [String] puppet_agent_version Version of puppet agent to get
   # @param [Hash{Symbol=>String}] opts Options hash to provide extra values
   #
-  # @note OSX doesn't use any additional options at this time, but does require
-  #   both puppet_collection & puppet_agent_version, & will fail without them
+  # @note OSX does require :download_url to be set on the opts argument
+  #   in order to check for builds on the builds server
   #
   # @raise [ArgumentError] If one of the two required parameters (puppet_collection,
   #   puppet_agent_version) is either not passed or set to nil
@@ -76,6 +76,7 @@ module Mac::Pkg
     error_message = "Must provide %s argument to get puppet agent dev package information"
     raise ArgumentError, error_message % "puppet_collection" unless puppet_collection
     raise ArgumentError, error_message % "puppet_agent_version" unless puppet_agent_version
+    raise ArgumentError, error_message % "opts[:download_url]" unless opts[:download_url]
 
     variant, version, arch, codename = self['platform'].to_array
 

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -376,8 +376,9 @@ module Unix::Pkg
   # @param [String] puppet_agent_version Version of puppet agent to get
   # @param [Hash{Symbol=>String}] opts Options hash to provide extra values
   #
-  # @note Solaris does require some options to be set. See
-  #   {#solaris_puppet_agent_dev_package_info} for more details
+  # @note Solaris & OSX do require some options to be set. See
+  #   {#solaris_puppet_agent_dev_package_info} &
+  #   {Mac::Pkg#puppet_agent_dev_package_info} for more details
   #
   # @raise [ArgumentError] If one of the two required parameters (puppet_collection,
   #   puppet_agent_version) is either not passed or set to nil

--- a/spec/beaker/host/mac_spec.rb
+++ b/spec/beaker/host/mac_spec.rb
@@ -14,30 +14,34 @@ module Mac
 
     describe '#puppet_agent_dev_package_info' do
       it 'raises an error if puppet_collection isn\'t passed' do
-        expect { host.puppet_agent_dev_package_info(nil, 'maybe') }.to raise_error(ArgumentError)
+        expect { host.puppet_agent_dev_package_info(nil, 'maybe', :download_url => '') }.to raise_error(ArgumentError)
       end
 
-      it 'raises as error if puppet_agent_version isn\'t passed' do
-        expect { host.puppet_agent_dev_package_info('maybe', nil) }.to raise_error(ArgumentError)
+      it 'raises an error if puppet_agent_version isn\'t passed' do
+        expect { host.puppet_agent_dev_package_info('maybe', nil, :download_url => '') }.to raise_error(ArgumentError)
+      end
+
+      it 'raises an error if opts[:download_url] isn\'t passed' do
+        expect { host.puppet_agent_dev_package_info('', '') }.to raise_error(ArgumentError)
       end
 
       it 'returns two strings that include the passed parameters' do
         allow( host ).to receive( :link_exists? ) { true }
-        return1, return2 = host.puppet_agent_dev_package_info( 'pc1', 'pav1' )
+        return1, return2 = host.puppet_agent_dev_package_info( 'pc1', 'pav1', :download_url => '' )
         expect( return1 ).to match( /pc1/ )
         expect( return2 ).to match( /pav1/ )
       end
 
       it 'gets the correct file type' do
         allow( host ).to receive( :link_exists? ) { true }
-        _, return2 = host.puppet_agent_dev_package_info( 'pc1', 'pav1' )
+        _, return2 = host.puppet_agent_dev_package_info( 'pc2', 'pav2', :download_url => '' )
         expect( return2 ).to match( /\.dmg$/ )
       end
 
       it 'adds the version dot correctly if not supplied' do
         @platform = 'osx-109-x86_64'
         allow( host ).to receive( :link_exists? ) { true }
-        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC3', 'pav3' )
+        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC3', 'pav3', :download_url => '' )
         expect( release_path_end ).to match( /10\.9/ )
         expect( release_file ).to match( /10\.9/ )
       end
@@ -45,7 +49,7 @@ module Mac
       it 'runs the correct install for osx platforms (newest link format)' do
         allow( host ).to receive( :link_exists? ) { true }
 
-        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC4', 'pav4' )
+        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC4', 'pav4', :download_url => '' )
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav4-/ )
         # verify the "newest hotness" is set correctly for the end of the mac package name
@@ -57,7 +61,7 @@ module Mac
       it 'runs the correct install for osx platforms (new link format)' do
         allow( host ).to receive( :link_exists? ).and_return( false, true )
 
-        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC7', 'pav7' )
+        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC7', 'pav7', :download_url => '' )
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav7-/ )
         # verify the "new hotness" is set correctly for the end of the mac package name
@@ -69,7 +73,7 @@ module Mac
       it 'runs the correct install for osx platforms (old link format)' do
         allow( host ).to receive( :link_exists? ) { false }
 
-        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC8', 'pav8' )
+        release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC8', 'pav8', :download_url => '' )
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav8-/ )
         # verify the old way is set correctly for the end of the mac package name


### PR DESCRIPTION
Doing work for 4be19a3, I found that
the OS X package info method uses the
option's :download_url parameter, but
doesn't require or assert that it exists.
Added an assertion to validate it's
existance since it's necessary.