### PR TITLE
(BKR-1035) add old env var behavior

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -246,7 +246,15 @@ module Unix::Exec
       else
         val = val.to_s
       end
-      env_array << "#{key.to_s}=\"#{val}\""
+      # doing this for the key itself & the upcase'd version allows us to remain
+      # backwards compatible
+      # TODO: (Next Major Version) get rid of upcase'd version
+      key_str = key.to_s
+      keys = [key_str]
+      keys << key_str.upcase if key_str.upcase != key_str
+      keys.each do |env_key|
+        env_array << "#{env_key}=\"#{val}\""
+      end
     end
     env_array
   end

--- a/spec/beaker/host/cisco_spec.rb
+++ b/spec/beaker/host/cisco_spec.rb
@@ -108,7 +108,7 @@ module Cisco
         it 'turns env maps into paired strings correctly' do
           @options = { :user => 'root' }
           env_map = { 'var1' => 'ans1', 'VAR2' => 'ans2' }
-          answer_correct = 'source /etc/profile; export var1="ans1" VAR2="ans2";'
+          answer_correct = 'source /etc/profile; export var1="ans1" VAR1="ans1" VAR2="ans2";'
           answer_test = host.environment_string( env_map )
           expect( answer_test ).to be === answer_correct
         end
@@ -142,7 +142,7 @@ module Cisco
         it 'turns env maps into paired strings correctly' do
           @options = { :user => 'root' }
           env_map = { 'VAR1' => 'ans1', 'var2' => 'ans2' }
-          answer_correct = 'source /etc/profile; env VAR1="ans1" var2="ans2"'
+          answer_correct = 'source /etc/profile; env VAR1="ans1" var2="ans2" VAR2="ans2"'
           answer_test = host.environment_string( env_map )
           expect( answer_test ).to be === answer_correct
         end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -61,7 +61,7 @@ module Beaker
 
       it 'takes an env hash with var_name/value pairs' do
         expect( instance.environment_string( {:HOME => '/', :http_proxy => 'http://foo'} ) ).
-          to be == 'env HOME="/" http_proxy="http://foo"'
+          to be == 'env HOME="/" http_proxy="http://foo" HTTP_PROXY="http://foo"'
       end
 
       it 'takes an env hash with var_name/value[Array] pairs' do


### PR DESCRIPTION
Original implementation of BKR-1035 uses just
the capitalization given to set environment
variables. This change sets the given env var
as well as the capitalized version, so that
we're backward compatible until the next major
release

/cc @joshcooper, @puppetlabs/beaker 