### PR TITLE
(BKR-995) Update requirement for net-ssh

### DIFF
--- a/acceptance/tests/base/host/host_test.rb
+++ b/acceptance/tests/base/host/host_test.rb
@@ -316,3 +316,17 @@ step "Ensure scp errors close the ssh connection" do
     on default, 'true'
   end
 end
+
+step 'Ensure that a long 128+ character string with UTF-8 characters does not break net-ssh' do
+  long_string = 'a' * 128 + "\u06FF"
+  on(default, "mkdir /tmp/#{long_string}")
+  result = on(default, 'ls /tmp')
+  assert(result.stdout.include?(long_string), 'Error in folder creation with long string + UTF-8 characters')
+
+  # remove the folder
+  on(default, "rm -rf /tmp/#{long_string}")
+  result = on(default, 'ls /tmp')
+  assert(!result.stdout.include?(long_string), 'Error in folder deletion with long string + UTF-8 characters')
+
+end
+

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'minitar', '~> 0.5.4'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
-  s.add_runtime_dependency 'net-ssh', '3.3.0.beta1'
+  s.add_runtime_dependency 'net-ssh', '~> 4.0'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 2.0'
   ## inifile: keep <3.0, breaks puppet_helpers.rb:puppet_conf_for when updated


### PR DESCRIPTION
Previous to this commit, we pinned net-ssh for fixes related to
UTF-8. This had the unfortunate side effect of breaking "gem install
beaker", as a Gem::DependencyError prevented installation because Gem
couldn't tell that version "3.3.0.beta1" met the dependency for "=>
2.6.5" for net-scp.. Now that version 4.0 has been released, we should
 move the pin to that version so that `gem install beaker` can happen
successfully from rubygems.