### PR TITLE
(BKR-1076) Refactor beaker init and provision

### DIFF
--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -4,45 +4,61 @@ test_name 'use the init subcommand' do
     on default, 'rm -rf /root/* /root/.beaker'
   end
 
-  step 'ensure that `beaker init` exit value should be 1 when not provided with a supported hypervisor' do
-    result = on(default, 'beaker init ec2', :accept_all_exit_codes => true)
-    assert_match(/Invalid hypervisor. Currently supported hypervisors are.+/, result.stdout)
-    refute_equal(0, result.exit_code, '`beaker init` with an unsupported hypervisor argument should return a non-zero exit code')
-	end
+  # step 'ensure that `beaker init` exit value should be 1 when not provided with a supported hypervisor' do
+  #   result = on(default, 'beaker init ec2', :accept_all_exit_codes => true)
+  #   assert_match(/Invalid hypervisor. Currently supported hypervisors are.+/, result.stdout)
+  #   refute_equal(0, result.exit_code, '`beaker init` with an unsupported hypervisor argument should return a non-zero exit code')
+	# end
 
-  step 'ensure that `beaker help init` works' do
-    result = on(default, 'beaker help init')
-    assert_match(/Usage+/, result.stdout)
+  # step 'ensure that `beaker help init` works' do
+  #   result = on(default, 'beaker help init')
+  #   assert_match(/Usage+/, result.stdout)
+  # end
+
+  # step 'ensure that `beaker init --help` works' do
+  #   result = on(default, 'beaker init --help')
+  #   assert_match(/Usage.+/, result.stdout)
+  #   assert_equal(0, result.exit_code, '`beaker init --help` should return a zero exit code')
+  # end
+
+  # step 'ensure that `beaker init` accepts no argument as well as accepts either vmpooler or vagrant hypervisor arguments' do
+  #   ['vmpooler', 'vagrant', ''].each do |hypervisor|
+  #     result = on(default, "beaker init #{hypervisor}")
+  #     assert_match(/Writing host config.+/, result.stdout)
+  #     step 'ensure that the Rakefile is present' do
+  #       on(default, '[ -e "Rakefile" ]')
+  #     end
+  #   delete_root_folder_contents
+  #   end
+  # end
+
+  # step 'ensure that a Rakefile is not overwritten if it does exist prior' do
+  #   delete_root_folder_contents
+  #   on(default, "beaker init vmpooler")
+  #   prepended_rakefile = on(default, 'cat Rakefile').stdout
+  #   delete_root_folder_contents
+  #   on(default, 'echo "require \'tempfile\'" >> Rakefile')
+  #   on(default, 'beaker init vmpooler', :accept_all_exit_codes => true)
+  #   rakefile = on(default, 'cat Rakefile')
+
+  #   # Assert that the Rakefile contents includes the original and inserted requirements
+  #   assert(result.stdout.include?(prepended_rakefile), 'Rakefile should not contain prepended require')
+  #   assert(result.stdout.include?("require 'tempfile'"), 'Rakefile should not contain prepended require')
+  # end
+  step 'ensure beaker init writes YAML configuration files to disk' do
+    delete_root_folder_contents
+    on(default, 'beaker init')
+    subcommand_options = on(default, 'cat .beaker/subcommand_options.yaml').stdout
+    subcommand_state = on(default, 'cat .beaker/.subcommand_state.yaml').stdout
+    assert(YAML.parse(subcommand_options).to_ruby.class == Hash)
+    assert(YAML.parse(subcommand_state).to_ruby.class == Hash)
   end
 
-  step 'ensure that `beaker init --help` works' do
-    result = on(default, 'beaker init --help')
-    assert_match(/Usage.+/, result.stdout)
-    assert_equal(0, result.exit_code, '`beaker init --help` should return a zero exit code')
-  end
-
-  step 'ensure that `beaker init` accepts no argument as well as accepts either vmpooler or vagrant hypervisor arguments' do
-    ['vmpooler', 'vagrant', ''].each do |hypervisor|
-      result = on(default, "beaker init #{hypervisor}")
-      assert_match(/Writing host config.+/, result.stdout)
-      step 'ensure that the Rakefile is present' do
-        on(default, '[ -e "Rakefile" ]')
-      end
+  step 'ensure beaker init saves beaker run arguments to the subcommand_options.yaml' do
     delete_root_folder_contents
