### PR TITLE
(BKR-1049) Updating require to align with oldest supported PE version

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.2.5')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.1.8')
 
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
PE and puppet-agent currently shipped with 2.1.9
Oldest supported PE release ships with 2.1.8
https://puppet.com/misc/puppet-enterprise-lifecycle
This is to keep beaker aligned with oldest supported PE release and
current puppet-agent vendored ruby.