### PR TITLE
(maint) stub out wait_for_host_in_dashboard

### DIFF
--- a/lib/beaker/dsl/helpers/puppet_helpers.rb
+++ b/lib/beaker/dsl/helpers/puppet_helpers.rb
@@ -759,13 +759,6 @@ module Beaker
         #wait for a given host to appear in the dashboard
         # @deprecated this method should be removed in the next release since we don't believe the check is necessary.
         def wait_for_host_in_dashboard(host)
-
-          hostname = host.node_name
-          hostcert = dashboard.puppet['hostcert']
-          key = dashboard.puppet['hostprivkey']
-          cacert = dashboard.puppet['localcacert']
-          retry_on(dashboard, "curl --cert #{hostcert} --key #{key} --cacert #{cacert}\
-                              https://#{dashboard}:4433/classifier-api/v1/nodes | grep '\"name\":\"#{hostname}\"'")
         end
 
         # Ensure the host has requested a cert, then sign it


### PR DESCRIPTION
wait_for_host_in_dashboard is no longer needed with PE and is causing
ihssues with attempts to turn off node-checkin by default in classifier.

This removes the check that validates a node is seen by the classifier.

It shouldn't be needed anyway as a puppet run has already been done by
the time this is run.