### PR TITLE
(BKR-937) Add support for installing AIX 7 agent on 7.2

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -1143,7 +1143,12 @@ module Beaker
             when /^(sles|aix|el)$/
               # NOTE: AIX does not support repo management. This block assumes
               # that the desired rpm has been mirrored to the 'repos' location.
-              on host, "rpm -ivh #{onhost_copied_file}"
+              # NOTE: the AIX 7.1 package will only install on 7.2 with
+              # --ignoreos. This is a bug in package building on AIX 7.1's RPM
+              if variant == "aix" and version == "7.2"
+                aix_72_ignoreos_hack = "--ignoreos"
+              end
+              on host, "rpm -ivh #{aix_72_ignoreos_hack} #{onhost_copied_file}"
             when /^windows$/
               result = on host, "echo #{onhost_copied_file}"
               onhost_copied_file = result.raw_output.chomp

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -403,6 +403,7 @@ module Unix::Pkg
     when /^(sles|aix|el|centos|oracle|redhat|scientific)$/
       variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|scientific)/)
       arch = 'ppc' if variant == 'aix' && arch == 'power'
+      version = '7.1' if variant == 'aix' && version == '7.2'
       release_path_end = "#{variant}/#{version}/#{puppet_collection}/#{arch}"
       release_file = "puppet-agent-#{puppet_agent_version}-1.#{variant}#{version}.#{arch}.rpm"
     else


### PR DESCRIPTION
To avoid unnecessarily expanding our build times, our initial support
for AIX 7.2 is through the existing 7.1 package. This will be replaced
with a single unified AIX build in the Agent 2.0 timeframe, but for now
we need to add a little bit of special-case logic to handle 7.2 with
existing packages.