### PR TITLE
(BKR-917) libvirt requires a correctly formatted mac

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -8,6 +8,13 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     attr_reader :memory
   end
 
+  # Return a random mac address with colons
+  #
+  # @return [String] a random mac address
+  def randmac
+    "08:00:27:" + (1..3).map{"%0.2X"%rand(256)}.join(':')
+  end
+
   def provision(provider = 'libvirt')
     super
   end

--- a/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_libvirt_spec.rb
@@ -29,7 +29,6 @@ describe Beaker::VagrantLibvirt do
     before(:each) do
       FakeFS.activate!
       path = vagrant.instance_variable_get( :@vagrant_path )
-      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
 
       vagrant.make_vfile( @hosts, options )
       @vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
@@ -52,6 +51,11 @@ describe Beaker::VagrantLibvirt do
     it "can specify any libvirt option" do
       expect( @vagrantfile.split("\n").map(&:strip) )
         .to include("node.uri = 'qemu+ssh://root@host/system'")
+    end
+
+    it "has a mac address in the proper format" do
+      expect( @vagrantfile.split("\n").map(&:strip) )
+        .to include(/:mac => "08:00:27:\h{2}:\h{2}:\h{2}"/)
     end
   end
 end


### PR DESCRIPTION
The libvirt provider expects a mac address with colons. This change
updates the libvirt class to generate a random mac address with colons
so libvirt can configure the network correctly.