### PR TITLE
(BKR-1035) Environment variable keys always get upper-cased

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -246,7 +246,7 @@ module Unix::Exec
       else
         val = val.to_s
       end
-      env_array << "#{key.to_s.upcase}=\"#{val}\""
+      env_array << "#{key.to_s}=\"#{val}\""
     end
     env_array
   end

--- a/spec/beaker/host/cisco_spec.rb
+++ b/spec/beaker/host/cisco_spec.rb
@@ -107,8 +107,8 @@ module Cisco
 
         it 'turns env maps into paired strings correctly' do
           @options = { :user => 'root' }
-          env_map = { 'var1' => 'ans1', 'var2' => 'ans2' }
-          answer_correct = 'source /etc/profile; export VAR1="ans1" VAR2="ans2";'
+          env_map = { 'var1' => 'ans1', 'VAR2' => 'ans2' }
+          answer_correct = 'source /etc/profile; export var1="ans1" VAR2="ans2";'
           answer_test = host.environment_string( env_map )
           expect( answer_test ).to be === answer_correct
         end
@@ -141,8 +141,8 @@ module Cisco
 
         it 'turns env maps into paired strings correctly' do
           @options = { :user => 'root' }
-          env_map = { 'var1' => 'ans1', 'var2' => 'ans2' }
-          answer_correct = 'source /etc/profile; env VAR1="ans1" VAR2="ans2"'
+          env_map = { 'VAR1' => 'ans1', 'var2' => 'ans2' }
+          answer_correct = 'source /etc/profile; env VAR1="ans1" var2="ans2"'
           answer_test = host.environment_string( env_map )
           expect( answer_test ).to be === answer_correct
         end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -60,8 +60,8 @@ module Beaker
       end
 
       it 'takes an env hash with var_name/value pairs' do
-        expect( instance.environment_string( {:HOME => '/'} ) ).
-          to be == "env HOME=\"/\""
+        expect( instance.environment_string( {:HOME => '/', :http_proxy => 'http://foo'} ) ).
+          to be == 'env HOME="/" http_proxy="http://foo"'
       end
 
       it 'takes an env hash with var_name/value[Array] pairs' do


### PR DESCRIPTION
This commit fixes an issue where the `environment_string` method of a
host unconditionally upper-cased the keys of the environment variables
of a command