### PR TITLE
(BKR-940) update base test configuration

### DIFF
--- a/acceptance/fixtures/files/sles-11-x86_64.repo
+++ b/acceptance/fixtures/files/sles-11-x86_64.repo
@@ -1,5 +1,0 @@
-[PE-3.8-sles-11-x86_64]
-name=PE-3.8-sles-11-x86_64
-baseurl=http://enterprise.delivery.puppetlabs.net/3.8/repos/sles-11-x86_64
-enabled=1
-gpgcheck=0

--- a/acceptance/fixtures/files/sles-11-x86_64.repo.txt
+++ b/acceptance/fixtures/files/sles-11-x86_64.repo.txt
@@ -1,0 +1,5 @@
+[PE-2016.4-sles-11-x86_64]
+name=PE-2016.4-sles-11-x86_64
+baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-11-x86_64
+enabled=1
+gpgcheck=0

--- a/acceptance/fixtures/files/sles-12-x86_64.repo.txt
+++ b/acceptance/fixtures/files/sles-12-x86_64.repo.txt
@@ -1,0 +1,5 @@
+[PE-2016.4-sles-12-x86_64]
+name=PE-2016.4-sles-12-x86_64
+baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-12-x86_64
+enabled=1
+gpgcheck=0

--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-xenial.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-xenial.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/xenial xenial PC1

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-24-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-fedora-24-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/fedora/f24/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-sles-12-x86_64.repo
+++ b/acceptance/fixtures/package/rpm/pl-puppetserver-latest-repos-pe-sles-12-x86_64.repo
@@ -1,0 +1,6 @@
+[pl-puppetserver-latest]
+name=PL Repo for puppetserver at commit latest
+baseurl=http://nightlies.puppetlabs.com/puppetserver-latest/repos/sles/12/PC1/x86_64/
+enabled=1
+gpgcheck=1
+gpgkey=http://nightlies.puppetlabs.com/07BB6C57

--- a/acceptance/tests/base/dsl/helpers/host_helpers/deploy_package_repo_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/deploy_package_repo_test.rb
@@ -106,15 +106,15 @@ test_name "dsl::helpers::host_helpers #deploy_package_repo" do
         platform = default['platform']
 
         FileUtils.mkdir(File.join(local_dir, "rpm"))
-        local_filename, contents = create_local_file_from_fixture("sles-11-x86_64.repo", File.join(local_dir, "rpm"), "pl-#{name}-#{version}-repos-pe-#{platform}.repo")
+        local_filename, contents = create_local_file_from_fixture("#{default["platform"]}.repo", File.join(local_dir, "rpm"), "pl-#{name}-#{version}-repos-pe-#{platform}.repo")
 
         deploy_package_repo default, local_dir, name, version
 
         result = on default, "zypper repos -d"
-        assert_match "PE-3.8-sles-11-x86_64", result.stdout
+        assert_match "PE-2016.4-#{default['platform']}", result.stdout
 
         # teardown
-        on default, "zypper rr PE-3.8-sles-11-x86_64"
+        on default, "zypper rr #{default['platform']}"
       end
     end
   end

--- a/acceptance/tests/base/host/packages.rb
+++ b/acceptance/tests/base/host/packages.rb
@@ -51,6 +51,7 @@ hosts.each do |host|
   # a lot of dependencies.
   package = 'zsh'
   package = 'CSWzsh' if host['platform'] =~ /solaris-10/
+  package = 'git' if host['platform'] =~ /sles/
 
   if host['platform'] =~ /solaris-11/
     logger.debug("#{package} should be uninstalled on #{host}")

--- a/acceptance/tests/base/host/packages_unix.rb
+++ b/acceptance/tests/base/host/packages_unix.rb
@@ -56,7 +56,7 @@ end
 
 step '#deploy_package_repo : deploy puppet-server nightly repo'
 hosts.each do |host|
-  next if host['platform'] =~ /fedora/
+  next if host['platform'].variant == 'sles' && Integer(host['platform'].version) < 12
   host.deploy_package_repo(pkg_fixtures, pkg_name, 'latest')
   clean_file(host, pkg_name)
 end


### PR DESCRIPTION
These changes update the base acceptance tests to match our currently
supported systems. Notably, it adds back in SLES testing, adds xenial
support for package testing, and adds fedora back into the mix as well.