### PR TITLE
(BKR-1004) beaker exec implementation

### DIFF
--- a/acceptance/tests/subcommands/exec.rb
+++ b/acceptance/tests/subcommands/exec.rb
@@ -1,0 +1,37 @@
+test_name 'use the exec subcommand' do
+
+  def delete_root_folder_contents
+    on default, 'rm -rf /root/* /root/.beaker'
+  end
+
+  step 'ensure the workspace is clean' do
+    delete_root_folder_contents
+  end
+
+  step 'run init and provision to set up the system' do
+    on default, 'beaker init --hosts centos6-64; beaker provision'
+    subcommand_state = on(default, 'cat .beaker/.subcommand_state.yaml').stdout
+    subcommand_state = YAML.parse(subcommand_state).to_ruby
+    assert_equal(true, subcommand_state['provisioned'])
+  end
+
+  step 'create a test dir and populate it with tests' do
+    on default, 'mkdir -p testing_dir'
+  end
+
+  step 'create remote test file' do
+    testfile = <<-TESTFILE
+    on(agents, 'echo hello world')
+    TESTFILE
+    create_remote_file(default, '/root/testing_dir/testfile1.rb', testfile)
+  end
+
+  step 'specify that remote file with beaker exec' do
+    result = on(default, 'beaker exec testing_dir/testfile1.rb --log-level verbose')
+    assert_match(/hello world/, result.stdout)
+  end
+end
+
+
+
+

--- a/bin/beaker
+++ b/bin/beaker
@@ -6,7 +6,7 @@ require 'beaker'
 if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(ARGV[0])
   Beaker::Subcommand.start(ARGV)
 else
-  Beaker::CLI.new.parse_options.execute!
+  Beaker::CLI.new.parse_options.provision.execute!
   puts "Beaker completed successfully, thanks."
 end
 

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -10,6 +10,8 @@ module Beaker
     |   |   | "
 
     attr_reader :options, :logger
+
+
     def initialize
       @timestamp = Time.now
       # Initialize a logger object prior to parsing; this should be overwritten whence
@@ -81,6 +83,17 @@ module Beaker
       rescue => e
         report_and_raise(@logger, e, "CLI.provision")
       end
+      self
+    end
+
+    #Initialize the network manager so it can initialize hosts for testing for subcommands
+    def initialize_network_manager
+      begin
+        @network_manager = Beaker::NetworkManager.new(@options, @logger)
+        @hosts = @network_manager.provision
+      rescue => e
+        report_and_raise(@logger, e, "CLI.initialize_network_manager")
+      end
     end
 
     #Run Beaker tests.
@@ -102,8 +115,6 @@ module Beaker
           @logger.warn "Interrupt received; exiting..."
           exit(1)
         end
-
-        provision
 
         # Setup perf monitoring if needed
         if @options[:collect_perf_data].to_s =~ /(aggressive)|(normal)/

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -53,20 +53,67 @@ module Beaker
       let ( :cli ) { subcommand.instance_variable_get(:@cli) }
       let( :yaml_store_mock ) { double('yaml_store_mock') }
       let ( :host_hash ) { {'mynode.net' => {:name => 'mynode', :platform => Beaker::Platform.new('centos-6-x86_64')}}}
+      let ( :cleaned_hosts ) {double()}
+      let ( :yielded_host_hash ) {double()}
+      let ( :yielded_host_name) {double()}
       it 'provisions the host and saves the host info' do
         expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
         allow(yaml_store_mock).to receive(:[]).and_return(false)
         expect(cli).to receive(:parse_options)
         expect(cli).to receive(:provision)
         expect(cli).to receive(:combined_instance_and_options_hosts).and_return(host_hash)
-        expect(SubcommandUtil).to receive(:sanitize_options_for_save).and_return('cleaned hosts')
+        expect(SubcommandUtil).to receive(:sanitize_options_for_save).and_return(cleaned_hosts)
+        expect(cleaned_hosts).to receive(:each).and_yield(yielded_host_name, yielded_host_hash)
+        expect(yielded_host_hash).to receive(:[]=).with('provision', false)
         expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_OPTIONS).and_return(yaml_store_mock)
 
         expect(yaml_store_mock).to receive(:transaction).and_yield.exactly(3).times
-        expect(yaml_store_mock).to receive(:[]=).with('HOSTS', 'cleaned hosts')
+        expect(yaml_store_mock).to receive(:[]=).with('HOSTS', cleaned_hosts)
 
         expect(yaml_store_mock).to receive(:[]=).with('provisioned', true)
         subcommand.provision
+      end
+    end
+
+
+    context 'exec' do
+      it 'calls execute! when no resource is given' do
+        expect_any_instance_of(Pathname).to_not receive(:directory?)
+        expect_any_instance_of(Pathname).to_not receive(:exist?)
+        expect_any_instance_of(Beaker::CLI).to receive(:parse_options).once
+        expect_any_instance_of(Beaker::CLI).to receive(:initialize_network_manager).once
+        expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
+        expect{subcommand.exec}.to_not raise_error
+      end
+
+      it 'checks to to see if the resource is a file_resource' do
+
+        expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+        expect_any_instance_of(Pathname).to receive(:directory?).and_return(false)
+        expect_any_instance_of(Pathname).to receive(:expand_path).once
+        expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
+        expect{subcommand.exec('resource')}.to_not raise_error
+      end
+
+      it 'checks to see if the resource is a directory' do
+        expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+        expect_any_instance_of(Pathname).to receive(:directory?).and_return(true)
+        expect(Dir).to receive(:glob)
+        expect_any_instance_of(Pathname).to receive(:expand_path).once
+        expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
+        expect{subcommand.exec('resource')}.to_not raise_error
+      end
+
+      it 'allows a hard coded suite name to be specified' do
+
+        allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+        expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
+        expect{subcommand.exec('tests')}.to_not raise_error
+      end
+
+      it 'errors when a resource is neither a valid file resource or suite name' do
+        allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+        expect{subcommand.exec('blahblahblah')}.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
These changes introduce new subcommand functionality for beaker; the
exec subcommand takes a file, directory, or beaker suite name and
launches beaker to test that resource specifically. If no resource is
specified, it reads in default configuration that should already be set
up by previous subcommands.