### PR TITLE
(MAINT) Change writing test tutorial to use more trivial package

### DIFF
--- a/docs/tutorials/lets_write_a_test.md
+++ b/docs/tutorials/lets_write_a_test.md
@@ -1,80 +1,53 @@
 ## The Task
 
-Consider if mcollectived incorrectly spawned a new process with every puppet agent run on Ubuntu 10.04.  We need an acceptance test to check that a new process is not spawned and to ensure that this issue does not regress in new builds.
+We will write an acceptance test to check if a package (specifically NTP) is installed on a host or not.
 
 ## Figure Out Test Steps
 
 What needs to happen in this test:
 
-* Install PE
-* Restart mcollective twice
-* Check to see if more than one mcollective process is running
+* Install NTP
+* Check to see if NTP is installed successfully on host or not
 
 ## Create a host configuration file
+We will be using a host from vmpooler. You can edit the host file to use other hypervisors like vagrant, but this document is supported for vmpooler as of now.
+
     $ beaker-hostgenerator redhat7-64ma > redhat7-64ma.yaml
 
-## Install PE
+## Install NTP
 
-We prefer to install PE once and then run a set of tests, so PE installation should not be part of the actual acceptance test.
+We prefer to install NTP first and then run a set of tests, so NTP installation should not be part of the actual acceptance test. Create and add the following code to a file called `install.rb`.
 
-    $ mkdir setup
-    $ cd setup
-    $ cat > install.rb << RUBY
-    test_name "Installing Puppet Enterprise" do
-    install_pe
-    RUBY
-    $ cd ..
+```ruby
+test_name "Installing NTP" do
+	hosts.each do |host|
+		install_package(host, 'ntp')
+	end
+end
+```
 
-This places our install steps in a ruby script (install.rb) which will run on localhost, but the #install_pe method knows where to install puppet enterprise based on the host configuration in use.
-The install.rb script is used in our commandline to beaker, below.
+This places our install steps in a ruby script (install.rb) which will run on our host. The `install_package` method knows where and how to install NTP based on the host configuration in use. The install.rb script is used in our commandline to beaker, below.
 
 ## Create a test file
 
-We need to create a test file to run.
-
-### Define some test commands to run
-#### Restart mcollective twice
-
-Here's our magic command that restarts mcollective:
-
-    restart_command = "bash -c '[[ -x /etc/init.d/pe-mcollective ]] && /etc/init.d/pe-mcollective restart'"
-
-#### Check to see if more than one mcollective process is running
-
-Here's our magic command that throws an error if more than one mcollective process is running:
-
-    process_count_check = "bash -c '[[ $(ps auxww | grep [m]collectived | wc -l) -eq 1 ]]'"
-
-### Put it all together
-
-Here's the finished acceptance test.
+We need to create a test file to run. Make a file called `mytest.rb` and add the following test that checks if ntp is installed or not.
 
 ```ruby
-test_name "/etc/init.d/pe-mcollective restart check"
+test_name "NTP installation check"
 
-# Don't run these tests on the following platforms
-confine :except, :platform => 'solaris'
+# Don't run these tests on the following platform
 confine :except, :platform => 'windows'
-confine :except, :platform => 'aix'
 
-step "Make sure the service restarts properly"
+step "Make sure NTP is installed"
 hosts.each do |host|
-  # Commands to execute on the target system.
-  restart_command = "bash -c '[[ -x /etc/init.d/pe-mcollective ]] && /etc/init.d/pe-mcollective restart'"
-  process_count_check = "bash -c '[[ $(ps auxww | grep [m]collectived | wc -l) -eq 1 ]]'"
-
-  # Restart once
-  on(host, restart_command) { assert_equal(0, exit_code) }
-  # Restart again
-  on(host, restart_command) { assert_equal(0, exit_code) }
   # Check to make sure only one process is running
-  on(host, process_count_check) { assert_equal(0, exit_code) }
+  check_for_package(host, 'ntp') { assert_equal(true) }
 end
 ```
 
 ## Run it!
 You can now run this with
 
-    beaker --host redhat7-64ma.yaml --pre-suite install.rb --test mytest.rb
+    beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
 
 Next up you may want to look at the [Beaker test for a module](../how_to/write_a_beaker_test_for_a_module.md) page.

--- a/docs/tutorials/quick_start_rake_tasks.md
+++ b/docs/tutorials/quick_start_rake_tasks.md
@@ -13,7 +13,7 @@ and running. See the docs on how to setup [Vmpooler](../how_to/hypervisors/vsphe
 
 ## How to use them
 
-To use the tasks, you need to put the following line at the top of your project's rake file:
+To use the tasks, you need to put the following line at the top of your project's rake file. If you don't have a project and are just going through the beaker tutorial, make a file named `Rakefile` inside a new directory and add the following line:
 
     require 'beaker/tasks/quick_start'
 


### PR DESCRIPTION
[skip ci]
1. Change the tutorial to test if NTP is installed rather than testing it on PE process, making it more easier to follow and use trivial package for general audience. 

2. Make a Rakefile for someone who is following quick start guide and don't have any project to follow the guide on