### PR TITLE
vagrant ssh user and password

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -35,7 +35,14 @@ module Beaker
       #generate the VagrantFile
       v_file = "Vagrant.configure(\"2\") do |c|\n"
       v_file << "  c.ssh.forward_agent = true\n" if options[:forward_ssh_agent] == true
-      v_file << "  c.ssh.insert_key = false\n"
+      if !options['ssh_username'].nil? and !options['ssh_password'].nil?
+        v_file << "  c.ssh.insert_key = true\n"
+        v_file << "  c.ssh.username = '#{options['ssh_username']}'\n"
+        v_file << "  c.ssh.password = '#{options['ssh_password']}'\n"
+        # v_file << "  c.ssh."
+      else
+        v_file << "  c.ssh.insert_key = false\n"
+      end
       hosts.each do |host|
         host['ip'] ||= randip #use the existing ip, otherwise default to a random ip
         v_file << "  c.vm.define '#{host.name}' do |v|\n"


### PR DESCRIPTION
if an ssh user and password is defined in the config section of the node definition, beaker will add the proper ssh options to the generated Vagrant file instead of forcing the use of pre-seeded keys