### PR TITLE
(BKR-222) docker support for systemd based OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ script: "bundle exec rake travis"
 notifications:
   email: false
 rvm:
-  - 2.0.0
-  - 1.9.3
-  - 1.8.7-p374
+  - 2.1.0
+  - 2.3.1

--- a/acceptance/tests/base/external_resources_test.rb
+++ b/acceptance/tests/base/external_resources_test.rb
@@ -1,9 +1,11 @@
 test_name 'External Resources Test' do
   step 'Verify EPEL resources are up and available' do
     def epel_url_test(el_version)
-      url = "#{options[:epel_url]}/epel-release-latest-#{el_version}.noarch.rpm"
+      url_base = options[:epel_url]
+      url_base = options[:epel_url_archive] if el_version == 5
+      url = "#{url_base}/epel-release-latest-#{el_version}.noarch.rpm"
       curl_headers_result = default.exec(Command.new("curl -I #{url}"))
-      assert_match(/200 OK/, curl_headers_result.stdout, "EPEL #{el_version} should be reachable")
+      assert_match(/200 OK/, curl_headers_result.stdout, "EPEL #{el_version} should be reachable at #{url}")
     end
 
     step 'Verify el_version numbers 5,6,7 are found on the epel resource' do

--- a/docs/how_to/hypervisors/vmpooler.md
+++ b/docs/how_to/hypervisors/vmpooler.md
@@ -18,6 +18,23 @@ An example of a `.fog` file with just the vmpooler details is below:
 :default:
   :vmpooler_token: 'randomtokentext'
 ```
+# Additional Disks
+Using the vmpooler API, Beaker enables you to attach additional storage disks in the host configuration file. The disks are added at the time the VM is created. Logic for using the disk must go into your tests.
+
+Simply add the `disks` key and a list containing the sizes(in GB) of the disks you want to create and attach to that host.
+For example, to create 2 disks sized 8GB and 16GB to example-box:
+
+```yaml
+ example-box:
+    disks:
+      - 8
+      - 16
+    roles:
+      - satellite
+    platform: el-7-x86_64
+    hypervisor: vmpooler
+    template: redhat-7-x86_64
+```
 
 Users with Puppet credentials can follow our instructions for getting & using
 vmpooler tokens in our

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -167,7 +167,11 @@ module Unix::Exec
     when /debian|ubuntu|cumulus|huaweios/
       exec(Beaker::Command.new("service ssh restart"))
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
-      exec(Beaker::Command.new("systemctl restart sshd.service"))
+      if self['hypervisor'] == 'docker'
+        exec(Beaker::Command.new("/bin/kill -HUP `cat /var/run/sshd.pid`"))
+      else
+        exec(Beaker::Command.new("systemctl restart sshd.service"))
+      end
     when /el-|centos|fedora|redhat|oracle|scientific|eos/
       exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -164,16 +164,8 @@ module Unix::Exec
   # @return [Result] result of restarting the SSH service
   def ssh_service_restart
     case self['platform']
-    when /debian|ubuntu|cumulus|huaweios/
-      exec(Beaker::Command.new("service ssh restart"))
-    when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
-      if self['hypervisor'] == 'docker'
+    when /debian|ubuntu|cumulus|huaweios|el-|centos-|redhat-|oracle-|scientific-|eos|fedora-|archlinux-/
         exec(Beaker::Command.new("/bin/kill -HUP `cat /var/run/sshd.pid`"))
-      else
-        exec(Beaker::Command.new("systemctl restart sshd.service"))
-      end
-    when /el-|centos|fedora|redhat|oracle|scientific|eos/
-      exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/
       exec(Beaker::Command.new("rcsshd restart"))
     when /solaris/

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -440,7 +440,11 @@ module Beaker
         if host['platform'] =~ /debian|ubuntu|cumulus/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|fedora-(1[4-9]|2[0-9])/
-          host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
+          if host['hypervisor'] = "docker"
+            host.exec(Command.new("/bin/kill -HUP `cat /var/run/sshd.pid`"), {:pty => true})
+          else
+            host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
+          end
         elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
           host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
         elsif host['platform'] =~ /(free|open)bsd/

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -255,9 +255,11 @@ module Beaker
         when el_based?(host) && ['5','6','7'].include?(host['platform'].version)
           result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
           if result.exit_code == 1
-            host.exec(Command.new("rpm -i#{debug_opt} #{opts[:epel_url]}/epel-release-latest-#{host['platform'].version}.noarch.rpm"))
+            url_base = opts[:epel_url]
+            url_base = opts[:epel_url_archive] if host['platform'].version == '5'
+            host.exec(Command.new("rpm -i#{debug_opt} #{url_base}/epel-release-latest-#{host['platform'].version}.noarch.rpm"))
             #update /etc/yum.repos.d/epel.repo for new baseurl
-            host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{opts[:epel_url]}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))
+            host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{url_base}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))
             #remove mirrorlist
             host.exec(Command.new("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"))
             host.exec(Command.new('yum clean all && yum makecache'))

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -436,17 +436,10 @@ module Beaker
         else
           host.exec(Command.new("sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\""), {:pty => true})
         end
+
         #restart sshd
-        if host['platform'] =~ /debian|ubuntu|cumulus/
-          host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
-        elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|fedora-(1[4-9]|2[0-9])/
-          if host['hypervisor'] = "docker"
-            host.exec(Command.new("/bin/kill -HUP `cat /var/run/sshd.pid`"), {:pty => true})
-          else
-            host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
-          end
-        elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
-          host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
+        if host['platform'] =~ /debian|ubuntu|cumulus|arch|centos|el-|redhat|fedora|eos/
+          host.exec(Command.new("/bin/kill -HUP `cat /var/run/sshd.pid`"), {:pty => true})
         elsif host['platform'] =~ /(free|open)bsd/
           host.exec(Command.new("sudo /etc/rc.d/sshd restart"))
         elsif host['platform'] =~ /solaris/

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -195,15 +195,9 @@ module Beaker
           ENV container docker
         EOF
 
-        # additional options to specify to the sshd
-        # may vary by platform
-        sshd_options = ''
-
         # add platform-specific actions
-        service_name = "sshd"
         case host['platform']
         when /ubuntu/, /debian/
-          service_name = "ssh"
           dockerfile += <<-EOF
             RUN apt-get update
             RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES.join(' ')}

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -264,7 +264,7 @@ module Beaker
 
         # How to start a sshd on port 22.  May be an init for more supervision
         # Ensure that the ssh server can be restarted (done from set_env) and container keeps running
-        cmd = host['docker_cmd'] || ["sh","-c","service #{service_name} start ; tail -f /dev/null"]
+        cmd = host['docker_cmd'] || ["sh","-c","/usr/sbin/sshd; tail -f /dev/null"]
         dockerfile += <<-EOF
           EXPOSE 22
           CMD #{cmd}
@@ -286,7 +286,7 @@ module Beaker
       container.exec(['sed','-ri',
                       's/^#?PasswordAuthentication .*/PasswordAuthentication yes/',
                       '/etc/ssh/sshd_config'])
-      container.exec(%w(service ssh restart))
+      container.exec(%w(/bin/kill -HUP `cat /var/run/sshd.pid`))
     end
 
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -172,6 +172,7 @@ module Beaker
           :package_proxy          => false,
           :add_el_extras          => false,
           :epel_url               => "http://dl.fedoraproject.org/pub/epel",
+          :epel_url_archive       => 'http://archive.fedoraproject.org/pub/archive/epel',
           :consoleport            => 443,
           :pe_dir                 => '/opt/enterprise/dists',
           :pe_version_file        => 'LATEST',

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module Version
-    STRING = '3.14.0'
+    STRING = '3.15.0'
   end
 end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -104,7 +104,7 @@ module Beaker
         it "calls the correct command for #{platform}" do
           opts['platform'] = platform 
           expect(instance).to receive(:exec)
-          expect(Beaker::Command).to receive(:new).with("systemctl restart sshd.service")
+          expect(Beaker::Command).to receive(:new).with("/bin/kill -HUP `cat /var/run/sshd.pid`")
           expect{instance.ssh_service_restart}.to_not raise_error
         end
       end
@@ -113,7 +113,7 @@ module Beaker
         it "calls the correct command for #{platform}" do
           opts['platform'] = platform
           expect(instance).to receive(:exec)
-          expect(Beaker::Command).to receive(:new).with("service ssh restart")
+          expect(Beaker::Command).to receive(:new).with("/bin/kill -HUP `cat /var/run/sshd.pid`")
           expect{instance.ssh_service_restart}.to_not raise_error
         end
       end
@@ -122,7 +122,7 @@ module Beaker
         it "calls the correct command for #{platform}" do
           opts['platform'] = "#{platform}-arch"
           expect(instance).to receive(:exec)
-          expect(Beaker::Command).to receive(:new).with("/sbin/service sshd restart")
+          expect(Beaker::Command).to receive(:new).with("/bin/kill -HUP `cat /var/run/sshd.pid`")
           expect{instance.ssh_service_restart}.to_not raise_error
         end
       end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -304,22 +304,53 @@ describe Beaker do
   context "add_el_extras" do
     subject { dummy_class.new }
 
-    it "add extras for el-5/6 hosts" do
+    it 'adds archived extras for el-5 hosts' do
 
-      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 6 )
-      hosts[0][:platform] = Beaker::Platform.new('el-6-arch')
+      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 2 )
+      hosts[1][:platform] = Beaker::Platform.new('oracle-5-arch')
+
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -qa | grep epel-release"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -i http://archive.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e 's;#baseurl.*$;baseurl=http://archive\\.fedoraproject\\.org/pub/archive/epel/5/$basearch;' /etc/yum.repos.d/epel.repo"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "yum clean all && yum makecache"
+      ).exactly( 2 ).times
+
+      subject.add_el_extras( hosts, options )
+
+    end
+
+    it 'adds extras for el-6 hosts' do
+
+      hosts = make_hosts( { :platform => Beaker::Platform.new('el-6-arch'), :exit_code => 1 }, 4 )
       hosts[1][:platform] = Beaker::Platform.new('centos-6-arch')
       hosts[2][:platform] = Beaker::Platform.new('scientific-6-arch')
       hosts[3][:platform] = Beaker::Platform.new('redhat-6-arch')
-      hosts[4][:platform] = Beaker::Platform.new('oracle-5-arch')
 
-      expect( Beaker::Command ).to receive( :new ).with("rpm -qa | grep epel-release").exactly( 6 ).times
-      expect( Beaker::Command ).to receive( :new ).with("rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm").exactly( 4 ).times
-      expect( Beaker::Command ).to receive( :new ).with("rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm").exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/6/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 4 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/5/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo").exactly( 6 ).times
-      expect( Beaker::Command ).to receive( :new ).with("yum clean all && yum makecache").exactly( 6 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -qa | grep epel-release"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/6/$basearch;' /etc/yum.repos.d/epel.repo"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "yum clean all && yum makecache"
+      ).exactly( 4 ).times
 
       subject.add_el_extras( hosts, options )
 

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -81,14 +81,14 @@ describe Beaker do
   ['debian','ubuntu','cumulus'].each do | deb_like |
     it_should_behave_like 'enables_root_login', deb_like, [
       "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\"",
-      "sudo su -c \"service ssh restart\""
+      "/bin/kill -HUP `cat /var/run/sshd.pid`"
     ]
   end
 
   ['centos','el-','redhat','fedora','eos'].each do | rhel_like |
     it_should_behave_like 'enables_root_login', rhel_like, [
       "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\"",
-      "sudo -E /sbin/service sshd reload"
+      "/bin/kill -HUP `cat /var/run/sshd.pid`"
     ]
   end
 

--- a/spec/beaker/hypervisor/vmpooler_spec.rb
+++ b/spec/beaker/hypervisor/vmpooler_spec.rb
@@ -60,6 +60,42 @@ module Beaker
       end
     end
 
+    describe '#disk_added?' do
+      let(:vmpooler) { Beaker::Vmpooler.new(make_hosts, make_opts) }
+      let(:response_hash_no_disk) {
+        {
+          "ok" => "true",
+          "hostname" => {
+            "template"=>"redhat-7-x86_64",
+            "domain"=>"delivery.puppetlabs.net"
+          }
+        }
+      }
+      let(:response_hash_disk) {
+        {
+          "ok" => "true",
+          "hostname" => {
+            "disk" => [
+              '+16gb',
+              '+8gb'
+            ],
+            "template"=>"redhat-7-x86_64",
+            "domain"=>"delivery.puppetlabs.net"
+          }
+        }
+      }
+      it 'returns false when there is no disk' do
+        host = response_hash_no_disk['hostname']
+        expect(vmpooler.disk_added?(host, "8", 0)).to be(false)
+      end
+
+      it 'returns true when there is a disk' do
+        host = response_hash_disk["hostname"]
+        expect(vmpooler.disk_added?(host, "16", 0)).to be(true)
+        expect(vmpooler.disk_added?(host, "8", 1)).to be(true)
+      end
+    end
+
     describe "#provision" do
 
       it 'provisions hosts from the pool' do


### PR DESCRIPTION
This Fixes espacially CentOS7 and most probably RHEL7 as well, as any other OS which is using sshd threw systemctl instead of init.d.

What happens inside the container currently:
```
[root@91ddf1f362e8 ~]# service sshd status 
-bash: service: command not found
[root@91ddf1f362e8 ~]# systemctl status sshd
Failed to get D-Bus connection: Operation not permitted
```

testable with: `docker run --rm -it centos:7 /bin/bash`

and installing sshd with:

```
$yum install -y openssh-server openssh-clients
$sshd-keygen
[...]
```

[1] https://rhatdan.wordpress.com/2014/04/30/running-systemd-within-a-docker-container/