### PR TITLE
(BKR-1051) Add retry loop for aws key check

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -811,7 +811,18 @@ module Beaker
       ssh_string = public_key()
       region.key_pairs.import(pair_name, ssh_string)
       kp = region.key_pairs[pair_name]
-      if kp.exists?
+
+      exists = false
+      for tries in 1..10
+        if kp.exists?
+          exists = true
+          break
+        end
+        @logger.debug("AWS key pair doesn't appear to exist yet, sleeping before retry ")
+        backoff_sleep(tries)
+      end
+
+      if exists
         @logger.debug("aws-sdk: key pair #{pair_name} imported")
         kp
       else

--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -813,7 +813,7 @@ module Beaker
       kp = region.key_pairs[pair_name]
 
       exists = false
-      for tries in 1..10
+      for tries in 1..5
         if kp.exists?
           exists = true
           break

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -844,8 +844,8 @@ module Beaker
       end
 
       it 'raises an exception if subsequent keypair check is false' do
-        expect(pair).to receive(:exists?).and_return(false).exactly(10).times
-        expect(aws).to receive(:backoff_sleep).exactly(10).times
+        expect(pair).to receive(:exists?).and_return(false).exactly(5).times
+        expect(aws).to receive(:backoff_sleep).exactly(5).times
         expect { aws.create_new_key_pair(region, pair_name) }.
           to raise_error(RuntimeError,
             "AWS key pair #{pair_name} can not be queried, even after import")

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -839,12 +839,13 @@ module Beaker
       end
 
       it 'imports the key given from public_key' do
-        expect(pair).to receive(:exists?).and_return (true)
+        expect(pair).to receive(:exists?).and_return(true)
         aws.create_new_key_pair(region, pair_name)
       end
 
       it 'raises an exception if subsequent keypair check is false' do
-        expect(pair).to receive(:exists?).and_return (false)
+        expect(pair).to receive(:exists?).and_return(false).exactly(10).times
+        expect(aws).to receive(:backoff_sleep).exactly(10).times
         expect { aws.create_new_key_pair(region, pair_name) }.
           to raise_error(RuntimeError,
             "AWS key pair #{pair_name} can not be queried, even after import")


### PR DESCRIPTION
The kb.exists? check fails intermittently; it one of the failures, manual
inspection shows that the key pair was in fact created. This heavily implies
that there's a race at work; where the key pair doesn't show as existing until
some time after the initial creation.

Add a retry loop around the kb.exists? check to attempt to work around this
issue.