### PR TITLE
(BKR-1047) Don't change module paths for the DSL

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -51,7 +51,6 @@ Gem::Specification.new do |s|
   # Run time dependencies that are Beaker libraries
   s.add_runtime_dependency 'stringify-hash', '~> 0.0'
   s.add_runtime_dependency 'beaker-hiera', '~> 0.0'
-  s.add_runtime_dependency 'beaker-facter', '~> 0.0'
   s.add_runtime_dependency 'beaker-hostgenerator'
 
   # Optional provisioner specific support

--- a/lib/beaker/dsl/helpers.rb
+++ b/lib/beaker/dsl/helpers.rb
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-[ 'host', 'puppet', 'test', 'tk', 'web', 'hocon' ].each do |lib|
+[ 'facter', 'host', 'puppet', 'test', 'tk', 'web', 'hocon' ].each do |lib|
       require "beaker/dsl/helpers/#{lib}_helpers"
 end
 
-require 'beaker-hiera'
-require 'beaker-facter'
+require "beaker-hiera"
 module Beaker
   module DSL
 
@@ -24,6 +23,7 @@ module Beaker
     #
     #
     module Helpers
+      include Beaker::DSL::Helpers::FacterHelpers
       include Beaker::DSL::Helpers::HostHelpers
       include Beaker::DSL::Helpers::PuppetHelpers
       include Beaker::DSL::Helpers::TestHelpers
@@ -31,7 +31,6 @@ module Beaker
       include Beaker::DSL::Helpers::WebHelpers
       include Beaker::DSL::Helpers::HoconHelpers
       include Beaker::DSL::Helpers::Hiera
-      include Beaker::DSL::Helpers::Facter
     end
   end
 end

--- a/lib/beaker/dsl/helpers/facter_helpers.rb
+++ b/lib/beaker/dsl/helpers/facter_helpers.rb
@@ -1,0 +1,57 @@
+module Beaker
+  module DSL
+    module Helpers
+      # Methods that help you interact with your facter installation, facter must be installed
+      # for these methods to execute correctly
+      #
+      module FacterHelpers
+
+        # @!macro [new] common_opts
+        #   @param [Hash{Symbol=>String}] opts Options to alter execution.
+        #   @option opts [Boolean] :silent (false) Do not produce log output
+        #   @option opts [Array<Fixnum>] :acceptable_exit_codes ([0]) An array
+        #     (or range) of integer exit codes that should be considered
+        #     acceptable.  An error will be thrown if the exit code does not
+        #     match one of the values in this list.
+        #   @option opts [Boolean] :accept_all_exit_codes (false) Consider all 
+        #     exit codes as passing.
+        #   @option opts [Boolean] :dry_run (false) Do not actually execute any
+        #     commands on the SUT
+        #   @option opts [String] :stdin (nil) Input to be provided during command
+        #     execution on the SUT.
+        #   @option opts [Boolean] :pty (false) Execute this command in a pseudoterminal.
+        #   @option opts [Boolean] :expect_connection_failure (false) Expect this command
+        #     to result in a connection failure, reconnect and continue execution.
+        #   @option opts [Hash{String=>String}] :environment ({}) These will be
+        #     treated as extra environment variables that should be set before
+        #     running the command.
+        #
+
+        # Get a facter fact from a provided host
+        #
+        # @param [Host, Array<Host>, String, Symbol] host    One or more hosts to act upon,
+        #                            or a role (String or Symbol) that identifies one or more hosts.
+        # @param [String] name The name of the fact to query for
+        # @!macro common_opts
+        #
+        # @return String The value of the fact 'name' on the provided host
+        # @raise  [FailTest] Raises an exception if call to facter fails
+        def fact_on(host, name, opts = {})
+          result = on host, facter(name, opts)
+          if result.kind_of?(Array)
+            result.map { |res| res.stdout.chomp }
+          else
+            result.stdout.chomp
+          end
+        end
+
+        # Get a facter fact from the default host
+        # @see #fact_on
+        def fact(name, opts = {})
+          fact_on(default, name, opts)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/beaker/dsl/helpers/facter_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/facter_helpers_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+class ClassMixedWithDSLHelpers
+  include Beaker::DSL::Helpers
+  include Beaker::DSL::Wrappers
+  include Beaker::DSL::Roles
+  include Beaker::DSL::Patterns
+
+  def logger
+    RSpec::Mocks::Double.new('logger').as_null_object
+  end
+
+end
+
+describe ClassMixedWithDSLHelpers do
+  let( :command ){ 'ls' }
+  let( :host )   { double.as_null_object }
+  let( :result ) { Beaker::Result.new( host, command ) }
+
+  let( :master ) { make_host( 'master',   :roles => %w( master agent default)    ) }
+  let( :agent )  { make_host( 'agent',    :roles => %w( agent )           ) }
+  let( :custom ) { make_host( 'custom',   :roles => %w( custom agent )    ) }
+  let( :dash )   { make_host( 'console',  :roles => %w( dashboard agent ) ) }
+  let( :db )     { make_host( 'db',       :roles => %w( database agent )  ) }
+  let( :hosts )  { [ master, agent, dash, db, custom ] }
+
+
+  describe '#fact_on' do
+    it 'retrieves a fact on a single host' do
+      result.stdout = "family\n"
+      expect( subject ).to receive(:facter).with('osfamily',{}).once
+      expect( subject ).to receive(:on).and_return(result)
+
+      expect( subject.fact_on('host','osfamily') ).to be === result.stdout.chomp
+    end
+
+    it 'retrieves an array of facts from multiple hosts' do
+      allow( subject ).to receive( :hosts ).and_return( hosts )
+      times = hosts.length
+      result.stdout = "family\n"
+      hosts.each do |host|
+        expect( host ).to receive(:exec).and_return(result)
+      end
+
+      expect( subject.fact_on(hosts,'osfamily') ).to be === [result.stdout.chomp] * hosts.length
+
+    end
+  end
+
+  describe '#fact' do
+    it 'delegates to #fact_on with the default host' do
+      allow( subject ).to receive(:hosts).and_return(hosts)
+      expect( subject ).to receive(:fact_on).with(master,"osfamily",{}).once
+
+      subject.fact('osfamily')
+    end
+  end
+
+end


### PR DESCRIPTION
This reverts commit 4d0e29fe1c7dc842c171f89f2acf6c74cba4ed42, reversing
changes made to 59cfccedf25a4cdce6296fe010ee22bba07e5855.

In our documentation, we make references to only utilizing elements of
the the DSL directly, instead of using them as a lump sum in TestCase.
During a major version, these paths should never change.