### PR TITLE
(BKR-1092) Keystone V3 Support

### DIFF
--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -156,5 +156,31 @@ module Beaker
       openstack.provision_storage mock_host, mock_vm
     end
 
+    it 'supports keystone v2' do
+      credentials = openstack.instance_eval('@credentials')
+      expect(credentials[:openstack_user_domain]).to be_nil
+      expect(credentials[:openstack_project_domain]).to be_nil
+    end
+
+    it 'supports keystone v3 with implicit arguments' do
+      v3_options = options
+      v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
+
+      credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
+      expect(credentials[:openstack_user_domain]).to eq('Default')
+      expect(credentials[:openstack_project_domain]).to eq('Default')
+    end
+
+    it 'supports keystone v3 with explicit arguments' do
+      v3_options = options
+      v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
+      v3_options[:openstack_user_domain] = 'acme.com'
+      v3_options[:openstack_project_domain] = 'R&D'
+
+      credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
+      expect(credentials[:openstack_user_domain]).to eq('acme.com')
+      expect(credentials[:openstack_project_domain]).to eq('R&D')
+    end
+
   end
 end


### PR DESCRIPTION
Primary change is to add in optional user and project domain names for authentication
against a Keystone V3 endpoint.  The secondary change is to tidy up how keystone
credentials are handled as there was a whole bunch of duplication.  If there is any
concern around the disappearing conditional protecting the region selection worry not
as Fog checks for nil before populating the authentication request body.