### PR TITLE
(maint) Update required rake version to avoid gem dependency error

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 
-  s.add_runtime_dependency 'rake', '~> 10.0'
+  s.add_runtime_dependency 'rake', '~> 11.0'
   s.add_runtime_dependency 'rsync', '~> 1.0.9'
   s.add_runtime_dependency 'open_uri_redirections', '~> 0.2.1'
   s.add_runtime_dependency 'in-parallel', '~> 0.1'


### PR DESCRIPTION
I did this locally and ran a few rake commands (namely test:spec, history:gen, and docs:clean) all of which ran and operated as expected. 

In pe-console-ui, I get the following error from running `bundle update beaker`:
```
Resolving dependencies.........
Bundler could not find compatible versions for gem "rake":
  In Gemfile:
    beaker (= 3.13.0) was resolved to 3.13.0, which depends on
      rake (~> 10.0)

    rototiller (~> 1.0) was resolved to 1.0.0, which depends on
      rake (~> 11.0)
```

Since updating rake doesn't (seem to) break anything, using the latest version here seems like the easiest fix, though I'm definitely open to other fixes. 