### PR TITLE
Updating require to align with oldest supported PE version which shipped with 2.1.8

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.2.5')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.1.8')
 
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Updating require to align with oldest supported PE version which shipped with 2.1.8 https://puppet.com/misc/puppet-enterprise-lifecycle