### PR TITLE
Minor fixes to make SLES work again

### DIFF
--- a/lib/beaker/dsl/install_utils/foss_utils.rb
+++ b/lib/beaker/dsl/install_utils/foss_utils.rb
@@ -367,6 +367,12 @@ module Beaker
             end
 
             if package_name
+              # Some SLES images already have rubygem-puppet installed and this
+              # conflicts with the regular puppet-agent installer
+              if host['platform'] =~ /sles/
+                host.uninstall_package('rubygem-puppet')
+              end
+
               install_puppetlabs_release_repo( host, opts[:puppet_collection] )
               host.install_package( package_name )
             end

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -32,7 +32,7 @@ module Unix::Pkg
           # The `:sles_rpmkeys_nightly_pl_imported` key is only read here at this
           # time. It's just to make sure that we only do the key import once, &
           # isn't for setting or use outside of beaker.
-          execute('rpmkeys --import http://nightlies.puppetlabs.com/07BB6C57', opts)
+          execute('rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet', opts)
           self[:sles_rpmkeys_nightly_pl_imported] = true
         end
         result = execute("zypper --gpg-auto-import-keys se -i --match-exact #{name}", opts) { |result| result }

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -32,6 +32,9 @@ module Unix::Pkg
           # The `:sles_rpmkeys_nightly_pl_imported` key is only read here at this
           # time. It's just to make sure that we only do the key import once, &
           # isn't for setting or use outside of beaker.
+          execute('rpmkeys --import http://nightlies.puppetlabs.com/07BB6C57', opts)
+
+          # We also need the real key in case users are pulling from the stable packages
           execute('rpmkeys --import https://yum.puppetlabs.com/RPM-GPG-KEY-puppet', opts)
           self[:sles_rpmkeys_nightly_pl_imported] = true
         end

--- a/spec/beaker/dsl/install_utils/foss_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/foss_utils_spec.rb
@@ -60,13 +60,23 @@ describe ClassMixedWithDSLInstallUtils do
   let(:el6hostaio)    { make_host( 'el6hostaio', { :platform => Beaker::Platform.new('el-6-i386'),
                                                  :pe_ver => '3.0',
                                                  :working_dir => '/tmp',
-                                                :type => 'aio',
+                                                 :type => 'aio',
                                                  :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-centos-6-i386' } ) }
   let(:el6hostfoss)   { make_host( 'el6hostfoss', { :platform => Beaker::Platform.new('el-6-i386'),
                                                  :pe_ver => '3.0',
                                                  :working_dir => '/tmp',
-                                                :type => 'foss',
+                                                 :type => 'foss',
                                                  :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-centos-6-i386' } ) }
+  let(:sles12hostaio)    { make_host( 'sles12hostaio', { :platform => Beaker::Platform.new('sles-12-x86_64'),
+                                                 :pe_ver => '3.0',
+                                                 :working_dir => '/tmp',
+                                                 :type => 'aio',
+                                                 :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-sles-12-x86_64' } ) }
+  let(:sles12hostfoss)    { make_host( 'sles12hostfoss', { :platform => Beaker::Platform.new('sles-12-x86_64'),
+                                                 :pe_ver => '3.0',
+                                                 :working_dir => '/tmp',
+                                                 :type => 'foss',
+                                                 :dist => 'puppet-enterprise-3.1.0-rc0-230-g36c9e5c-sles-12-x86_64' } ) }
 
   let(:win_temp)      { 'C:\\Windows\\Temp' }
 
@@ -268,17 +278,43 @@ describe ClassMixedWithDSLInstallUtils do
     end
   end
 
-  context 'install_puppet_from_rpm_on' do
-    it 'installs PC1 release repo when AIO' do
-      expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostaio,'pc1',{})
-
-      subject.install_puppet_from_rpm_on( el6hostaio, {}  )
+  context 'install_puppet_agent_on' do
+    before :each do
+      allow( subject ).to receive( :options ) { opts }
     end
 
-    it 'installs non-PC1 package when not-AIO' do
-      expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostfoss,nil,{})
+    context 'when AIO' do
+      it 'installs PC1 release repo' do
+        expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostaio, 'pc1')
 
-      subject.install_puppet_from_rpm_on( el6hostfoss, {}  )
+        subject.install_puppet_agent_on( el6hostaio, {}  )
+      end
+
+      context 'when running SLES' do
+        it 'removes existing rubygem-puppet packages' do
+          expect(sles12hostaio).to receive(:uninstall_package).with('rubygem-puppet')
+
+          subject.install_puppet_agent_on( sles12hostaio, {}  )
+        end
+      end
+    end
+  end
+
+  context 'install_puppet_from_rpm_on' do
+    context 'when AIO' do
+      it 'installs PC1 release repo' do
+        expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostaio,'pc1',{})
+
+        subject.install_puppet_from_rpm_on( el6hostaio, {}  )
+      end
+    end
+
+    context 'when FOSS' do
+      it 'installs non-PC1 package when not-AIO' do
+        expect(subject).to receive(:install_puppetlabs_release_repo).with(el6hostfoss,nil,{})
+
+        subject.install_puppet_from_rpm_on( el6hostfoss, {}  )
+      end
     end
   end
 
@@ -1275,6 +1311,7 @@ describe ClassMixedWithDSLInstallUtils do
                               'scientific-7-x86_64',
                               'sles-10-x86_64',
                               'sles-11-x86_64',
+                              'sles-12-x86_64',
                               'sles-12-s390x'
                             ]
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -97,9 +97,10 @@ module Beaker
       it "checks correctly on sles" do
         @opts = {'platform' => 'sles-is-me'}
         pkg = 'sles_package'
+        expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys --import http.+07BB6C57$/, anything, anything ).and_return('').ordered.once
         expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys --import http.+RPM-GPG-KEY.+/, anything, anything ).and_return('').ordered.once
         expect( Beaker::Command ).to receive(:new).with("zypper --gpg-auto-import-keys se -i --match-exact #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('').ordered.once
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
+        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0})).exactly(3).times
         expect( instance.check_for_package(pkg) ).to be === true
       end
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -97,7 +97,7 @@ module Beaker
       it "checks correctly on sles" do
         @opts = {'platform' => 'sles-is-me'}
         pkg = 'sles_package'
-        expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys.*nightlies.puppetlabs.com.*/, anything, anything ).and_return('').ordered.once
+        expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys --import http.+RPM-GPG-KEY.+/, anything, anything ).and_return('').ordered.once
         expect( Beaker::Command ).to receive(:new).with("zypper --gpg-auto-import-keys se -i --match-exact #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('').ordered.once
         expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
         expect( instance.check_for_package(pkg) ).to be === true


### PR DESCRIPTION
* Pull the updated RPM GPG key
* Remove rubygem-puppet prior to trying to install puppet-agent
* Tested with opensuse/openSUSE-42.2-x86_64