### PR TITLE
(BKR-1113) do_scp_to now also copies files that start with a dot

### DIFF
--- a/acceptance/tests/base/dsl/helpers/host_helpers/scp_to_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/scp_to_test.rb
@@ -34,6 +34,19 @@ test_name "dsl::helpers::host_helpers #scp_to" do
     end
   end
 
+  step "#scp_to creates a dotfile on the remote system" do
+    Dir.mktmpdir do |local_dir|
+      local_filename, contents = create_local_file_from_fixture("simple_text_file", local_dir, ".testfile.txt")
+      remote_tmpdir = tmpdir_on default
+
+      scp_to default, local_filename, remote_tmpdir
+
+      remote_filename = File.join(remote_tmpdir, ".testfile.txt")
+      remote_contents = on(default, "cat #{remote_filename}").stdout
+      assert_equal contents, remote_contents
+    end
+  end
+
   step "#scp_to creates the file on all remote systems when a host array is provided" do
     Dir.mktmpdir do |local_dir|
       local_filename, contents = create_local_file_from_fixture("simple_text_file", local_dir, "testfile.txt")

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -438,7 +438,7 @@ module Beaker
           @logger.trace result.stdout
         end
       else # a directory with ignores
-        dir_source = Dir.glob("#{source}/**/*").reject do |f|
+        dir_source = Dir.glob("#{source}/**/{*,.*}").reject do |f|
           f.gsub(/\A#{Regexp.escape(source)}/, '') =~ ignore_re #only match against subdirs, not full path
         end
         @logger.trace "After rejecting ignored files/dirs, going to scp [#{dir_source.join(", ")}]"

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -465,7 +465,9 @@ module Beaker
               '00_EnvSetup.rb', '035_StopFirewall.rb', '05_HieraSetup.rb',
               '01_TestSetup.rb', '03_PuppetMasterSanity.rb',
               '06_InstallModules.rb','02_PuppetUserAndGroup.rb',
-              '04_ValidateSignCert.rb', '07_InstallCACerts.rb'              ]
+              '04_ValidateSignCert.rb', '07_InstallCACerts.rb',
+              '.08_HiddenFile.rb'
+          ]
 
           @fileset1 = files.shuffle.map {|file| test_dir + '/' + file }
           @fileset2 = files.shuffle.map {|file| other_test_dir + '/' + file }
@@ -529,7 +531,9 @@ module Beaker
             '00_EnvSetup.rb', '035_StopFirewall.rb', '05_HieraSetup.rb',
             '01_TestSetup.rb', '03_PuppetMasterSanity.rb',
             '06_InstallModules.rb','02_PuppetUserAndGroup.rb',
-            '04_ValidateSignCert.rb', '07_InstallCACerts.rb'              ]
+            '04_ValidateSignCert.rb', '07_InstallCACerts.rb',
+            '.08_HiddenFile.rb'
+          ]
 
           @fileset1 = files.shuffle.map {|file| test_dir + '/' + file }
           @fileset2 = files.shuffle.map {|file| other_test_dir + '/' + file }


### PR DESCRIPTION
With this patch do_scp_to also copies all files that start with a dot (this issue was noticed when using copy_module_to).

The fixed pattern is taken from glob() documentation (https://ruby-doc.org/core-2.4.1/Dir.html#method-c-glob).