### PR TITLE
Fix for enable_root_login on OSX 10.11 & 10.12

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -409,10 +409,14 @@ module Beaker
     def enable_root_login host, opts
       logger = opts[:logger]
       block_on host do |host|
-        logger.debug "Update /etc/ssh/sshd_config to allow root login"
+        logger.debug "Update sshd_config to allow root login"
         if host['platform'] =~ /osx/
-          host.exec(Command.new("sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /etc/sshd_config"))
-          host.exec(Command.new("sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' /etc/sshd_config"))
+          # If osx > 10.10 use '/private/etc/ssh/sshd_config', else use '/etc/sshd_config'
+          ssh_config_file = '/private/etc/ssh/sshd_config'
+          ssh_config_file = '/etc/sshd_config' if host['platform'] =~ /^osx-10\.(9|10)/i
+
+          host.exec(Command.new("sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' #{ssh_config_file}"))
+          host.exec(Command.new("sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' #{ssh_config_file}"))
         elsif host['platform'] =~ /freebsd/
           host.exec(Command.new("sudo sed -i -e 's/#PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config"), {:pty => true} )
         elsif host['platform'] =~ /openbsd/

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -51,9 +51,19 @@ describe Beaker do
     "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""
   ], true
 
-  it_should_behave_like 'enables_root_login', 'osx', [
+  it_should_behave_like 'enables_root_login', 'osx-10.10', [
     "sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' /etc/sshd_config",
     "sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /etc/sshd_config"
+  ]
+
+  it_should_behave_like 'enables_root_login', 'osx-10.11', [
+    "sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' /private/etc/ssh/sshd_config",
+    "sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /private/etc/ssh/sshd_config"
+  ]
+
+  it_should_behave_like 'enables_root_login', 'osx-10.12', [
+      "sudo sed -i '' 's/#PermitRootLogin yes/PermitRootLogin Yes/g' /private/etc/ssh/sshd_config",
+      "sudo sed -i '' 's/#PermitRootLogin no/PermitRootLogin Yes/g' /private/etc/ssh/sshd_config"
   ]
 
   # Solaris
@@ -538,8 +548,16 @@ describe Beaker do
   context "set_env" do
     subject { dummy_class.new }
 
-    it "permits user environments on an OS X host" do
-      test_host_ssh_permit_user_environment('osx')
+    it "permits user environments on an OS X 10.10 host" do
+      test_host_ssh_permit_user_environment('osx-10.10')
+    end
+
+    it "permits user environments on an OS X 10.11 host" do
+      test_host_ssh_permit_user_environment('osx-10.11')
+    end
+
+    it "permits user environments on an OS X 10.12 host" do
+      test_host_ssh_permit_user_environment('osx-10.12')
     end
 
     it "permits user environments on an ssh-based linux host" do
@@ -571,8 +589,16 @@ describe Beaker do
     end
 
 
-    it "sets user ssh environment on an OS X host" do
-      test_host_ssh_set_user_environment('osx')
+    it "sets user ssh environment on an OS X 10.10 host" do
+      test_host_ssh_set_user_environment('osx-10.10')
+    end
+
+    it "sets user ssh environment on an OS X 10.11 host" do
+      test_host_ssh_set_user_environment('osx-10.11')
+    end
+
+    it "sets user ssh environment on an OS X 10.12 host" do
+      test_host_ssh_set_user_environment('osx-10.12')
     end
 
     it "sets user ssh environment on an ssh-based linux host" do


### PR DESCRIPTION
This fixes enable_root_login for osx 10.11 and 10.12 where the wrong ssh config file was being used.