### PR TITLE
(BKR-1011) Fix Windows group_get error detection

### DIFF
--- a/acceptance/tests/base/host/group_test.rb
+++ b/acceptance/tests/base/host/group_test.rb
@@ -1,0 +1,18 @@
+test_name 'Group Test' do
+  step "#group_get: has an Administrators group on Windows" do
+    hosts.select { |h| h['platform'] =~ /windows/ }.each do |host|
+      host.group_get('Administrators') do |result|
+        refute_match(result.stdout, '1376', 'Output indicates Administrators not found')
+      end
+    end
+  end
+
+  step "#group_get: should not have CroMags group on Windows" do
+    hosts.select { |h| h['platform'] =~ /windows/ }.each do |host|
+      assert_raises Beaker::Host::CommandFailure do
+        host.group_get('CroMags') { |result| }
+      end
+    end
+  end
+
+end

--- a/acceptance/tests/base/host/user_test.rb
+++ b/acceptance/tests/base/host/user_test.rb
@@ -1,0 +1,18 @@
+test_name 'User Test' do
+  step "#user_get: has an Administrator user on Windows" do
+    hosts.select { |h| h['platform'] =~ /windows/ }.each do |host|
+      host.user_get('Administrator') do |result|
+        refute_match(result.stdout, 'NET HELPMSG', 'Output indicates Administrator not found')
+      end
+    end
+  end
+
+  step "#user_get: should not have CaptainCaveman user on Windows" do
+    hosts.select { |h| h['platform'] =~ /windows/ }.each do |host|
+      assert_raises Beaker::Host::CommandFailure do
+        host.user_get('CaptainCaveman') { |result| }
+      end
+    end
+  end
+
+end

--- a/lib/beaker/host/pswindows/group.rb
+++ b/lib/beaker/host/pswindows/group.rb
@@ -16,7 +16,7 @@ module PSWindows::Group
 
   def group_get(name, &block)
     execute("net localgroup \"#{name}\"") do |result|
-      fail_test "failed to get group #{name}" unless result.stdout =~ /^Alias name\s+#{name}/
+      fail_test "failed to get group #{name}" if result.exit_code != 0
 
       yield result if block_given?
     end

--- a/lib/beaker/host/pswindows/user.rb
+++ b/lib/beaker/host/pswindows/user.rb
@@ -16,7 +16,7 @@ module PSWindows::User
 
   def user_get(name, &block)
     execute("net user \"#{name}\"") do |result|
-      fail_test "failed to get user #{name}" unless result.stdout =~ /^User name\s+#{name}/
+      fail_test "failed to get user #{name}" if result.exit_code != 0
 
       yield result if block_given?
     end

--- a/lib/beaker/host/windows/group.rb
+++ b/lib/beaker/host/windows/group.rb
@@ -16,7 +16,7 @@ module Windows::Group
 
   def group_get(name, &block)
     execute("net localgroup \"#{name}\"") do |result|
-      fail_test "failed to get group #{name}" unless result.stdout =~ /^Alias name\s+#{name}/
+      fail_test "failed to get group #{name}" if result.exit_code != 0
 
       yield result if block_given?
     end

--- a/lib/beaker/host/windows/user.rb
+++ b/lib/beaker/host/windows/user.rb
@@ -16,7 +16,7 @@ module Windows::User
 
   def user_get(name, &block)
     execute("net user \"#{name}\"") do |result|
-      fail_test "failed to get user #{name}" unless result.stdout =~ /^User name\s+#{name}/
+      fail_test "failed to get user #{name}" if result.exit_code != 0
 
       yield result if block_given?
     end


### PR DESCRIPTION
 - The existing mechanism is tightly coupled to English / ASCII output
   and should instead use exit codes.

   Fix both the PowerShell and CMD hosts.

   Add a new acceptance test so that this can be validated on a
   non-English Windows host (for instance Japanse Windows 2012R2
   template win-2012r2-ja-x86_64)