-    end
-  end
-
-  step 'ensure that a Rakefile is not overwritten if it does exist prior' do
-    delete_root_folder_contents
-    on(default, "beaker init vmpooler")
-    prepended_rakefile = on(default, 'cat Rakefile').stdout
-    delete_root_folder_contents
-    on(default, 'echo "require \'tempfile\'" >> Rakefile')
-    on(default, 'beaker init vmpooler', :accept_all_exit_codes => true)
-    rakefile = on(default, 'cat Rakefile')
-
-    # Assert that the Rakefile contents includes the original and inserted requirements
-    assert(result.stdout.include?(prepended_rakefile), 'Rakefile should not contain prepended require')
-    assert(result.stdout.include?("require 'tempfile'"), 'Rakefile should not contain prepended require')
+    on(default, 'beaker init --log-level verbose')
+    subcommand_options = on(default, 'cat .beaker/subcommand_options.yaml').stdout
+    hash = YAML.parse(subcommand_options).to_ruby
+    assert_equal('verbose', hash['log_level'])
   end
 end

--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -1,5 +1,6 @@
 test_name 'use the init subcommand' do
 
+  SubcommandUtil = Beaker::Subcommands::SubcommandUtil
   def delete_root_folder_contents
     on default, 'rm -rf /root/* /root/.beaker'
   end
@@ -7,8 +8,8 @@ test_name 'use the init subcommand' do
   step 'ensure beaker init writes YAML configuration files to disk' do
     delete_root_folder_contents
     on(default, 'beaker init')
-    subcommand_options = on(default, 'cat .beaker/subcommand_options.yaml').stdout
-    subcommand_state = on(default, 'cat .beaker/.subcommand_state.yaml').stdout
+    subcommand_options = on(default, "cat #{SubcommandUtil::SUBCOMMAND_OPTIONS}").stdout
+    subcommand_state = on(default, "cat #{SubcommandUtil::SUBCOMMAND_STATE}").stdout
     assert(YAML.parse(subcommand_options).to_ruby.class == Hash)
     assert(YAML.parse(subcommand_state).to_ruby.class == Hash)
   end
@@ -16,7 +17,7 @@ test_name 'use the init subcommand' do
   step 'ensure beaker init saves beaker-run arguments to the subcommand_options.yaml' do
     delete_root_folder_contents
     on(default, 'beaker init --log-level verbose')
-    subcommand_options = on(default, 'cat .beaker/subcommand_options.yaml').stdout
+    subcommand_options = on(default, "cat #{SubcommandUtil::SUBCOMMAND_OPTIONS}").stdout
     hash = YAML.parse(subcommand_options).to_ruby
     assert_equal('verbose', hash['log_level'])
   end

--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -4,47 +4,6 @@ test_name 'use the init subcommand' do
     on default, 'rm -rf /root/* /root/.beaker'
   end
 
