### PR TITLE
(MAINT): Use mac address format for randmac that libvirt understands.

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -7,6 +7,11 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
   class << self
     attr_reader :memory
   end
+  
+  def randmac
+    "08:00:27:" + (1..3).map{"%0.2X"%rand(256)}.join(":")
+  end
+
 
   def provision(provider = 'libvirt')
     super


### PR DESCRIPTION
This patch fixes the randmac method of the vagrant libvirt provider
to generate mac addresses that are in a format libvirt understands.

So instead of 080027aabbcc it will generate 08:00:27:aa:bb:cc