### PR TITLE
(BKR-954) Add Ability to Disable Openstack Volume Management

### DIFF
--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -152,3 +152,15 @@ volume size in MB.
             size: 10000
           journal:
             size: 1000
+
+
+In the event your using an OpenStack instance that does not deploy the volume service you can disable that functionality to prevent beaker runs from failing.  Either using an ENV variable or setting the following value in the `CONFIG` section of your hosts file(valid values are `true` or `false`):
+
+```
+openstack_volume_support: false
+```
+
+You can also configure this setting via an environment variable:
+
+```
+export OS_VOL_SUPPORT=false

--- a/docs/how_to/hypervisors/openstack.md
+++ b/docs/how_to/hypervisors/openstack.md
@@ -154,7 +154,7 @@ volume size in MB.
             size: 1000
 
 
-In the event your using an OpenStack instance that does not deploy the volume service you can disable that functionality to prevent beaker runs from failing.  Either using an ENV variable or setting the following value in the `CONFIG` section of your hosts file(valid values are `true` or `false`):
+In the event you're using an OpenStack instance that does not deploy the volume service you can disable that functionality to prevent beaker runs from failing.  Either using an ENV variable or setting the following value in the `CONFIG` section of your hosts file(valid values are `true` or `false`):
 
 ```
 openstack_volume_support: false