-  # step 'ensure that `beaker init` exit value should be 1 when not provided with a supported hypervisor' do
-  #   result = on(default, 'beaker init ec2', :accept_all_exit_codes => true)
-  #   assert_match(/Invalid hypervisor. Currently supported hypervisors are.+/, result.stdout)
-  #   refute_equal(0, result.exit_code, '`beaker init` with an unsupported hypervisor argument should return a non-zero exit code')
-	# end
-
-  # step 'ensure that `beaker help init` works' do
-  #   result = on(default, 'beaker help init')
-  #   assert_match(/Usage+/, result.stdout)
-  # end
-
-  # step 'ensure that `beaker init --help` works' do
-  #   result = on(default, 'beaker init --help')
-  #   assert_match(/Usage.+/, result.stdout)
-  #   assert_equal(0, result.exit_code, '`beaker init --help` should return a zero exit code')
-  # end
-
-  # step 'ensure that `beaker init` accepts no argument as well as accepts either vmpooler or vagrant hypervisor arguments' do
-  #   ['vmpooler', 'vagrant', ''].each do |hypervisor|
-  #     result = on(default, "beaker init #{hypervisor}")
-  #     assert_match(/Writing host config.+/, result.stdout)
-  #     step 'ensure that the Rakefile is present' do
-  #       on(default, '[ -e "Rakefile" ]')
-  #     end
-  #   delete_root_folder_contents
-  #   end
-  # end
-
-  # step 'ensure that a Rakefile is not overwritten if it does exist prior' do
-  #   delete_root_folder_contents
-  #   on(default, "beaker init vmpooler")
-  #   prepended_rakefile = on(default, 'cat Rakefile').stdout
-  #   delete_root_folder_contents
-  #   on(default, 'echo "require \'tempfile\'" >> Rakefile')
-  #   on(default, 'beaker init vmpooler', :accept_all_exit_codes => true)
-  #   rakefile = on(default, 'cat Rakefile')
-
-  #   # Assert that the Rakefile contents includes the original and inserted requirements
-  #   assert(result.stdout.include?(prepended_rakefile), 'Rakefile should not contain prepended require')
-  #   assert(result.stdout.include?("require 'tempfile'"), 'Rakefile should not contain prepended require')
-  # end
   step 'ensure beaker init writes YAML configuration files to disk' do
     delete_root_folder_contents
     on(default, 'beaker init')
@@ -54,7 +13,7 @@ test_name 'use the init subcommand' do
     assert(YAML.parse(subcommand_state).to_ruby.class == Hash)
   end
 
-  step 'ensure beaker init saves beaker run arguments to the subcommand_options.yaml' do
+  step 'ensure beaker init saves beaker-run arguments to the subcommand_options.yaml' do
     delete_root_folder_contents
     on(default, 'beaker init --log-level verbose')
     subcommand_options = on(default, 'cat .beaker/subcommand_options.yaml').stdout

--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -4,42 +4,47 @@ test_name 'use the provision subcommand' do
     on default, 'rm -rf /root/* /root/.beaker'
   end
 
-  step 'ensure that `beaker provision` fails correctly when a configuration has not been initialized' do
-    delete_root_folder_contents
-    result = on(default, 'beaker provision', :accept_all_exit_codes => true)
-    assert_match(/Please initialise a configuration/, result.stdout)
-    refute_equal(0, result.exit_code, '`beaker provision` in an uninitialised configuration should return a non-zero exit code')
-  end
+  # step 'ensure that `beaker provision` fails correctly when a configuration has not been initialized' do
+  #   delete_root_folder_contents
+  #   result = on(default, 'beaker provision', :accept_all_exit_codes => true)
+  #   assert_match(/Please initialise a configuration/, result.stdout)
+  #   refute_equal(0, result.exit_code, '`beaker provision` in an uninitialised configuration should return a non-zero exit code')
+  # end
 
-  step 'ensure that `beaker help provision` works' do
-    result = on(default, 'beaker help provision')
-    assert_match(/Usage/, result.stdout)
-    assert_equal(0, result.exit_code, '`beaker help provision` should return a zero exit code')
-  end
+  # step 'ensure that `beaker help provision` works' do
+  #   result = on(default, 'beaker help provision')
+  #   assert_match(/Usage/, result.stdout)
+  #   assert_equal(0, result.exit_code, '`beaker help provision` should return a zero exit code')
+  # end
 
-  step 'ensure that `beaker provision --help` works' do
-    result = on(default, 'beaker provision --help')
-    assert_match(/Usage/, result.stdout)
-    assert_equal(0, result.exit_code, '`beaker provision --help` should return a zero exit code')
-  end
+  # step 'ensure that `beaker provision --help` works' do
+  #   result = on(default, 'beaker provision --help')
+  #   assert_match(/Usage/, result.stdout)
+  #   assert_equal(0, result.exit_code, '`beaker provision --help` should return a zero exit code')
+  # end
 
