### PR TITLE
(BKR-1018) copy_ssh_to_root not working on windows

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -329,7 +329,7 @@ module Beaker
           host.exec(Command.new('cp -r .ssh /cygdrive/c/Users/Administrator/.'))
           host.exec(Command.new('chown -R Administrator /cygdrive/c/Users/Administrator/.ssh'))
         elsif host['platform'] =~ /windows/ and not host.is_cygwin?
-          host.exec(Command.new("if exist .ssh (xcopy .ssh C:\\Users\\Administrator\\.ssh /s /e)"))
+          host.exec(Command.new("if exist .ssh (xcopy .ssh C:\\Users\\Administrator\\.ssh /s /e /y /i)"))
         elsif host['platform'] =~ /osx/
           host.exec(Command.new('sudo cp -r .ssh /var/root/.'), {:pty => true})
         elsif host['platform'] =~ /freebsd/

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -329,6 +329,15 @@ module Beaker
           host.exec(Command.new('cp -r .ssh /cygdrive/c/Users/Administrator/.'))
           host.exec(Command.new('chown -R Administrator /cygdrive/c/Users/Administrator/.ssh'))
         elsif host['platform'] =~ /windows/ and not host.is_cygwin?
+          # from https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/xcopy.mspx?mfr=true:
+          #    /i : If Source is a directory or contains wildcards and Destination
+          #      does not exist, xcopy assumes destination specifies a directory
+          #      name and creates a new directory. Then, xcopy copies all specified
+          #      files into the new directory. By default, xcopy prompts you to
+          #      specify whether Destination is a file or a directory.
+          #
+          #    /y : Suppresses prompting to confirm that you want to overwrite an
+          #      existing destination file.
           host.exec(Command.new("if exist .ssh (xcopy .ssh C:\\Users\\Administrator\\.ssh /s /e /y /i)"))
         elsif host['platform'] =~ /osx/
           host.exec(Command.new('sudo cp -r .ssh /var/root/.'), {:pty => true})

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -451,6 +451,18 @@ describe Beaker do
 
   end
 
+  context "copy_ssh_to_root" do
+    subject { dummy_class.new }
+
+    it "can copy ssh to root in windows hosts with no cygwin" do
+      host = make_host( 'testhost', { :platform => 'windows', :is_cygwin => false })
+      expect( Beaker::Command ).to receive( :new ).with( "if exist .ssh (xcopy .ssh C:\\Users\\Administrator\\.ssh /s /e /y /i)" ).once
+
+      subject.copy_ssh_to_root(host, options)
+    end
+
+  end
+
   context "package_proxy" do
 
     subject { dummy_class.new }


### PR DESCRIPTION
https://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/xcopy.mspx?mfr=true

> /i : If Source is a directory or contains wildcards and Destination does not exist, xcopy assumes destination specifies a directory name and creates a new directory. Then, xcopy copies all specified files into the new directory. By default, xcopy prompts you to specify whether Destination is a file or a directory.
> 
> /y : Suppresses prompting to confirm that you want to overwrite an existing destination file.