### PR TITLE
(BKR-230) Update inifile gem dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -37,11 +37,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '3.3.0.beta1'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
-  s.add_runtime_dependency 'inifile', '~> 2.0'
-  ## inifile: keep <3.0, breaks puppet_helpers.rb:puppet_conf_for when updated
-  ## will need to fix that to upgrade this gem
-  ## indicating test from puppet acceptance:
-  ##   tests/security/cve-2013-1652_improper_query_params.rb
+  s.add_runtime_dependency 'inifile', '~> 3.0'
 
   s.add_runtime_dependency 'rsync', '~> 1.0.9'
   s.add_runtime_dependency 'open_uri_redirections', '~> 0.2.1'

--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -322,7 +322,7 @@ module Beaker
         # @!visibility private
         def puppet_conf_for host, conf_opts
           puppetconf = host.exec( Command.new( "cat #{host.puppet('master')['config']}" ) ).stdout
-          new_conf   = IniFile.new( puppetconf ).merge( conf_opts )
+          new_conf   = IniFile.new(content: puppetconf).merge( conf_opts )
 
           new_conf
         end

--- a/lib/beaker/dsl/helpers/tk_helpers.rb
+++ b/lib/beaker/dsl/helpers/tk_helpers.rb
@@ -75,7 +75,7 @@ module Beaker
             end
 
             begin
-              return IniFile.new(string)
+              return IniFile.new(content: string)
             rescue IniFile::Error
               nil
             end


### PR DESCRIPTION
This fixes calls to the IniFile constructor to reflect the changed api in inifile 3.0.0 and bumps the dependency in beaker.gemspec.