-  step 'ensure that `beaker provision` provisions vmpooler configuration' do
-     result = on(default, "beaker init vmpooler")
-     assert_match(/Writing host config/, result.stdout)
-     assert_equal(0, result.exit_code, "`beaker init vmpooler` should return a zero exit code")
-     step 'ensure that the Rakefile is present' do
-       on(default, '[ -e "Rakefile" ]')
-     end
-     step 'ensure provision provisions, validates, and configures new hosts' do
-       result = on(default, "beaker provision")
-       assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
-     end
-     step 'ensure provision will not provision new hosts if hosts have already been provisioned' do
-       result = on(default, 'beaker provision')
-       assert_match(/Hosts have already been provisioned/, result.stdout)
-       assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
-     end
-    delete_root_folder_contents
+  # step 'ensure that `beaker provision` provisions vmpooler configuration' do
+  #    result = on(default, "beaker init vmpooler")
+  #    assert_match(/Writing host config/, result.stdout)
+  #    assert_equal(0, result.exit_code, "`beaker init vmpooler` should return a zero exit code")
+  #    step 'ensure that the Rakefile is present' do
+  #      on(default, '[ -e "Rakefile" ]')
+  #    end
+  #    step 'ensure provision provisions, validates, and configures new hosts' do
+  #      result = on(default, "beaker provision")
+  #      assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
+  #    end
+  #    step 'ensure provision will not provision new hosts if hosts have already been provisioned' do
+  #      result = on(default, 'beaker provision')
+  #      assert_match(/Hosts have already been provisioned/, result.stdout)
+  #      assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
+  #    end
+  #   delete_root_folder_contents
+  # end
+  step 'run beaker init and provision' do
+    on(default, 'beaker init')
+    result = on(default, 'beaker provision --hosts centos6-64')
+    assert_match(/Using available host/, result.stdout)
   end
 
 end

--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -1,5 +1,7 @@
 test_name 'use the provision subcommand' do
 
+  SubcommandUtil = Beaker::Subcommands::SubcommandUtil
+
   def delete_root_folder_contents
     on default, 'rm -rf /root/* /root/.beaker'
   end
@@ -9,7 +11,7 @@ test_name 'use the provision subcommand' do
     result = on(default, 'beaker provision --hosts centos6-64')
     assert_match(/Using available host/, result.stdout)
 
-    subcommand_state = on(default, 'cat .beaker/.subcommand_state.yaml').stdout
+    subcommand_state = on(default, "cat #{SubcommandUtil::SUBCOMMAND_STATE}").stdout
     subcommand_state = YAML.parse(subcommand_state).to_ruby
     assert_equal(true, subcommand_state['provisioned'])
   end

--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -4,47 +4,13 @@ test_name 'use the provision subcommand' do
     on default, 'rm -rf /root/* /root/.beaker'
   end
 
