### PR TITLE
(BKR-1066) Quote PATH to allow for spaces

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -173,7 +173,7 @@ module Beaker
         elsif host['platform'] =~ /aix/
           host.exec(Command.new(ROOT_KEYS_SYNC_CMD_AIX % "env PATH=/usr/gnu/bin:$PATH bash"), :accept_all_exit_codes => true)
         else
-          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "env PATH=/usr/gnu/bin:$PATH bash"), :accept_all_exit_codes => true)
+          host.exec(Command.new(ROOT_KEYS_SYNC_CMD % "env PATH=\"/usr/gnu/bin:$PATH\" bash"), :accept_all_exit_codes => true)
         end
       end
     rescue => e

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -349,7 +349,7 @@ describe Beaker do
 
     it "can sync keys on a non-solaris host" do
 
-      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "env PATH=/usr/gnu/bin:$PATH bash" ).exactly( 3 ).times
+      expect( Beaker::Command ).to receive( :new ).with( sync_cmd % "env PATH=\"/usr/gnu/bin:$PATH\" bash" ).exactly( 3 ).times
 
       subject.sync_root_keys( hosts, options )
 


### PR DESCRIPTION
When using `$PATH`, quote it to accomodate spaces in file paths. This is
common on Windows systems, and causes the command to fail.