### PR TITLE
(BKR-1010) Fix Cygwin install_package helper

### DIFF
--- a/acceptance/tests/base/host/packages.rb
+++ b/acceptance/tests/base/host/packages.rb
@@ -60,7 +60,11 @@ hosts.each do |host|
 
   assert_equal(false, host.check_for_package(package), "'#{package}' not should be installed")
   logger.debug("#{package} should be installed on #{host}")
-  host.install_package(package)
+  cmdline_args = ''
+  # Newer vmpooler hosts created by Packer templates, and running Cygwin 2.4,
+  # must have these switches passed
+  cmdline_args = '--local-install --download' if (host['platform'] =~ /windows/ and host.is_cygwin?)
+  host.install_package(package, cmdline_args)
   assert(host.check_for_package(package), "'#{package}' should be installed")
 
   # windows does not support uninstall_package

--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -34,7 +34,7 @@ module Windows::Pkg
         execute(command)
       end
     end
-    execute("#{cygwin} -q -n -N -d -R #{cmdline_args} #{rootdir} -s http://cygwin.osuosl.org -P #{name}")
+    execute("#{cygwin} -q -n -N -d -R #{rootdir} -s http://cygwin.osuosl.org -P #{name} #{cmdline_args}")
   end
 
   def uninstall_package(name, cmdline_args = '')


### PR DESCRIPTION
 - Newer Windows templates in vmpooler have been produced through a
   Packer process, and install packages differently than earlier
   templates based on how Cygwin was installed.

   Two additional switches must now be passed for package installs to
   succeed using Cygwins package manager.

   See https://tickets.puppetlabs.com/browse/IMAGES-424 for more detail

   This fixes a bug where `cmdline_args` passed to Cygwins setup*.exe
   are injecetd into the wrong location.  When specify a -R, the
   rootdir value must be passed next.  Previously, additional args
   were injected in between the -R and the rootdir value.