-  # step 'ensure that `beaker provision` fails correctly when a configuration has not been initialized' do
-  #   delete_root_folder_contents
-  #   result = on(default, 'beaker provision', :accept_all_exit_codes => true)
-  #   assert_match(/Please initialise a configuration/, result.stdout)
-  #   refute_equal(0, result.exit_code, '`beaker provision` in an uninitialised configuration should return a non-zero exit code')
-  # end
-
-  # step 'ensure that `beaker help provision` works' do
-  #   result = on(default, 'beaker help provision')
-  #   assert_match(/Usage/, result.stdout)
-  #   assert_equal(0, result.exit_code, '`beaker help provision` should return a zero exit code')
-  # end
-
-  # step 'ensure that `beaker provision --help` works' do
-  #   result = on(default, 'beaker provision --help')
-  #   assert_match(/Usage/, result.stdout)
-  #   assert_equal(0, result.exit_code, '`beaker provision --help` should return a zero exit code')
-  # end
-
-  # step 'ensure that `beaker provision` provisions vmpooler configuration' do
-  #    result = on(default, "beaker init vmpooler")
-  #    assert_match(/Writing host config/, result.stdout)
-  #    assert_equal(0, result.exit_code, "`beaker init vmpooler` should return a zero exit code")
-  #    step 'ensure that the Rakefile is present' do
-  #      on(default, '[ -e "Rakefile" ]')
-  #    end
-  #    step 'ensure provision provisions, validates, and configures new hosts' do
-  #      result = on(default, "beaker provision")
-  #      assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
-  #    end
-  #    step 'ensure provision will not provision new hosts if hosts have already been provisioned' do
-  #      result = on(default, 'beaker provision')
-  #      assert_match(/Hosts have already been provisioned/, result.stdout)
-  #      assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
-  #    end
-  #   delete_root_folder_contents
-  # end
   step 'run beaker init and provision' do
     on(default, 'beaker init')
     result = on(default, 'beaker provision --hosts centos6-64')
     assert_match(/Using available host/, result.stdout)
-  end
 
+    subcommand_state = on(default, 'cat .beaker/.subcommand_state.yaml').stdout
+    subcommand_state = YAML.parse(subcommand_state).to_ruby
+    assert_equal(true, subcommand_state['provisioned'])
+  end
 end

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -194,9 +194,7 @@ module Beaker
       ).run_and_raise_on_failure
     end
 
-    # Get the list of options that are not equal to presets. Skip certain keys that
-    # that shouldn't be shared between cli objects, such as :timestamp, :logger, and
-    # :command_line.
+    # Get the list of options that are not equal to presets.
     # @return Beaker::Options::OptionsHash
     def configured_options
       result = Beaker::Options::OptionsHash.new
@@ -226,7 +224,7 @@ module Beaker
       preserved_hosts_filename = File.join(@options[:log_dated_dir], 'hosts_preserved.yml')
 
       hosts_yaml = @options
-      hosts_yaml['HOSTS'] = hosts_with_reachable_name
+      hosts_yaml['HOSTS'] = combined_instance_and_options_hosts
       hosts_yaml['CONFIG'] = Beaker::Options::OptionsHash.new.merge(hosts_yaml['CONFIG'] || {})
       # save the rest of the options, excepting the HOSTS that we have already processed
       hosts_yaml['CONFIG'] = hosts_yaml['CONFIG'].merge(@options.reject{ |k,v| k =~ dontpreserve })
@@ -238,8 +236,9 @@ module Beaker
       @options[:hosts_preserved_yaml_file] = preserved_hosts_filename
     end
 
-    # Return a host_hash that is updated to have reachable names
-    def hosts_with_reachable_name
+    # Return a host_hash that is a merging of options host hashes with instance host objects
+    # @return Hash
+    def combined_instance_and_options_hosts
       hosts_yaml = @options
       newly_keyed_hosts_entries = {}
       hosts_yaml['HOSTS'].each do |host_name, file_host_hash|

--- a/lib/beaker/options.rb
+++ b/lib/beaker/options.rb
@@ -1,3 +1,3 @@
-%w(validator options_hash presets command_line_parser options_file_parser hosts_file_parser parser).each do |lib|
+%w(validator options_hash presets command_line_parser options_file_parser hosts_file_parser parser subcommand_options_file_parser).each do |lib|
   require "beaker/options/#{lib}"
 end

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -224,7 +224,6 @@ module Beaker
         file_options                    = Beaker::Options::OptionsFileParser.parse_options_file(cmd_line_options[:options_file])
         @attribution = @attribution.merge(tag_sources(file_options, "options_file"))
 
-
         # merge together command line and file_options
         #   overwrite file options with command line options
         cmd_line_and_file_options       = file_options.merge(cmd_line_options)

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -217,6 +217,14 @@ module Beaker
         file_options                    = Beaker::Options::OptionsFileParser.parse_options_file(cmd_line_options[:options_file])
         @attribution = @attribution.merge(tag_sources(file_options, "options_file"))
 
