### PR TITLE
(BKR-966) Add acceptance tests fo subcommands

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -177,6 +177,14 @@ Run the base beaker acceptance tests
   end
 
   desc <<-EOS
+Run the subcommand beaker acceptance tests
+#{USAGE}
+  EOS
+  task :subcommands => 'gen_hosts' do
+    beaker_test(:subcommands)
+  end
+
+  desc <<-EOS
 Run the hypervisor beaker acceptance tests
 #{USAGE}
   EOS

--- a/acceptance/config/subcommands/acceptance-options.rb
+++ b/acceptance/config/subcommands/acceptance-options.rb
@@ -1,0 +1,4 @@
+{
+    :pre_suite => 'acceptance/pre_suite/subcommands/',
+    :tests => 'acceptance/tests/subcommands/'
+}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/pre_suite/README.md
+++ b/acceptance/pre_suite/README.md
@@ -5,3 +5,4 @@ Collection of pre-suites for SUT configuration before test execution.
 Options:
 * install PE
 * install FOSS Puppet
+* install beaker itself on a SUT

--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -1,0 +1,32 @@
+test_name 'Install and configure Ruby 2.2.5 on the SUT' do
+
+  step 'Ensure that the default system is an el-based system' do
+    # The pre-suite currently only supports el systems, and we should
+    #fail early if the default platform is not a supported platform
+    assert(default.platform.variant == 'el',
+           "Expected the platform variant to be 'el', not #{default.platform.variant}")
+  end
+
+  step 'clean out current ruby and its dependencies' do
+    on default, 'yum remove ruby ruby-devel -y'
+  end
+
+  # These steps install git, openssl, and wget
+  step 'install development dependencies' do
+    on default, 'yum groupinstall "Development Tools" -y'
+    on default, 'yum install openssl-devel -y'
+    on default, 'yum install wget -y'
+  end
+
+  step 'download and install ruby 2.2.5' do
+    on default, 'wget http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz'
+    on default, 'tar xvfz ruby-2.2.5.tar.gz'
+    on default, 'cd ruby-2.2.5;./configure'
+    on default, 'cd ruby-2.2.5;make'
+    on default, 'cd ruby-2.2.5;make install'
+  end
+
+  step 'update gem on the SUT and install bundler' do
+    on default, 'gem update --system;gem install bundler'
+  end
+end

--- a/acceptance/pre_suite/subcommands/08_install_beaker.rb
+++ b/acceptance/pre_suite/subcommands/08_install_beaker.rb
@@ -1,0 +1,22 @@
+test_name 'Install beaker and checkout branch if necessary' do
+
+  step 'Download the beaker git repo' do
+   on default, 'git clone https://github.com/puppetlabs/beaker.git /opt/beaker/'
+  end
+
+  step 'Detect if checking out branch for testing and checkout' do
+    if ENV['BEAKER_PULL_ID']
+      logger.notify "Pull Request detected, checking out PR branch"
+      on(default, 'cd /opt/beaker/;git -c core.askpass=true fetch --tags --progress https://github.com/puppetlabs/beaker.git +refs/pull/*:refs/remotes/origin/pr/*')
+      on(default, "cd /opt/beaker/;git merge origin/pr/#{ENV['BEAKER_PULL_ID']}/head --no-edit")
+    else
+      logger.notify 'No PR branch detected, building from master'
+    end
+  end
+
+  step 'Build the gem and install it on the local system' do
+    build_output = on(default, 'cd /opt/beaker/;gem build beaker.gemspec').stdout
+    version = build_output.match(/^  File: (.+)$/)[1]
+    on(default, "cd /opt/beaker/;gem install #{version} --no-rdoc --no-ri")
+  end
+end

--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -1,0 +1,47 @@
+test_name 'use the init subcommand' do
+
+  def delete_root_folder_contents
+    on default, 'rm -rf /root/*'
+  end
+
+  step 'ensure that `beaker init` fails correctly when not provided a hypervisor' do
+    expect_failure('it should return a non-zero code when it fails') do
+      result = on(default, 'beaker init', :accept_all_exit_codes => true)
+      refute_equal(0, result.exit_code, '`beaker init` without a hypervisor argument should return a non-zero exit code')
+    end
+  end
+
+  step 'ensure that `beaker help init` works' do
+    result = on(default, 'beaker help init')
+    assert_equal(0, result.exit_code, '`beaker help init` should return a zero exit code')
+  end
+
+  step 'ensure that `beaker init` accepts both vmpooler and vagrant hypervisor arguments' do
+
+    ['vmpooler', 'vagrant'].each do |hypervisor|
+      result = on(default, "beaker init --hypervisor=#{hypervisor}")
+      assert_match(/Writing default host config/, result.stdout)
+      assert_equal(0, result.exit_code, "`beaker init --hypervisor=#{hypervisor}` should return a zero exit code")
+      step 'ensure that the Rakefile is present' do
+        on(default, '[ -e "Rakefile" ]')
+      end
+    delete_root_folder_contents
+    end
+  end
+
+
+  step 'ensure that a Rakefile is not overwritten if it does exist prior' do
+    delete_root_folder_contents
+    on(default, "beaker init --hypervisor=vmpooler")
+    prepended_rakefile = on(default, 'cat Rakefile').stdout
+    delete_root_folder_contents
+    on(default, 'echo "require \'tempfile\'" >> Rakefile')
+    on(default, 'beaker init --hypervisor=vmpooler', :accept_all_exit_codes => true)
+    rakefile = on(default, 'cat Rakefile')
+
+    # Assert that the Rakefile contents includes the original and inserted requirements
+    assert(result.stdout.include?(prepended_rakefile), 'Rakefile should not contain prepended require')
+    assert(result.stdout.include?("require 'tempfile'"), 'Rakefile should not contain prepended require')
+  end
+end
+


### PR DESCRIPTION
This PR adds in acceptance testing for beaker subcommands, using beaker
to install ruby and configure beaker on a SUT. The tests can be run
using rake with `rake test:subcommands` defined in the Rakefile at the
root of the repo.

The testing jenkins jobs that will run this rake task is [here](https://jenkins-beaker.delivery.puppetlabs.net/job/qe_beaker_intn-sys_beaker-acceptance-subcommands-vpool/). #1323 is required for merge before testing will pass for this build, as `gem install beaker` needs to function for this pre-suite to work.