### PR TITLE
Disable reverse DNS on Docker containers

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -246,9 +246,12 @@ module Beaker
         EOF
 
         # Configure sshd service to allowroot login using password
+        # Also, disable reverse DNS lookups to prevent every. single. ssh
+        # operation taking 30 seconds while the lookup times out.
         dockerfile += <<-EOF
           RUN sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
           RUN sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+          RUN sed -ri 's/^#?UseDNS .*/UseDNS no/' /etc/ssh/sshd_config
         EOF
 
 
@@ -285,6 +288,9 @@ module Beaker
                       '/etc/ssh/sshd_config'])
       container.exec(['sed','-ri',
                       's/^#?PasswordAuthentication .*/PasswordAuthentication yes/',
+                      '/etc/ssh/sshd_config'])
+      container.exec(['sed','-ri',
+                      's/^#?UseDNS .*/UseDNS no/',
                       '/etc/ssh/sshd_config'])
       container.exec(%w(service ssh restart))
     end

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -309,7 +309,7 @@ module Beaker
             host['docker_container_name'] = container_name
 
             expect( ::Docker::Container ).to receive(:all).and_return([container])
-            expect(container).to receive(:exec).exactly(3).times
+            expect(container).to receive(:exec).exactly(4).times
           end
           docker.provision
         end


### PR DESCRIPTION
This patch adds `UseDNS no` to the sshd configuration added to Docker
containers. This prevents SSH connections from triggering revers DNS lookups
which can take up to 30 seconds to time out per connection. Disabling this
behavior cut a simple beaker-rspec "hello world" from 14 minutes to 12 seconds
on the centos:centos7 image.