+        if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(ARGV[0])
+          unless ARGV[0] == 'init'
+            subcommand_options = Beaker::Subcommands::SubcommandUtil.load_subcommand_options
+            @attribution = @attribution.merge(tag_sources(subcommand_options, 'subcommand'))
+            @options.merge!(subcommand_options)
+          end
+        end
+
         # merge together command line and file_options
         #   overwrite file options with command line options
         cmd_line_and_file_options       = file_options.merge(cmd_line_options)

--- a/lib/beaker/options/subcommand_options_file_parser.rb
+++ b/lib/beaker/options/subcommand_options_file_parser.rb
@@ -1,0 +1,20 @@
+module Beaker
+  module Options
+    #A set of functions to read options files
+    module SubcommandOptionsParser
+
+      # @return [OptionsHash, Hash] returns an empty OptionHash or loads subcommand options yaml
+      #   from disk
+      def self.parse_subcommand_options(argv)
+        result = OptionsHash.new
+        if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(argv[0])
+          return result if argv[0] == 'init'
+          if Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS.exist?
+           result = YAML.load_file(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
+          end
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -58,11 +58,9 @@ module Beaker
     long_desc <<-LONGDESC
       Initializes the required .beaker configuration folder. This folder contains
       a subcommand_options.yaml file that is user-facing; altering this file will
-      alter the options subcommand execution.
-
-      Also modified in this operation is the .subcommand_state file that is used
-      by beaker to determine subcommand state. You as a user should never have to
-      edit this file.
+      alter the options subcommand execution. Subsequent subcommand execution,
+      such as `provision`, will result in beaker making modifications to this file
+      as necessary.
     LONGDESC
     def init()
       if options[:help]
@@ -81,10 +79,11 @@ module Beaker
 
       options_to_write = SubcommandUtil.sanitize_options_for_save(options_to_write)
 
-      @cli.logger.notify 'writing configured options to disk'
+      @cli.logger.notify 'Writing configured options to disk'
       File.open(SubcommandUtil::SUBCOMMAND_OPTIONS, 'w') do |f|
         f.write(options_to_write.to_yaml)
       end
+      @cli.logger.notify "Options written to #{SubcommandUtil::SUBCOMMAND_OPTIONS}"
 
       state = YAML::Store.new(SubcommandUtil::SUBCOMMAND_STATE)
       state.transaction do

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -113,7 +113,7 @@ module Beaker
       @cli.provision
 
       # Sanitize the hosts
-      cleaned_hosts = SubcommandUtil.sanitize_options_for_save(@cli.hosts_with_reachable_name)
+      cleaned_hosts = SubcommandUtil.sanitize_options_for_save(@cli.combined_instance_and_options_hosts)
 
       # should we only update the options here with the new host? Or update the settings
       # with whatever new flags may have been provided with provision?

--- a/lib/beaker/subcommands/subcommand_util.rb
+++ b/lib/beaker/subcommands/subcommand_util.rb
@@ -32,17 +32,6 @@ module Beaker
         (Beaker::Subcommand.instance_methods(false) << :help).include? arg0.to_sym
       end
 
-      # Checks to ensure the the subcommand options are there and load them. Otherwise,
-      # return an empty OptionsHash.
-      # @return [Hash, OptionsHash]
-      def self.load_subcommand_options
-        if SUBCOMMAND_OPTIONS.exist?
-          YAML.load_file(SUBCOMMAND_OPTIONS)
-        else
-          Beaker::Options::OptionsHash.new
-        end
-      end
-
       # Reset ARGV to contain the arguments determined by a specific subcommand
       # @param [Array<String>] args the arguments determined by a specific subcommand
       def self.reset_argv(args)

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -50,6 +50,36 @@ module Beaker
       Beaker::CLI.new.parse_options
     }
 
