### PR TITLE
(BKR-1009) Don't fail when ip is unavailable in Vagrantfile

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -147,7 +147,8 @@ module Beaker
           ip = m[2]
           @logger.debug("Determined existing vagrant box #{hostname} ip to be: #{ip} ")
         else
-          raise("Unable to determine ip for vagrant box #{hostname}")
+          ip = nil
+          @logger.debug("Unable to determine ip for vagrant box #{hostname}")
         end
       else
         raise("No vagrant file found (should be located at #{@vagrant_file})")

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -375,9 +375,8 @@ EOF
 
       end
 
-      it "raises an error if it is unable to find an ip" do
-        expect{ vagrant.get_ip_from_vagrant_file("unknown") }.to raise_error
-
+      it "returns nil if it is unable to find an ip" do
+        expect( vagrant.get_ip_from_vagrant_file("unknown") ).to be_nil
       end
 
       it "raises an error if no Vagrantfile is present" do


### PR DESCRIPTION
I was running into an issue when using the vagrant_custom hypervisor and not using any private_network with a known ip address (only the NAT interface, no hostonly). In all examples, I am using the virtualbox provider.

The first run with provisioning worked perfectly. If I ran it a second time without reprovisioning I would get an exception stating "Unable to determine ip for vagrant box #{hostname}". This was because only on reprovisioning does beaker attempt to parse out an ip address from the Vagrantfile.

I propose that instead of raising an exception, we just return nil for the ip address. As far as I can tell, beaker connects to the machines using the ssh config file generated from the set_ssh_config method. I compared the host.host_hash from a fresh run and a run without provisioning and they seem functionally equivalent (the ip address was undefined vs nil, respectively). Testing so far doesn't seem to have any negative impact (I've tried with the vagrant_custom and vagrant hypervisor).

https://tickets.puppetlabs.com/browse/BKR-1009