### PR TITLE
(BKR-1075) Remove parsing from CLI intialize

### DIFF
--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -32,8 +32,6 @@ test_name 'use the provision subcommand' do
      end
      step 'ensure provision provisions, validates, and configures new hosts' do
        result = on(default, "beaker provision")
-       assert_match(/"validate": true,/, result.stdout)
-       assert_match(/"configure": true,/, result.stdout)
        assert_equal(0, result.exit_code, "`beaker provision` should return a zero exit code")
      end
      step 'ensure provision will not provision new hosts if hosts have already been provisioned' do

--- a/bin/beaker
+++ b/bin/beaker
@@ -6,7 +6,7 @@ require 'beaker'
 if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(ARGV[0])
   Beaker::Subcommand.start(ARGV)
 else
-  Beaker::CLI.new.execute!
+  Beaker::CLI.new.parse_options.execute!
   puts "Beaker completed successfully, thanks."
 end
 

--- a/lib/beaker/subcommands/subcommand_util.rb
+++ b/lib/beaker/subcommands/subcommand_util.rb
@@ -164,7 +164,7 @@ module Beaker
       # @param [Array<Object>] options the options to use when provisioning
       def self.provision(hypervisor, options)
         reset_argv(["--hosts", "#{CONFIG_DIR}/acceptance/config/default_#{hypervisor}_hosts.yaml", "--validate", options[:validate], "--configure", options[:configure]])
-        beaker = Beaker::CLI.new
+        beaker = Beaker::CLI.new.parse_options
         beaker.provision
         beaker.preserve_hosts_file
       end

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -2,9 +2,52 @@ require 'spec_helper'
 
 module Beaker
   describe CLI do
+
+    context 'initializing and parsing' do
+      let( :cli ) {
+        Beaker::CLI.new
+      }
+
+      describe 'instance variable initialization' do
+        it 'creates a logger for use before parse is called' do
+          expect(Beaker::Logger).to receive(:new).once.and_call_original
+          expect(cli.logger).to be_instance_of(Beaker::Logger)
+        end
+
+        it 'generates the timestamp' do
+          expect(Time).to receive(:now).once
+          cli
+        end
+      end
+
+      describe '#parse_options' do
+        it 'returns self' do
+          expect(cli.parse_options).to be_instance_of(Beaker::CLI)
+        end
+
+        it 'replaces the logger object with a new one' do
+          expect(Beaker::Logger).to receive(:new).with(no_args).once.and_call_original
+          expect(Beaker::Logger).to receive(:new).once.and_call_original
+          cli.parse_options
+        end
+      end
+
+      describe '#print_version_and_options' do
+        before do
+          options  = Beaker::Options::OptionsHash.new
+          options[:beaker_version] = 'version_number'
+          cli.instance_variable_set('@options', options)
+        end
+        it 'prints the version and dumps the options' do
+          expect(cli.logger).to receive(:info).exactly(3).times
+          cli.print_version_and_options
+        end
+      end
+    end
+
     let(:cli)      {
       allow(File).to receive(:exists?).and_return(true)
-      Beaker::CLI.new
+      Beaker::CLI.new.parse_options
     }
 
     context 'execute!' do

--- a/spec/beaker/subcommand/subcommand_util_spec.rb
+++ b/spec/beaker/subcommand/subcommand_util_spec.rb
@@ -249,6 +249,7 @@ module Beaker
           expect(cli).to receive(:provision).and_return(true)
           expect(cli).to receive(:preserve_hosts_file).exactly(1).times
           allow(Beaker::CLI).to receive(:new).and_return(cli)
+          allow(cli).to receive(:parse_options).and_return(cli)
           hypervisor = "vmpooler"
           expect(subject).to receive(:reset_argv).with(["--hosts",".beaker/acceptance/config/default_#{hypervisor}_hosts.yaml", "--validate", true, "--configure", true]).exactly(1).times
           subject.provision(hypervisor, options)
@@ -259,6 +260,7 @@ module Beaker
           expect(cli).to receive(:provision).and_return(true)
           expect(cli).to receive(:preserve_hosts_file).exactly(1).times
           allow(Beaker::CLI).to receive(:new).and_return(cli)
+          allow(cli).to receive(:parse_options).and_return(cli)
           hypervisor = "vmpooler"
           expect(subject).to receive(:reset_argv).with(["--hosts",".beaker/acceptance/config/default_#{hypervisor}_hosts.yaml", "--validate", true, "--configure", false]).exactly(1).times
           subject.provision(hypervisor, options)
@@ -269,6 +271,7 @@ module Beaker
           expect(cli).to receive(:provision).and_return(true)
           expect(cli).to receive(:preserve_hosts_file).exactly(1).times
           allow(Beaker::CLI).to receive(:new).and_return(cli)
+          allow(cli).to receive(:parse_options).and_return(cli)
           hypervisor = "vmpooler"
           expect(subject).to receive(:reset_argv).with(["--hosts",".beaker/acceptance/config/default_#{hypervisor}_hosts.yaml", "--validate", false, "--configure", false]).exactly(1).times
           subject.provision(hypervisor, options)


### PR DESCRIPTION
Prior to this commit, a Beaker::CLI object would do all options parsing
during initialization; now that parsing is needed by subcommands, we
should pull the parsing from initialization and call it after the object
has been instantiated.
