### PR TITLE
(BKR-1028) Pin yard to below 0.9.6

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.10'
 
   # Documentation dependencies
-  s.add_development_dependency 'yard'
+  s.add_development_dependency 'yard', '< 0.9.6'
 
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
The documentation generation is generating warnings with the definition
for #run_block_on not working. Pinning for now until we find a better
solution.