### PR TITLE
(MAINT) Fix invalid chars in Openstack ssh keyname

### DIFF
--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -353,12 +353,13 @@ module Beaker
           retry
         end
 
+        keyname = host[:vmhostname].gsub('.','-')
         type = key.ssh_type
         data = [ key.to_blob ].pack('m0')
-        @logger.debug "Creating Openstack keypair for public key '#{type} #{data}'"
-        @compute_client.create_key_pair host[:vmhostname], "#{type} #{data}"
+        @logger.debug "Creating Openstack keypair '#{keyname}' for public key '#{type} #{data}'"
+        @compute_client.create_key_pair keyname, "#{type} #{data}"
         host['ssh'][:key_data] = [ key.to_pem ]
-        host[:vmhostname]
+        keyname
       end
     end
   end

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -84,7 +84,7 @@ module Beaker
       openstack.provision
 
       @hosts.each do |host|
-        expect(host[:keyname]).to match(/[_\-0-9a-zA-Z]+/)
+        expect(host[:keyname]).to match(/^[_\-0-9a-zA-Z]+$/)
       end
     end
 


### PR DESCRIPTION
Current behaviour will result in 400 error from OpenStack. "Keypair data is invalid: Keypair name contains unsafe characters"