### PR TITLE
(BKR-1091) vCloud datacenter selection support

### DIFF
--- a/docs/how_to/hypervisors/vsphere.md
+++ b/docs/how_to/hypervisors/vsphere.md
@@ -10,6 +10,8 @@ To do this create a `~/.fog` file with your vSphere credentials:
 
 These follow the conventions used by Cloud Provisioner and Fog.
 
+>Note: Your fog credential file location may be specified in the 'CONFIG' section using the 'dot_fog' setting
+
 There are two possible `hypervisor` hypervisor-types to use for vSphere testing, `vsphere` and `vcloud`.
 
 ### `hypervisor: vsphere`
@@ -18,7 +20,7 @@ This option locates an existing static VM, optionally reverts it to a pre-existi
 ### `hypervisor: vcloud`
 This option clones a new VM from a pre-existing template, runs tests on the newly-provisioned clone, then deletes the clone once testing completes.
 
-The `vcloud` option requires a slightly-modified test configuration file, specifying both the target template as well as three additional parameters in the 'CONFIG' section ('datastore', 'resourcepool', and 'folder').
+The `vcloud` option requires a slightly-modified test configuration file, specifying both the target template as well as three additional parameters in the 'CONFIG' section ('datastore', 'datacenter', and 'folder').  Optionally, a resourcepool may be specified via the 'resourcepool' setting in the 'CONFIG' section.  Template can be expressed in the 'HOSTS' section, or you can set the template to be used via the `BEAKER_vcloud_template` environment variable.
 
 #### example vcloud hosts file ###
     HOSTS:
@@ -38,6 +40,7 @@ The `vcloud` option requires a slightly-modified test configuration file, specif
         hypervisor: vcloud
     CONFIG:
       consoleport: 443
+      datacenter: testdc
       datastore: instance0
       resourcepool: Delivery/Quality Assurance/FOSS/Dynamic
       folder: delivery/Quality Assurance/FOSS/Dynamic

--- a/lib/beaker/hypervisor/vsphere_helper.rb
+++ b/lib/beaker/hypervisor/vsphere_helper.rb
@@ -118,29 +118,23 @@ class VsphereHelper
     vms
   end
 
-  def find_datastore datastorename
-    datacenter = @connection.serviceInstance.find_datacenter
+  def find_datastore(dc,datastorename)
+    datacenter = @connection.serviceInstance.find_datacenter(dc)
     datacenter.find_datastore(datastorename)
   end
 
-  def find_folder foldername
-    datacenter = @connection.serviceInstance.find_datacenter
-    base = datacenter.vmFolder
-    folders = foldername.split('/')
-    folders.each do |folder|
-      case base
-        when RbVmomi::VIM::Folder
-          base = base.childEntity.find { |f| f.name == folder }
-        else
-          abort "Unexpected object type encountered (#{base.class}) while finding folder"
-      end
+  def find_folder(dc,foldername)
+    datacenter = @connection.serviceInstance.find_datacenter(dc)
+    base = datacenter.vmFolder.traverse(foldername)
+    if base != nil
+      base
+    else
+      abort "Failed to find folder #{foldername}"
     end
-
-    base
   end
 
-  def find_pool poolname
-    datacenter = @connection.serviceInstance.find_datacenter
+  def find_pool(dc,poolname)
+    datacenter = @connection.serviceInstance.find_datacenter(dc)
     base = datacenter.hostFolder
     pools = poolname.split('/')
     pools.each do |pool|

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -9,7 +9,7 @@ module Beaker
      stub_const( "VsphereHelper", MockVsphereHelper )
      stub_const( "Net", MockNet )
       json = double( 'json' )
-      allow( json ).to receive( :parse ) do |arg| 
+      allow( json ).to receive( :parse ) do |arg|
         arg
       end
      stub_const( "JSON", json )
@@ -23,6 +23,7 @@ module Beaker
 
         opts = make_opts
         opts[:pooling_api] = nil
+        opts[:datacenter] = 'testdc'
 
         vcloud = Beaker::Vcloud.new( make_hosts, opts )
         allow( vcloud ).to receive( :require ).and_return( true )
@@ -47,6 +48,7 @@ module Beaker
 
         opts = make_opts
         opts[:pooling_api] = nil
+        opts[:datacenter] = 'testdc'
 
         vcloud = Beaker::Vcloud.new( make_hosts, opts )
         allow( vcloud ).to receive( :require ).and_return( true )

--- a/spec/beaker/hypervisor/vsphere_helper_spec.rb
+++ b/spec/beaker/hypervisor/vsphere_helper_spec.rb
@@ -5,23 +5,21 @@ module Beaker
     let( :logger )         { double('logger').as_null_object }
     let( :vInfo )          { { :server => "vsphere.labs.net", :user => "vsphere@labs.com", :pass => "supersekritpassword" } }
     let( :vsphere_helper ) { VsphereHelper.new ( vInfo.merge( { :logger => logger } ) ) }
