### PR TITLE
BKR-1089 Fixing Custom Facts added to environment on Windows

### DIFF
--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -164,7 +164,7 @@ module PSWindows::Exec
 
     environment_string = ''
     env_array.each_with_index do |env|
-      environment_string += "set #{env} && "
+      environment_string += "set #{env}&& "
     end
     environment_string
   end


### PR DESCRIPTION
* This version of the fix removes the unnecessary space