### PR TITLE
(MAINT) add SSH setup link to vmpooler doc

### DIFF
--- a/docs/how_to/hypervisors/vmpooler.md
+++ b/docs/how_to/hypervisors/vmpooler.md
@@ -5,6 +5,10 @@ systems.
 beaker's vmpooler hypervisor interacts with vmpooler to get Systems Under Test
 (SUTs) for testing purposes.
 
+**Note** that if you're a puppet-internal user, you'll have to setup your SSH
+keys to communicate with vmpooler SUTs. To do that, refer to our
+[internal doc](https://confluence.puppetlabs.com/display/SRE/SSH+access+to+vmpooler+VMs).
+
 # Tokens
 
 Using tokens will allow you to extend your VMs lifetime, as well as interact

--- a/docs/how_to/hypervisors/vsphere.md
+++ b/docs/how_to/hypervisors/vsphere.md
@@ -1,3 +1,11 @@
+This doc describes beaker's vSphere hypervisor. This is the interaction layer
+that beaker will use to get Systems Under Test (SUTs) from any vSphere
+infrastructure that you might have.
+
+**Note** that if you're a puppet-internal user, or an external user that is
+using the vmpooler hypervisor, please refer to our [vmpooler doc](vmpooler.md)
+for info, as it can be different than the information here. 
+
 The harness can use vms and snapshots that live within vSphere as well.
 To do this create a `~/.fog` file with your vSphere credentials:
 


### PR DESCRIPTION
[skip ci]

@genebean, @joel-m-allen, I think one of you were talking about needing the SSH doc for vmpooler hosts. Is that correct?