### PR TITLE
(MODULES-4594) vmpooler hypervisor: add disks

### DIFF
--- a/docs/how_to/hypervisors/vmpooler.md
+++ b/docs/how_to/hypervisors/vmpooler.md
@@ -18,6 +18,23 @@ An example of a `.fog` file with just the vmpooler details is below:
 :default:
   :vmpooler_token: 'randomtokentext'
 ```
+# Additional Disks
+Using the vmpooler API, Beaker enables you to attach additional storage disks in the host configuration file. The disks are added at the time the VM is created. Logic for using the disk must go into your tests.
+
+Simply add the `disks` key and a list containing the sizes(in GB) of the disks you want to create and attach to that host.
+For example, to create 2 disks sized 8GB and 16GB to example-box:
+
+```yaml
+ example-box:
+    disks:
+      - 8
+      - 16
+    roles:
+      - satellite
+    platform: el-7-x86_64
+    hypervisor: vmpooler
+    template: redhat-7-x86_64
+```
 
 Users with Puppet credentials can follow our instructions for getting & using
 vmpooler tokens in our

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -60,6 +60,42 @@ module Beaker
       end
     end
 
+    describe '#disk_added?' do
+      let(:vmpooler) { Beaker::Vmpooler.new(make_hosts, make_opts) }
+      let(:response_hash_no_disk) {
+        {
+          "ok" => "true",
+          "hostname" => {
+            "template"=>"redhat-7-x86_64",
+            "domain"=>"delivery.puppetlabs.net"
+          }
+        }
+      }
+      let(:response_hash_disk) {
+        {
+          "ok" => "true",
+          "hostname" => {
+            "disk" => [
+              '+16gb',
+              '+8gb'
+            ],
+            "template"=>"redhat-7-x86_64",
+            "domain"=>"delivery.puppetlabs.net"
+          }
+        }
+      }
+      it 'returns false when there is no disk' do
+        host = response_hash_no_disk['hostname']
+        expect(vmpooler.disk_added?(host, "8", 0)).to be(false)
+      end
+
+      it 'returns true when there is a disk' do
+        host = response_hash_disk["hostname"]
+        expect(vmpooler.disk_added?(host, "16", 0)).to be(true)
+        expect(vmpooler.disk_added?(host, "8", 1)).to be(true)
+      end
+    end
+
     describe "#provision" do
 
       it 'provisions hosts from the pool' do


### PR DESCRIPTION
In order to set up a test environment for Red Hat Satellite, we need a
disk that's larger than the default vmpooler allotment (about 5 GB free
vs the 1.5GB that are free on a redhat host after all is said and done).
This adds a step to the provision function in the vmpooler hypervisor to
add a disk of x size to any host in the host configuration file. It is
then up to the tests to partition, mount, expand, or whatever they
decide to do with it.