### PR TITLE
(maint) Ruby 2.1 in Windows git acceptance tests

### DIFF
--- a/acceptance/pre_suite/puppet_git/install.rb
+++ b/acceptance/pre_suite/puppet_git/install.rb
@@ -56,9 +56,9 @@ hosts.each do |host|
     step "#{host} Selected architecture #{arch}"
 
     revision = if arch == 'x64'
-                 '2.0.0-x64'
+                 '2.1.x-x64'
                else
-                 '1.9.3-x86'
+                 '2.1.x-x86'
                end
 
     step "#{host} Install ruby from git using revision #{revision}"


### PR DESCRIPTION
 - When Ruby < 2.0.0, Puppet will issue warnings.  This was changed
   in 2015 in the Puppet repository pre-suite, but looks to have
   never been changed in Beaker.

   https://github.com/puppetlabs/puppet/commit/e7f0cef0d50d7ded9659c7c8a81b0f6ea3aeca90