### PR TITLE
(BKR-1093) Fix Nova Keypair Generation

### DIFF
--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -84,7 +84,7 @@ module Beaker
       openstack.provision
 
       @hosts.each do |host|
-        expect(host[:keyname]).to match(/[_\-0-9a-zA-Z]+/)
+        expect(host[:keyname]).to match(/^[_\-0-9a-zA-Z]+$/)
       end
     end
 


### PR DESCRIPTION
Firstly this fixes the rspec test that doesn't work, shame on me.  Secondly it
ensures only the hostname part of the host's FQDN is used in keypair generation,
as the FQDN includes periods and is illegal according to Nova.