-    let( :snaplist )       { { 'snap1' => { 'snap1sub1' => nil , 
-                                            'snap1sub2' => nil }, 
+    let( :snaplist )       { { 'snap1' => { 'snap1sub1' => nil ,
+                                            'snap1sub2' => nil },
                                'snap2' => nil,
-                               'snap3' => { 'snap3sub1' => nil , 
+                               'snap3' => { 'snap3sub1' => nil ,
                                             'snap3sub2' => nil ,
                                             'snap3sub3' => nil } } }
-    let( :vms )            {  [ MockRbVmomiVM.new( 'mockvm1', snaplist ), 
-                                MockRbVmomiVM.new( 'mockvm2', snaplist ), 
+    let( :vms )            {  [ MockRbVmomiVM.new( 'mockvm1', snaplist ),
+                                MockRbVmomiVM.new( 'mockvm2', snaplist ),
                                 MockRbVmomiVM.new( 'mockvm3', snaplist ) ] }
-
-                                                
 
     before :each do
      stub_const( "RbVmomi", MockRbVmomi )
     end
 
-    describe "#load_config" do 
+    describe "#load_config" do
 
       it 'can load a .fog file' do
         allow( File ).to receive( :exists? ).and_return( true )
@@ -78,7 +76,9 @@ module Beaker
 
    describe "#find_datastore" do
      it 'finds the datastore from the connection object' do
-       expect(vsphere_helper.find_datastore( 'datastorename' ) ).to be === true
+       connection = vsphere_helper.instance_variable_get( :@connection )
+       dc = connection.serviceInstance.find_datacenter('testdc')
+       expect(vsphere_helper.find_datastore( dc,'datastorename' ) ).to be === true
      end
 
    end
@@ -86,8 +86,7 @@ module Beaker
    describe "#find_folder" do
      it 'can find a folder in the datacenter' do
        connection = vsphere_helper.instance_variable_get( :@connection )
-
-       expect(vsphere_helper.find_folder( 'root' ) ).to be === connection.serviceInstance.find_datacenter.vmFolder
+       expect(vsphere_helper.find_folder( 'testdc','root' ) ).to be === connection.serviceInstance.find_datacenter('testdc').vmFolder
      end
 
    end
@@ -95,26 +94,28 @@ module Beaker
    describe "#find_pool" do
      it 'can find a pool in a folder in the datacenter' do
        connection = vsphere_helper.instance_variable_get( :@connection )
-       connection.serviceInstance.find_datacenter.hostFolder = MockRbVmomi::VIM::Folder.new
-       connection.serviceInstance.find_datacenter.hostFolder.name = "/root"
+       dc = connection.serviceInstance.find_datacenter('testdc')
+       dc.hostFolder = MockRbVmomi::VIM::Folder.new
+       dc.hostFolder.name = "/root"
 
-       expect(vsphere_helper.find_pool( 'root' ) ).to be === connection.serviceInstance.find_datacenter.hostFolder
+       expect(vsphere_helper.find_pool( 'testdc','root' ) ).to be === connection.serviceInstance.find_datacenter('testdc').hostFolder
 
      end
      it 'can find a pool in a clustercomputeresource in the datacenter' do
        connection = vsphere_helper.instance_variable_get( :@connection )
-       connection.serviceInstance.find_datacenter.hostFolder = MockRbVmomi::VIM::ClusterComputeResource.new
-       connection.serviceInstance.find_datacenter.hostFolder.name = "/root"
+       dc = connection.serviceInstance.find_datacenter('testdc')
+       dc.hostFolder = MockRbVmomi::VIM::ClusterComputeResource.new
+       dc.hostFolder.name = "/root"
 
-       expect(vsphere_helper.find_pool( 'root' ) ).to be === connection.serviceInstance.find_datacenter.hostFolder
-
+       expect(vsphere_helper.find_pool( 'testdc','root' ) ).to be === connection.serviceInstance.find_datacenter('testdc').hostFolder
      end
      it 'can find a pool in a resourcepool in the datacenter' do
        connection = vsphere_helper.instance_variable_get( :@connection )
-       connection.serviceInstance.find_datacenter.hostFolder = MockRbVmomi::VIM::ResourcePool.new
-       connection.serviceInstance.find_datacenter.hostFolder.name = "/root"
+       dc = connection.serviceInstance.find_datacenter('testdc')
+       dc.hostFolder = MockRbVmomi::VIM::ResourcePool.new
+       dc.hostFolder.name = "/root"
 
-       expect(vsphere_helper.find_pool( 'root' ) ).to be === connection.serviceInstance.find_datacenter.hostFolder
+       expect(vsphere_helper.find_pool( 'testdc','root' ) ).to be === connection.serviceInstance.find_datacenter('testdc').hostFolder
      end
 
    end

--- a/spec/mock_vsphere.rb
+++ b/spec/mock_vsphere.rb
@@ -183,7 +183,7 @@ class MockRbVmomiConnection
       @datacenter = Datacenter.new
     end
 
-    def find_datacenter
+    def find_datacenter dc
       @datacenter
     end
 
@@ -258,6 +258,7 @@ class MockRbVmomi
         self
       end
 
+
       def childEntity
         self
       end
@@ -266,6 +267,9 @@ class MockRbVmomi
         self
       end
 
+      def traverse path, type=Object, create=false
+        self
+      end
     end
 
     class ResourcePool

--- a/spec/mock_vsphere_helper.rb
+++ b/spec/mock_vsphere_helper.rb
@@ -160,15 +160,15 @@ class MockVsphereHelper
     nil
   end
 
-  def find_datastore datastore
+  def find_datastore dc,datastore
     datastore
   end
 
-  def find_pool pool
+  def find_pool dc,pool
     pool
   end
 
-  def find_folder folder
+  def find_folder dc,folder
     folder
   end
 


### PR DESCRIPTION
Prior to this commit you couldn't specify the datacenter to search for a
given folder.  The `find_datacenter` method will return the first found
datacenter, and in the case that you have linked vcenters this falls
apart.  This commit adds the ability for `datacenter` to be included in
@options.  Related, folder search now respects datacenter as well as
uses the traverse method.  Prior to this commit some folder searches
were not possible (for example a base level because it didn't contain a
`/` which was being split on).

Other minor updates; docs updated and template can be provided as ENV var.