### PR TITLE
(BKR-931) Ensure that :type = 'aio' works in EL

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -436,7 +436,11 @@ module Beaker
         # @api private
         def install_puppet_from_rpm_on( hosts, opts )
           block_on hosts do |host|
-            install_puppetlabs_release_repo(host)
+            if host[:type] == 'aio'
+              install_puppetlabs_release_repo(host,'pc1',opts)
+            else
+              install_puppetlabs_release_repo(host,nil,opts)
+            end
 
             if opts[:facter_version]
               host.install_package("facter-#{opts[:facter_version]}")

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -57,6 +57,17 @@ describe ClassMixedWithDSLInstallUtils do
                                                 :working_dir => '/tmp',
                                                 :type => 'foss',
                                                 :dist => 'puppet-enterprise-3.7.1-rc0-78-gffc958f-eos-4-i386' } ) }
+  let(:el6hostaio)    { make_host( 'el6hostaio', { :platform => Beaker::Platform.new('el-6-i386'),
+                                                 :pe_ver => '3.0',
+                                                 :working_dir => '/tmp',
+                                                :type => 'aio',
+                                                 :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-centos-6-i386' } ) }
+  let(:el6hostfoss)   { make_host( 'el6hostfoss', { :platform => Beaker::Platform.new('el-6-i386'),
+                                                 :pe_ver => '3.0',
+                                                 :working_dir => '/tmp',
+                                                :type => 'foss',
+                                                 :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-centos-6-i386' } ) }
+
   let(:win_temp)      { 'C:\\Windows\\Temp' }
 
 
@@ -254,6 +265,20 @@ describe ClassMixedWithDSLInstallUtils do
       version = subject.find_git_repo_versions( host, path, repository )
 
       expect( version ).to be == { 'name' => '2' }
+    end
+  end
+
+  context 'install_puppet_from_rpm_on' do
+    it 'installs PC1 release repo when AIO' do
+      expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostaio,'pc1',{})
+
+      subject.install_puppet_from_rpm_on( el6hostaio, {}  )
+    end
+
+    it 'installs non-PC1 package when not-AIO' do
+      expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostfoss,nil,{})
+
+      subject.install_puppet_from_rpm_on( el6hostfoss, {}  )
     end
   end
 


### PR DESCRIPTION
EL and Fedora systems were not installing the pc1 version of Puppet
when :type = aio. This ensures that the case is properly addressed.

BKR-931 #close

Rebase of @trevor-vaughan's work with unit tests.