### PR TITLE
BKR-1114: Added buildargs for Docker::Image::build invocation

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -5,7 +5,7 @@ module Beaker
     # Env variables supported:
     # DOCKER_REGISTRY: Docker registry URL
     # DOCKER_HOST: Remote docker host
-	# DOCKER_BUILDARGS: Docker buildargs map
+    # DOCKER_BUILDARGS: Docker buildargs map
     # @param [Host, Array<Host>, String, Symbol] hosts    One or more hosts to act upon,
     #                            or a role (String or Symbol) that identifies one or more hosts.
     # @param [Hash{Symbol=>String}] options Options to pass on to the hypervisor

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -162,7 +162,15 @@ module Beaker
 
       it 'should pass the Dockerfile on to Docker::Image.create' do
         allow( docker ).to receive(:dockerfile_for).and_return('special testing value')
-        expect( ::Docker::Image ).to receive(:build).with('special testing value', { :rm => true })
+        expect( ::Docker::Image ).to receive(:build).with('special testing value', { :rm => true, :buildargs => '{}' })
+
+        docker.provision
+      end
+
+      it 'should pass the buildargs from ENV DOCKER_BUILDARGS on to Docker::Image.create' do
+        allow( docker ).to receive(:dockerfile_for).and_return('special testing value')
+        ENV['DOCKER_BUILDARGS'] = 'HTTP_PROXY=http://1.1.1.1:3128'
+        expect( ::Docker::Image ).to receive(:build).with('special testing value', { :rm => true, :buildargs => "{\"HTTP_PROXY\":\"http://1.1.1.1:3128\"}" })
 
         docker.provision
       end

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -186,6 +186,25 @@ module Beaker
         docker.provision
       end
 
+      it 'should pass the multiple buildargs from ENV DOCKER_BUILDARGS on to Docker::Image.create' do
+        allow( docker ).to receive(:dockerfile_for).and_return('special testing value')
+        ENV['DOCKER_BUILDARGS'] = 'HTTP_PROXY=http://1.1.1.1:3128	HTTPS_PROXY=https://1.1.1.1:3129'
+        expect( ::Docker::Image ).to receive(:build).with('special testing value', { :rm => true, :buildargs => "{\"HTTP_PROXY\":\"http://1.1.1.1:3128\",\"HTTPS_PROXY\":\"https://1.1.1.1:3129\"}" })
+
+        docker.provision
+      end
+
+      it 'should create a container based on the Image (identified by image.id)' do
+        hosts.each do |host|
+          expect( ::Docker::Container ).to receive(:create).with({
+            'Image' => image.id,
+            'Hostname' => host.name,
+          })
+        end
+
+        docker.provision
+      end
+
       it 'should create a named container based on the Image (identified by image.id)' do
         hosts.each_with_index do |host, index|
           container_name = "spec-container-#{index}"


### PR DESCRIPTION
Currently beaker acceptance tests will fail if executed behind a proxy.
By exposing the buildargs build parameter, it can be configured via ENV
DOCKER_BUILDARGS, or per host docker_buildargs