### PR TITLE
(BKR-1083) Pass beaker run options through from subcommands

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -11,6 +11,44 @@ module Beaker
       @@config = SubcommandUtil.init_config()
     end
 
+    # Options listed in this group 'Beaker run' are options that can be set on subcommands
+    # but are not processed by the subcommand itself. They are passed through so that when
+    # a Beaker::CLI object executes, it can pick up these options. Notably excluded from this
+    # group are `help` and `version`. Please note that whenever the command_line_parser.rb is
+    # updated, this list should also be updated as well.
+    class_option :hosts, :aliases => '-h', :type => :string, :group => 'Beaker run'
+    class_option :'options-file', :aliases => '-o', :type => :string, :group => 'Beaker run'
+    class_option :helper, :type => :string, :group => 'Beaker run'
+    class_option :'load-path', :type => :string, :group => 'Beaker run'
+    class_option :tests, :aliases => '-t', :type => :string, :group => 'Beaker run'
+    class_option :'pre-suite', :type => :string, :group => 'Beaker run'
+    class_option :'post-suite', :type => :string, :group => 'Beaker run'
+    class_option :'pre-cleanup', :type => :string, :group => 'Beaker run'
+    class_option :'provision', :type => :boolean, :group => 'Beaker run'
+    class_option :'preserve-hosts', :type => :string, :group => 'Beaker run'
+    class_option :'root-keys', :type => :boolean, :group => 'Beaker run'
+    class_option :keyfile, :type => :string, :group => 'Beaker run'
+    class_option :timeout, :type => :string, :group => 'Beaker run'
+    class_option :install, :aliases => '-i', :type => :string, :group => 'Beaker run'
+    class_option :modules, :aliases => '-m', :type => :string, :group => 'Beaker run'
+    class_option :quiet, :aliases => '-q', :type => :boolean, :group => 'Beaker run'
+    class_option :color, :type => :boolean, :group => 'Beaker run'
+    class_option :'color-host-output', :type => :boolean, :group => 'Beaker run'
+    class_option :'log-level', :type => :string, :group => 'Beaker run'
+    class_option :'log-prefix', :type => :string, :group => 'Beaker run'
+    class_option :'dry-run', :type => :boolean, :group => 'Beaker run'
+    class_option :'fail-mode', :type => :string, :group => 'Beaker run'
+    class_option :ntp, :type => :boolean, :group => 'Beaker run'
+    class_option :'repo-proxy', :type => :boolean, :group => 'Beaker run'
+    class_option :'add-el-extras', :type => :boolean, :group => 'Beaker run'
+    class_option :'package-proxy', :type => :string, :group => 'Beaker run'
+    class_option :'validate', :type => :boolean, :group => 'Beaker run'
+    class_option :'collect-perf-data', :type => :boolean, :group => 'Beaker run'
+    class_option :'parse-only', :type => :boolean, :group => 'Beaker run'
+    class_option :tag, :type => :string, :group => 'Beaker run'
+    class_option :'exclude-tags', :type => :string, :group => 'Beaker run'
+    class_option :'xml-time-order', :type => :boolean, :group => 'Beaker run'
+
     desc "init HYPERVISOR", "Initialises the beaker test environment configuration"
     option :help, :type => :boolean, :hide => true
     long_desc <<-LONGDESC


### PR DESCRIPTION
This PR adds in the ability to accept and pass through options from a subcommand
to a Beaker::CLI object. Prior to this change, subcommands could not configure
beaker execution; this PR opens up virtually every option.