### PR TITLE
(BKR-1006) Close connection immediately when rebooting Windows

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -340,6 +340,13 @@ module Beaker
           @logger.debug "\n#{log_prefix} executed in %0.2f seconds" % seconds
         end
 
+        if options[:reset_connection]
+          # Expect the connection to fail hard and possibly take a long time timeout.
+          # Pre-emptively reset it so we don't wait forever.
+          close
+          return result
+        end
+
         unless options[:silent]
           # What?
           result.log(@logger)

--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -2,7 +2,7 @@ module Windows::Exec
   include Beaker::CommandFactory
 
   def reboot
-    exec(Beaker::Command.new('shutdown /f /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :expect_connection_failure => true)
+    exec(Beaker::Command.new('shutdown /f /r /t 0 /d p:4:1 /c "Beaker::Host reboot command issued"'), :reset_connection => true)
     # rebooting on windows is sloooooow
     # give it some breathing room before attempting a reconnect
     sleep(40)

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -51,5 +51,14 @@ module Beaker
         expect(instance.selinux_enabled?).to be === false
       end
     end
+
+    describe '#reboot' do
+      it 'invokes the correct command on the host' do
+        expect( Beaker::Command ).to receive( :new ).with( /^shutdown \/f \/r \/t 0 \/d p:4:1 \/c "Beaker::Host reboot command issued"/ ).and_return( :foo )
+        expect( instance ).to receive( :exec ).with( :foo, :reset_connection => true )
+        expect( instance ).to receive( :sleep )
+        instance.reboot
+      end
+    end
   end
 end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -315,6 +315,11 @@ module Beaker
         expect { host.exec(command, opts) }.to_not raise_error
       end
 
+      it 'explicitly closes the connection when :reset_connection is set' do
+        expect( host ).to receive( :close )
+        expect { host.exec(command, :reset_connection => true) }.to_not raise_error
+      end
+
       context "controls the result objects logging" do
         it "and passes a test if the exit_code doesn't match the default :acceptable_exit_codes of 0" do
           result.exit_code = 0


### PR DESCRIPTION
When using `Windows::Exec::reboot`, the SSH connection is expected to
fail. However, it can take a long time to do so (greater than 30 minutes
in some cases). This should be faster, as we know the connection will
fail.

Add a new option to `exec`, `:reset_connection`, that immediately closes
the connection after sending a message. Use it when performing reboot on
a Windows host.