+    context '#configured_options' do
+      it 'returns a list of options that were not presets' do
+        attribution = cli.instance_variable_get(:@attribution)
+        attribution.each do |attribute, setter|
+          if setter == 'preset'
+            expect(cli.configured_options[attribute]).to be_nil
+          end
+        end
+      end
+    end
+
+    context '#combined_instance_and_options_hosts' do
+      let (:options_host) { {'HOSTS' => {'ubuntu' => {:options_attribute => 'options'}} }}
+      let (:instance_host ) {
+        [Beaker::Host.create('ubuntu', {:platform => 'host'}, {} )]
+      }
+      before do
+        cli.instance_variable_set(:@options, options_host)
+        cli.instance_variable_set(:@hosts, instance_host)
+      end
+      it 'combines the options and instance host objects' do
+        merged_host = cli.combined_instance_and_options_hosts
+        expect(merged_host).to have_key('ubuntu')
+        expect(merged_host['ubuntu']).to have_key(:options_attribute)
+        expect(merged_host['ubuntu']).to have_key(:platform)
+        expect(merged_host['ubuntu'][:options_attribute]).to eq('options')
+        expect(merged_host['ubuntu'][:platform]).to eq('host')
+      end
+    end
+
     context 'execute!' do
       before :each do
        stub_const("Beaker::Logger", double().as_null_object )

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -146,6 +146,7 @@ module Beaker
                               :user_known_hosts_file => 'hosts123'
                             }                                
           } }
