### PR TITLE
(BKR-1102) install EPEL5 from archives

### DIFF
--- a/acceptance/tests/base/external_resources_test.rb
+++ b/acceptance/tests/base/external_resources_test.rb
@@ -1,9 +1,11 @@
 test_name 'External Resources Test' do
   step 'Verify EPEL resources are up and available' do
     def epel_url_test(el_version)
-      url = "#{options[:epel_url]}/epel-release-latest-#{el_version}.noarch.rpm"
+      url_base = options[:epel_url]
+      url_base = options[:epel_url_archive] if el_version == 5
+      url = "#{url_base}/epel-release-latest-#{el_version}.noarch.rpm"
       curl_headers_result = default.exec(Command.new("curl -I #{url}"))
-      assert_match(/200 OK/, curl_headers_result.stdout, "EPEL #{el_version} should be reachable")
+      assert_match(/200 OK/, curl_headers_result.stdout, "EPEL #{el_version} should be reachable at #{url}")
     end
 
     step 'Verify el_version numbers 5,6,7 are found on the epel resource' do

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -255,9 +255,11 @@ module Beaker
         when el_based?(host) && ['5','6','7'].include?(host['platform'].version)
           result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
           if result.exit_code == 1
-            host.exec(Command.new("rpm -i#{debug_opt} #{opts[:epel_url]}/epel-release-latest-#{host['platform'].version}.noarch.rpm"))
+            url_base = opts[:epel_url]
+            url_base = opts[:epel_url_archive] if host['platform'].version == '5'
+            host.exec(Command.new("rpm -i#{debug_opt} #{url_base}/epel-release-latest-#{host['platform'].version}.noarch.rpm"))
             #update /etc/yum.repos.d/epel.repo for new baseurl
-            host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{opts[:epel_url]}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))
+            host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{url_base}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))
             #remove mirrorlist
             host.exec(Command.new("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"))
             host.exec(Command.new('yum clean all && yum makecache'))

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -172,6 +172,7 @@ module Beaker
           :package_proxy          => false,
           :add_el_extras          => false,
           :epel_url               => "http://dl.fedoraproject.org/pub/epel",
+          :epel_url_archive       => 'http://archive.fedoraproject.org/pub/archive/epel',
           :consoleport            => 443,
           :pe_dir                 => '/opt/enterprise/dists',
           :pe_version_file        => 'LATEST',

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -304,22 +304,53 @@ describe Beaker do
   context "add_el_extras" do
     subject { dummy_class.new }
 
-    it "add extras for el-5/6 hosts" do
+    it 'adds archived extras for el-5 hosts' do
 
-      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 6 )
-      hosts[0][:platform] = Beaker::Platform.new('el-6-arch')
+      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 2 )
+      hosts[1][:platform] = Beaker::Platform.new('oracle-5-arch')
+
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -qa | grep epel-release"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -i http://archive.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e 's;#baseurl.*$;baseurl=http://archive\\.fedoraproject\\.org/pub/archive/epel/5/$basearch;' /etc/yum.repos.d/epel.repo"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"
+      ).exactly( 2 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "yum clean all && yum makecache"
+      ).exactly( 2 ).times
+
+      subject.add_el_extras( hosts, options )
+
+    end
+
+    it 'adds extras for el-6 hosts' do
+
+      hosts = make_hosts( { :platform => Beaker::Platform.new('el-6-arch'), :exit_code => 1 }, 4 )
       hosts[1][:platform] = Beaker::Platform.new('centos-6-arch')
       hosts[2][:platform] = Beaker::Platform.new('scientific-6-arch')
       hosts[3][:platform] = Beaker::Platform.new('redhat-6-arch')
-      hosts[4][:platform] = Beaker::Platform.new('oracle-5-arch')
 
-      expect( Beaker::Command ).to receive( :new ).with("rpm -qa | grep epel-release").exactly( 6 ).times
-      expect( Beaker::Command ).to receive( :new ).with("rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm").exactly( 4 ).times
-      expect( Beaker::Command ).to receive( :new ).with("rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-5.noarch.rpm").exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/6/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 4 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/5/$basearch;' /etc/yum.repos.d/epel.repo").exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with("sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo").exactly( 6 ).times
-      expect( Beaker::Command ).to receive( :new ).with("yum clean all && yum makecache").exactly( 6 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -qa | grep epel-release"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/6/$basearch;' /etc/yum.repos.d/epel.repo"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"
+      ).exactly( 4 ).times
+      expect( Beaker::Command ).to receive( :new ).with(
+        "yum clean all && yum makecache"
+      ).exactly( 4 ).times
 
       subject.add_el_extras( hosts, options )
 


### PR DESCRIPTION
EPEL5 has recently been moved to [archives](http://dl.fedoraproject.org/pub/epel/5/README).

This PR allows beaker to install from the archives, so that EL5 users can continue using EPEL.

@puppetlabs/beaker please review, automated testing should be starting soon.