### PR TITLE
(BKR-1124) Pass info text to summary logger to print on file

### DIFF
--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -116,22 +116,22 @@ module Beaker
 
         summary_logger.notify "Failed Tests Cases:"
         (grouped_summary[:fail] || []).each do |test_case|
-          print_test_result(test_case)
+          summary_logger.notify print_test_result(test_case)
         end
 
         summary_logger.notify "Errored Tests Cases:"
         (grouped_summary[:error] || []).each do |test_case|
-          print_test_result(test_case)
+          summary_logger.notify print_test_result(test_case)
         end
 
         summary_logger.notify "Skipped Tests Cases:"
         (grouped_summary[:skip] || []).each do |test_case|
-          print_test_result(test_case)
+          summary_logger.notify print_test_result(test_case)
         end
 
         summary_logger.notify "Pending Tests Cases:"
         (grouped_summary[:pending] || []).each do |test_case|
-          print_test_result(test_case)
+          summary_logger.notify print_test_result(test_case)
         end
 
         summary_logger.notify("\n\n")
@@ -152,7 +152,7 @@ module Beaker
         else
           test_case.test_status
         end
-        @logger.notify "  Test Case #{test_case.path} #{test_reported}"
+        "  Test Case #{test_case.path} #{test_reported}"
       end
 
       # Writes Junit XML of this {TestSuiteResult}

--- a/spec/beaker/test_suite_spec.rb
+++ b/spec/beaker/test_suite_spec.rb
@@ -233,7 +233,7 @@ module Beaker
           allow(ex).to receive(:backtrace).and_return(['path_to_test_file.rb line 1 - blah'])
           tc.instance_variable_set(:@exception, ex)
           test_suite_result.add_test_case( tc )
-          expect(options[:logger]).to_not receive(:notify).with(/Test line:/)
+          expect(test_suite_result.print_test_result(tc)).not_to match(/Test line:/)
           expect{ test_suite_result.print_test_result(tc) }.to_not raise_error
         end
 
@@ -243,8 +243,7 @@ module Beaker
           allow(ex).to receive(:backtrace).and_return(['path_to_test_file.rb line 1 - blah'])
           tc.instance_variable_set(:@exception, ex)
           test_suite_result.add_test_case( tc )
-
-          expect(options[:logger]).to receive(:notify).with(/Test line:/)
+          expect(test_suite_result.print_test_result(tc)).to match(/Test line:/)
           expect{ test_suite_result.print_test_result(tc) }.to_not raise_error
         end
       end


### PR DESCRIPTION
Spec test breaking [here](https://github.com/puppetlabs/beaker/blob/master/spec/beaker/test_suite_spec.rb#L247)

`summary_logger` is the instance that logs the summary to terminal and the file.

`print_test_result` was passing the test_cases that failed to be notified using `@logger` instance [here](https://github.com/puppetlabs/beaker/blob/master/lib/beaker/test_suite.rb#L155)

I changed it to return the string and then am notifying it using the `summary_logger` instance. 