+          let(:subcommand_file) {@subcommand_file || {:level => 'fifth'}}
           let(:presets) { {:level => 'lowest',
                             :ssh => {
                               :config => 'config123',
@@ -173,16 +174,28 @@ module Beaker
 
             allow(OptionsFileParser).to receive(:parse_options_file).and_return(opt_file)
             allow(parser).to receive(:parse_hosts_options).and_return(host_file)
+
+            allow(SubcommandOptionsParser).to receive(:parse_subcommand_options).and_return(subcommand_file)
           end
 
           it 'presets have the lowest priority' do
-            @env = @argv = @host_file = @opt_file = {}
+            @env = @argv = @host_file = @opt_file = @subcommand_file = {}
             mock_out_parsing
 
             opts = parser.parse_args([])
             attribution = parser.attribution
             expect(opts[:level]).to be == 'lowest'
             expect(attribution[:level]).to be == 'preset'
+          end
+
+          it 'subcommand_options should have fifth priority' do
+            @env = @argv = @host_file = @opt_file = {}
+            mock_out_parsing
+
+            opts = parser.parse_args([])
+            attribution = parser.attribution
+            expect(opts[:level]).to be == 'fifth'
+            expect(attribution[:level]).to be == 'subcommand'
           end
 
           it 'options file has fourth priority' do

--- a/spec/beaker/options/subcommand_options_parser_spec.rb
+++ b/spec/beaker/options/subcommand_options_parser_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+module Beaker
+  module Options
+    describe '#parse_subcommand_options' do
+      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv)}
+      let( :argv ) {[]}
+
+      it 'returns an empty OptionsHash if not executing a subcommand' do
+        expect(parser).to be_kind_of(OptionsHash)
+        expect(parser).to be_empty
+      end
+
+      describe 'when the subcommand is init' do
+        let( :argv ) {['init']}
+        it 'returns an empty OptionsHash' do
+          expect(parser).to be_kind_of(OptionsHash)
+          expect(parser).to be_empty
+        end
+      end
+
+      describe 'when the subcommand is not init' do
+        let( :argv ) {['provision']}
+        it 'checks for file existence and loads the YAML file' do
+          expect(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS).to receive(:exist?).and_return(true)
+          allow(YAML).to receive(:load_file).and_return({})
+          expect(parser).to be_kind_of(Hash)
+          expect(parser).not_to be_kind_of(OptionsHash)
+        end
+      end
+    end
+  end
+end

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+module Beaker
+  SubcommandUtil = Beaker::Subcommands::SubcommandUtil
+  describe Subcommand do
+    let( :subcommand ) {
+      Beaker::Subcommand.new
+    }
+
+    context '#initialize' do
+      it 'creates a cli object' do
+        expect(Beaker::CLI).to receive(:new).once
+        subcommand
+      end
+      describe 'File operation initialization for subcommands' do
+        it 'checks to ensure subcommand file resources exist' do
+          expect(FileUtils).to receive(:mkdir_p).with(SubcommandUtil::CONFIG_DIR)
+          expect(SubcommandUtil::SUBCOMMAND_OPTIONS).to receive(:exist?).and_return(true)
+          expect(SubcommandUtil::SUBCOMMAND_STATE).to receive(:exist?).and_return(true)
+          subcommand
+        end
+
+        it 'touches the files when they do not exist' do
+          expect(FileUtils).to receive(:mkdir_p).with(SubcommandUtil::CONFIG_DIR)
+          allow(SubcommandUtil::SUBCOMMAND_OPTIONS).to receive(:exist?).and_return(false)
+          allow(SubcommandUtil::SUBCOMMAND_STATE).to receive(:exist?).and_return(false)
+          expect(FileUtils).to receive(:touch).with(SubcommandUtil::SUBCOMMAND_OPTIONS)
+          expect(FileUtils).to receive(:touch).with(SubcommandUtil::SUBCOMMAND_STATE)
+          subcommand
+        end
+
+      end
+    end
+
+    context '#init' do
+      let( :cli ) { subcommand.instance_variable_get(:@cli) }
+      let( :mock_options ) { {:timestamp => 'noon', :other_key => 'cordite'}}
+      let( :yaml_store_mock ) { double('yaml_store_mock') }
+      it 'calculates options and writes them to disk and deletes the' do
+        expect(cli).to receive(:parse_options)
+        allow(cli).to receive(:configured_options).and_return(mock_options)
+
+        allow(File).to receive(:open)
+        allow(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
+        allow(yaml_store_mock).to receive(:transaction).and_yield
+        expect(yaml_store_mock).to receive(:[]=).with('provisioned', false)
+        subcommand.init
+        expect(mock_options).not_to have_key(:timestamp)
+      end
+    end
+
+    context '#provision' do
+      let ( :cli ) { subcommand.instance_variable_get(:@cli) }
+      let( :yaml_store_mock ) { double('yaml_store_mock') }
+      let ( :host_hash ) { {'mynode.net' => {:name => 'mynode', :platform => Beaker::Platform.new('centos-6-x86_64')}}}
+      it 'provisions the host and saves the host info' do
+        expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
+        allow(yaml_store_mock).to receive(:[]).and_return(false)
+        expect(cli).to receive(:parse_options)
+        expect(cli).to receive(:provision)
+        expect(cli).to receive(:hosts_with_reachable_name).and_return(host_hash)
+        expect(SubcommandUtil).to receive(:sanitize_options_for_save).and_return('cleaned hosts')
+        expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_OPTIONS).and_return(yaml_store_mock)
+
+        expect(yaml_store_mock).to receive(:transaction).and_yield.exactly(3).times
+        expect(yaml_store_mock).to receive(:[]=).with('HOSTS', 'cleaned hosts')
+
+        expect(yaml_store_mock).to receive(:[]=).with('provisioned', true)
+        subcommand.provision
+      end
+    end
+  end
+end

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -58,7 +58,7 @@ module Beaker
         allow(yaml_store_mock).to receive(:[]).and_return(false)
         expect(cli).to receive(:parse_options)
         expect(cli).to receive(:provision)
-        expect(cli).to receive(:hosts_with_reachable_name).and_return(host_hash)
+        expect(cli).to receive(:combined_instance_and_options_hosts).and_return(host_hash)
         expect(SubcommandUtil).to receive(:sanitize_options_for_save).and_return('cleaned hosts')
         expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_OPTIONS).and_return(yaml_store_mock)
 


### PR DESCRIPTION
This changes beaker init to focus on setting up a repository for
beaker subcommands, rather than focusing in on generating host files
themselves. This also adds the functionality to create files that
contain the configured options; that is, all options that are not
presets after beaker parses its OptionsHash.