### PR TITLE
(BKR-1046) Use pdb status for started validation

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -676,7 +676,10 @@ module Beaker
         def sleep_until_puppetdb_started(host, nonssl_port = nil, ssl_port = nil)
           nonssl_port = options[:puppetdb_port_nonssl] if nonssl_port.nil?
           ssl_port = options[:puppetdb_port_ssl] if ssl_port.nil?
-          curl_with_retries("start puppetdb", host, "http://localhost:#{nonssl_port}", 0, 120)
+          endpoint = 'status/v1/services/puppetdb-status'
+          retry_on(host,
+                   "curl -m 1 http://localhost:#{nonssl_port}/#{endpoint} | grep '\"state\":\"running\"'",
+                   {:max_retries => 120})
           curl_with_retries("start puppetdb (ssl)",
                             host, "https://#{host.node_name}:#{ssl_port}", [35, 60])
         end

--- a/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/puppet_helpers_spec.rb
@@ -1096,14 +1096,14 @@ describe ClassMixedWithDSLHelpers do
 
     it 'uses the default ports if none given' do
       host = hosts[0]
-      expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8080/, anything(), anything() ).once.ordered
+      expect( subject ).to receive( :retry_on ).with( anything(), /8080/, anything() ).once.ordered
       expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8081/, anything() ).once.ordered
       subject.sleep_until_puppetdb_started( host )
     end
 
     it 'allows setting the nonssl_port' do
       host = hosts[0]
-      expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8084/, anything(), anything() ).once.ordered
+      expect( subject ).to receive( :retry_on ).with( anything(), /8084/, anything() ).once.ordered
       expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8081/, anything() ).once.ordered
       subject.sleep_until_puppetdb_started( host, 8084 )
 
@@ -1111,7 +1111,7 @@ describe ClassMixedWithDSLHelpers do
 
     it 'allows setting the ssl_port' do
       host = hosts[0]
-      expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8080/, anything(), anything() ).once.ordered
+      expect( subject ).to receive( :retry_on ).with( anything(), /8080/, anything() ).once.ordered
       expect( subject ).to receive( :curl_with_retries ).with( anything(), anything(), /8085/, anything() ).once.ordered
       subject.sleep_until_puppetdb_started( host, nil, 8085 )
     end


### PR DESCRIPTION
This commit changes the implementation of the
`sleep_until_puppetdb_started` helper method to query the PuppetDB
status endpoint to verify that the PDB web services are available.