@@ -163,4 +163,4 @@ openstack_volume_support: false
 You can also configure this setting via an environment variable:
 
 ```
-export OS_VOL_SUPPORT=false
+export OS_VOLUME_SUPPORT=false

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -63,6 +63,17 @@ module Beaker
         raise "Unable to create OpenStack Network instance (api_key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]})"
       end
 
+      # Validate openstack_volume_support setting value, reset to boolean if passed via ENV value string
+      if not @options[:openstack_volume_support].is_a?(TrueClass) || @options[:openstack_volume_support].is_a?(FalseClass)
+        if @options[:openstack_volume_support].match(/\btrue\b/i)
+          @options[:openstack_volume_support] = true
+        elsif @options[:openstack_volume_support].match(/\bfalse\b/i)
+          @options[:openstack_volume_support] = false
+        else
+          raise "Invalid value provided for CONFIG setting openstack_volume_support, current value #{@options[:openstack_volume_support]}"
+        end
+      end
+
     end
 
     #Provided a flavor name return the OpenStack id for that flavor
@@ -229,7 +240,6 @@ module Beaker
         vm = @compute_client.servers.create(options)
 
         #wait for the new instance to start up
-        start = Time.now
         try = 1
         attempts = @options[:timeout].to_i / SLEEPWAIT
 
@@ -266,7 +276,8 @@ module Beaker
         #enable root if user is not root
         enable_root(host)
 
-        provision_storage(host, vm)
+        provision_storage(host, vm) if @options[:openstack_volume_support]
+        @logger.notify "OpenStack Volume Support Disabled, can't provision volumes" if not @options[:openstack_volume_support]
       end
 
       hack_etc_hosts @hosts, @options
@@ -277,7 +288,7 @@ module Beaker
     def cleanup
       @logger.notify "Cleaning up OpenStack"
       @vms.each do |vm|
-        cleanup_storage(vm)
+        cleanup_storage(vm) if @options[:openstack_volume_support]
         @logger.debug "Release floating IPs for OpenStack host #{vm.name}"
         floating_ips = vm.all_addresses # fetch and release its floating IPs
         floating_ips.each do |address|

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -64,15 +64,9 @@ module Beaker
       end
 
       # Validate openstack_volume_support setting value, reset to boolean if passed via ENV value string
-      if not @options[:openstack_volume_support].is_a?(TrueClass) || @options[:openstack_volume_support].is_a?(FalseClass)
-        if @options[:openstack_volume_support].match(/\btrue\b/i)
-          @options[:openstack_volume_support] = true
-        elsif @options[:openstack_volume_support].match(/\bfalse\b/i)
-          @options[:openstack_volume_support] = false
-        else
-          raise "Invalid value provided for CONFIG setting openstack_volume_support, current value #{@options[:openstack_volume_support]}"
-        end
-      end
+      @options[:openstack_volume_support] = true  if @options[:openstack_volume_support].to_s.match(/\btrue\b/i)
+      @options[:openstack_volume_support] = false if @options[:openstack_volume_support].to_s.match(/\bfalse\b/i)
+      [true,false].include? @options[:openstack_volume_support] or raise "Invalid openstack_volume_support setting, current: @options[:openstack_volume_support]"
 
     end
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -134,7 +134,7 @@ module Beaker
           :openstack_keyname      => ENV['OS_KEYNAME'],
           :openstack_network      => ENV['OS_NETWORK'],
           :openstack_region       => ENV['OS_REGION'],
-          :openstack_volume_support => ENV['OS_VOL_SUPPORT'] || true,
+          :openstack_volume_support => ENV['OS_VOLUME_SUPPORT'] || true,
           :jenkins_build_url      => nil,
           :validate               => true,
           :configure              => true,

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -134,6 +134,7 @@ module Beaker
           :openstack_keyname      => ENV['OS_KEYNAME'],
           :openstack_network      => ENV['OS_NETWORK'],
           :openstack_region       => ENV['OS_REGION'],
+          :openstack_volume_support => ENV['OS_VOL_SUPPORT'] || true,
           :jenkins_build_url      => nil,
           :validate               => true,
           :configure              => true,

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -20,167 +20,219 @@ module Beaker
       allow( Fog::Network ).to receive( :new ).and_return( @network_client )
     end
 
-    it 'check openstack options during initialization' do
-      options = openstack.instance_eval('@options')
-      expect(options['openstack_api_key']).to eq('P1as$w0rd')
-      expect(options['openstack_username']).to eq('user')
-      expect(options['openstack_auth_url']).to eq('http://openstack_hypervisor.labs.net:5000/v2.0/tokens')
-      expect(options['openstack_tenant']).to eq('testing')
-      expect(options['openstack_network']).to eq('testing')
-      expect(options['openstack_keyname']).to eq('nopass')
-      expect(options['security_group']).to eq(['my_sg', 'default'])
-      expect(options['floating_ip_pool']).to eq('my_pool')
-    end
+    context 'keystone version support' do
+      it 'supports keystone v2' do
+        credentials = openstack.instance_eval('@credentials')
+        expect(credentials[:openstack_user_domain]).to be_nil
+        expect(credentials[:openstack_project_domain]).to be_nil
+      end
 
-    it 'check hosts options during initialization' do
-      hosts = openstack.instance_eval('@hosts')
-      @hosts.each do |host|
-        expect(host['image']).to eq('default_image')
-        expect(host['flavor']).to eq('m1.large')
-        expect(host['user_data']).to eq('#cloud-config\nmanage_etc_hosts: true\nfinal_message: "The host is finally up!"')
+      it 'supports keystone v3 with implicit arguments' do
+        v3_options = options
+        v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
+
+        credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
+        expect(credentials[:openstack_user_domain]).to eq('Default')
+        expect(credentials[:openstack_project_domain]).to eq('Default')
+      end
+
+      it 'supports keystone v3 with explicit arguments' do
+        v3_options = options
+        v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
+        v3_options[:openstack_user_domain] = 'acme.com'
+        v3_options[:openstack_project_domain] = 'R&D'
+
+        credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
+        expect(credentials[:openstack_user_domain]).to eq('acme.com')
+        expect(credentials[:openstack_project_domain]).to eq('R&D')
       end
     end
 
-    it 'check host options during server creation' do
+    describe '#provision' do
 
-      mock_flavor = Object.new
-      allow( mock_flavor ).to receive( :id ).and_return( 12345 )
-      allow( openstack ).to receive( :flavor ).and_return( mock_flavor )
-      expect( openstack ).to receive( :flavor ).with( 'm1.large' )
-
-      mock_image = Object.new
-      allow( mock_image ).to receive( :id ).and_return( 54321 )
-      allow( openstack ).to receive( :image ).and_return( mock_image )
-      expect( openstack ).to receive( :image ).with( 'default_image' )
-
-      mock_servers = double().as_null_object
-      allow( @compute_client ).to receive( :servers ).and_return( mock_servers )
-
-      expect(mock_servers).to receive(:create).with(hash_including(
-        :user_data => '#cloud-config\nmanage_etc_hosts: true\nfinal_message: "The host is finally up!"',
-        :flavor_ref => 12345,
-        :image_ref => 54321)
-      )
-
-      @hosts.each do |host|
-        allow(host).to receive(:wait_for_port).and_return(true)
+      it 'check openstack options during initialization' do
+        options = openstack.instance_eval('@options')
+        expect(options['openstack_api_key']).to eq('P1as$w0rd')
+        expect(options['openstack_username']).to eq('user')
+        expect(options['openstack_auth_url']).to eq('http://openstack_hypervisor.labs.net:5000/v2.0/tokens')
+        expect(options['openstack_tenant']).to eq('testing')
+        expect(options['openstack_network']).to eq('testing')
+        expect(options['openstack_keyname']).to eq('nopass')
+        expect(options['security_group']).to eq(['my_sg', 'default'])
+        expect(options['floating_ip_pool']).to eq('my_pool')
       end
 
-      openstack.provision
-    end
-
-    it 'generates valid keynames during server creation' do
-      # Simulate getting a dynamic IP from OpenStack to test key generation code
-      # after provisioning. See _validate_new_key_pair in openstack/nova for reference
-      mock_ip = double().as_null_object
-      allow( openstack ).to receive( :get_ip ).and_return( mock_ip )
-      allow( mock_ip ).to receive( :ip ).and_return( '172.16.0.1' )
-      openstack.instance_eval('@options')['openstack_keyname'] = nil
-
-      @hosts.each do |host|
-        allow(host).to receive(:wait_for_port).and_return(true)
+      it 'check hosts options during initialization' do
+        @hosts.each do |host|
+          expect(host['image']).to eq('default_image')
+          expect(host['flavor']).to eq('m1.large')
+          expect(host['user_data']).to eq('#cloud-config\nmanage_etc_hosts: true\nfinal_message: "The host is finally up!"')
+        end
       end
 
-      openstack.provision
+      it 'check host options during server creation' do
 
-      @hosts.each do |host|
-        expect(host[:keyname]).to match(/^[_\-0-9a-zA-Z]+$/)
+        mock_flavor = Object.new
+        allow( mock_flavor ).to receive( :id ).and_return( 12345 )
+        allow( openstack ).to receive( :flavor ).and_return( mock_flavor )
+        expect( openstack ).to receive( :flavor ).with( 'm1.large' )
+
+        mock_image = Object.new
+        allow( mock_image ).to receive( :id ).and_return( 54321 )
+        allow( openstack ).to receive( :image ).and_return( mock_image )
+        expect( openstack ).to receive( :image ).with( 'default_image' )
+
+        mock_servers = double().as_null_object
+        allow( @compute_client ).to receive( :servers ).and_return( mock_servers )
+
+        expect(mock_servers).to receive(:create).with(hash_including(
+          :user_data => '#cloud-config\nmanage_etc_hosts: true\nfinal_message: "The host is finally up!"',
+          :flavor_ref => 12345,
+          :image_ref => 54321)
+        )
+
+        @hosts.each do |host|
+          allow(host).to receive(:wait_for_port).and_return(true)
+        end
+
+        openstack.provision
+      end
+
+      it 'generates valid keynames during server creation' do
+        # Simulate getting a dynamic IP from OpenStack to test key generation code
+        # after provisioning. See _validate_new_key_pair in openstack/nova for reference
+        mock_ip = double().as_null_object
+        allow( openstack ).to receive( :get_ip ).and_return( mock_ip )
+        allow( mock_ip ).to receive( :ip ).and_return( '172.16.0.1' )
+        openstack.instance_eval('@options')['openstack_keyname'] = nil
+
+        @hosts.each do |host|
+          allow(host).to receive(:wait_for_port).and_return(true)
+        end
+
+        openstack.provision
+
+        @hosts.each do |host|
+          expect(host[:keyname]).to match(/^[_\-0-9a-zA-Z]+$/)
+        end
+      end
+
+      it 'get_ip always allocates a new floatingip' do
+        # Assume beaker is being executed in parallel N times by travis (or similar).
+        # IPs are allocated (but not associated) before an instance is created; it is
+        # hightly possible the first instance will allocate a new IP and create an ssh
+        # key.  While the instance is being created the other N-1 instances come along,
+        # find the unused IP and try to use it as well which causes keyname clashes
+        # and other IP related shenannigans.  Ensure we allocate a new IP each and every
+        # time
+        mock_addresses = double().as_null_object
+        mock_ip = double().as_null_object
+        allow(@compute_client).to receive(:addresses).and_return(mock_addresses)
+        allow(mock_addresses).to receive(:create).and_return(mock_ip)
+        expect(mock_addresses).to receive(:create).exactly(3).times
+        (1..3).each { openstack.get_ip }
+      end
+
+      context 'volume creation option' do
+        it 'provisions volume by default' do
+          mock_flavor = Object.new
+          allow( mock_flavor ).to receive( :id ).and_return( 12345 )
+          allow( openstack ).to receive( :flavor ).and_return( mock_flavor )
+          mock_image = Object.new
+          allow( mock_image ).to receive( :id ).and_return( 54321 )
+          allow( openstack ).to receive( :image ).and_return( mock_image )
+          mock_servers = double().as_null_object
+          allow( @compute_client ).to receive( :servers ).and_return( mock_servers )
+
+          @hosts.each do |host|
+            allow(host).to receive(:wait_for_port).and_return(true)
+            expect(openstack).to receive(:provision_storage)
+          end
+
+          openstack.provision
+        end
+
+        it 'skips provisioning when disabled' do
+          mock_flavor = Object.new
+          allow( mock_flavor ).to receive( :id ).and_return( 12345 )
+          allow( openstack ).to receive( :flavor ).and_return( mock_flavor )
+          mock_image = Object.new
+          allow( mock_image ).to receive( :id ).and_return( 54321 )
+          allow( openstack ).to receive( :image ).and_return( mock_image )
+          mock_servers = double().as_null_object
+          allow( @compute_client ).to receive( :servers ).and_return( mock_servers )
+
+          openstack.instance_eval('@options')['openstack_volume_support'] = false
+
+          @hosts.each do |host|
+            allow(host).to receive(:wait_for_port).and_return(true)
+            expect(openstack).not_to receive(:provision_storage)
+          end
+
+          openstack.provision
+        end
       end
     end
 
-    it 'get_ip always allocates a new floatingip' do
-      # Assume beaker is being executed in parallel N times by travis (or similar).
-      # IPs are allocated (but not associated) before an instance is created; it is
-      # hightly possible the first instance will allocate a new IP and create an ssh
-      # key.  While the instance is being created the other N-1 instances come along,
-      # find the unused IP and try to use it as well which causes keyname clashes
-      # and other IP related shenannigans.  Ensure we allocate a new IP each and every
-      # time
-      mock_addresses = double().as_null_object
-      mock_ip = double().as_null_object
-      allow(@compute_client).to receive(:addresses).and_return(mock_addresses)
-      allow(mock_addresses).to receive(:create).and_return(mock_ip)
-      expect(mock_addresses).to receive(:create).exactly(3).times
-      (1..3).each { openstack.get_ip }
+    describe '#provision_storage' do
+
+      it 'creates volumes with cinder v1' do
+        # Mock a volume
+        allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
+
+        # Stub out the call to create the client and hard code the return value
+        allow(openstack).to receive(:volume_client_create).and_return(nil)
+        client = double().as_null_object
+        openstack.instance_variable_set(:@volume_client, client)
+        allow(openstack).to receive(:get_volume_api_version).and_return(1)
+
+        # Check the parameters are valid, correct 'name' parameter and correct size conversion
+        mock_volume = double().as_null_object
+        expect(client).to receive(:create).with(:display_name => 'volume1',
+                                                :description => 'Beaker volume: host=alan volume=volume1',
+                                                :size => 1000
+                                               ).and_return(mock_volume)
+        allow(mock_volume).to receive(:wait_for).and_return(nil)
+
+        # Perform the test!
+        mock_vm = double().as_null_object
+        allow(mock_volume).to receive(:id).and_return('Fake ID')
+        expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
+
+        mock_host = double().as_null_object
+        allow(mock_host).to receive(:name).and_return('alan')
+
+        openstack.provision_storage mock_host, mock_vm
+      end
+
+      it 'creates volumes with cinder v2' do
+        # Mock a volume
+        allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
+
+        # Stub out the call to create the client and hard code the return value
+        allow(openstack).to receive(:volume_client_create).and_return(nil)
+        client = double().as_null_object
+        openstack.instance_variable_set(:@volume_client, client)
+        allow(openstack).to receive(:get_volume_api_version).and_return(-1)
+
+        # Check the parameters are valid, correct 'name' parameter and correct size conversion
+        mock_volume = double().as_null_object
+        expect(client).to receive(:create).with(:name => 'volume1',
+                                                :description => 'Beaker volume: host=alan volume=volume1',
+                                                :size => 1000
+                                               ).and_return(mock_volume)
+        allow(mock_volume).to receive(:wait_for).and_return(nil)
+
+        # Perform the test!
+        mock_vm = double().as_null_object
+        allow(mock_volume).to receive(:id).and_return('Fake ID')
+        expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
+
+        mock_host = double().as_null_object
+        allow(mock_host).to receive(:name).and_return('alan')
+
+        openstack.provision_storage mock_host, mock_vm
+      end
     end
-
-    it 'creates volumes with cinder v1' do
-      # Mock a volume
-      allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
-
-      # Stub out the call to create the client and hard code the return value
-      allow(openstack).to receive(:volume_client_create).and_return(nil)
-      client = double().as_null_object
-      openstack.instance_variable_set(:@volume_client, client)
-      allow(openstack).to receive(:get_volume_api_version).and_return(1)
-
-      # Check the parameters are valid, correct 'name' parameter and correct size conversion
-      mock_volume = double().as_null_object
-      expect(client).to receive(:create).with(:display_name => 'volume1', :description => 'Beaker volume: host=alan volume=volume1', :size => 1000).and_return(mock_volume)
-      allow(mock_volume).to receive(:wait_for).and_return(nil)
-
-      # Perform the test!
-      mock_vm = double().as_null_object
-      allow(mock_volume).to receive(:id).and_return('Fake ID')
-      expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
-
-      mock_host = double().as_null_object
-      allow(mock_host).to receive(:name).and_return('alan')
-
-      openstack.provision_storage mock_host, mock_vm
-    end
-
-    it 'creates volumes with cinder v2' do
-      # Mock a volume
-      allow(openstack).to receive(:get_volumes).and_return({'volume1' => {'size' => 1000000 }})
-
-      # Stub out the call to create the client and hard code the return value
-      allow(openstack).to receive(:volume_client_create).and_return(nil)
-      client = double().as_null_object
-      openstack.instance_variable_set(:@volume_client, client)
-      allow(openstack).to receive(:get_volume_api_version).and_return(-1)
-
-      # Check the parameters are valid, correct 'name' parameter and correct size conversion
-      mock_volume = double().as_null_object
-      expect(client).to receive(:create).with(:name => 'volume1', :description => 'Beaker volume: host=alan volume=volume1', :size => 1000).and_return(mock_volume)
-      allow(mock_volume).to receive(:wait_for).and_return(nil)
-
-      # Perform the test!
-      mock_vm = double().as_null_object
-      allow(mock_volume).to receive(:id).and_return('Fake ID')
-      expect(mock_vm).to receive(:attach_volume).with('Fake ID', '/dev/vdb')
-
-      mock_host = double().as_null_object
-      allow(mock_host).to receive(:name).and_return('alan')
-
-      openstack.provision_storage mock_host, mock_vm
-    end
-
-    it 'supports keystone v2' do
-      credentials = openstack.instance_eval('@credentials')
-      expect(credentials[:openstack_user_domain]).to be_nil
-      expect(credentials[:openstack_project_domain]).to be_nil
-    end
-
-    it 'supports keystone v3 with implicit arguments' do
-      v3_options = options
-      v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
-
-      credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
-      expect(credentials[:openstack_user_domain]).to eq('Default')
-      expect(credentials[:openstack_project_domain]).to eq('Default')
-    end
-
-    it 'supports keystone v3 with explicit arguments' do
-      v3_options = options
-      v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
-      v3_options[:openstack_user_domain] = 'acme.com'
-      v3_options[:openstack_project_domain] = 'R&D'
-
-      credentials = OpenStack.new(@hosts, v3_options).instance_eval('@credentials')
-      expect(credentials[:openstack_user_domain]).to eq('acme.com')
-      expect(credentials[:openstack_project_domain]).to eq('R&D')
-    end
-
   end
 end


### PR DESCRIPTION
Prior to this commit beaker openstack support assumed that the
`volumes` service was provisioned.  This service is not always
available in an Openstack deployment.  This commit gives you the
option to disable that functionality.  If you do not disable it
on an instance that does not publish this functionality, even if
you don't configure the volumes setting in `CONFIG`, beaker runs
will fail.