### PR TITLE
(BKR-1112) Change path for host file created by quickstart

### DIFF
--- a/lib/beaker/tasks/quick_start.rb
+++ b/lib/beaker/tasks/quick_start.rb
@@ -1,6 +1,6 @@
 require 'beaker-hostgenerator'
 
-CONFIG_DIR = '.beaker/acceptance/config'
+CONFIG_DIR = 'acceptance/config'
 
 VAGRANT  = ['ubuntu1404-64default.mdcal-ubuntu1404-64af', '--hypervisor=vagrant',
             '--global-config={box_url=https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm,box=puppetlabs/ubuntu-14.04-64-nocm}']


### PR DESCRIPTION
`rake beaker_quickstart:gen_hosts[hypervisor]` commands create a config file in `.beaker/acceptance/config/` directory and while the `rake beaker_quickstart:run_test[hypervisor]` is looking for the config file at `acceptance/config/`.

Changed the default directory where the config file is created to match the one used by the test command.