### PR TITLE
(BKR-1096) Block hosts flag with provision subcommand

### DIFF
--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -7,11 +7,12 @@ test_name 'use the init subcommand' do
 
   step 'ensure beaker init writes YAML configuration files to disk' do
     delete_root_folder_contents
-    result = on(default, 'beaker init --hosts centos6-64')
-    assert_match(/Trying as beaker-hostgenerator input/, result.stdout)
+    on(default, 'beaker init --hosts centos6-64')
     subcommand_options = on(default, "cat #{SubcommandUtil::SUBCOMMAND_OPTIONS}").stdout
     subcommand_state = on(default, "cat #{SubcommandUtil::SUBCOMMAND_STATE}").stdout
-    assert(YAML.parse(subcommand_options).to_ruby.class == Hash)
+    parsed_options = YAML.parse(subcommand_options).to_ruby
+    assert(parsed_options["HOSTS"].count == 1)
+    assert(parsed_options.class == Hash)
     assert(YAML.parse(subcommand_state).to_ruby.class == Hash)
   end
 

--- a/acceptance/tests/subcommands/init.rb
+++ b/acceptance/tests/subcommands/init.rb
@@ -7,7 +7,8 @@ test_name 'use the init subcommand' do
 
   step 'ensure beaker init writes YAML configuration files to disk' do
     delete_root_folder_contents
-    on(default, 'beaker init')
+    result = on(default, 'beaker init --hosts centos6-64')
+    assert_match(/Trying as beaker-hostgenerator input/, result.stdout)
     subcommand_options = on(default, "cat #{SubcommandUtil::SUBCOMMAND_OPTIONS}").stdout
     subcommand_state = on(default, "cat #{SubcommandUtil::SUBCOMMAND_STATE}").stdout
     assert(YAML.parse(subcommand_options).to_ruby.class == Hash)

--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -8,9 +8,8 @@ test_name 'use the provision subcommand' do
 
   step 'run beaker init and provision' do
     delete_root_folder_contents
-    on(default, 'beaker init')
     result = on(default, 'beaker provision --hosts centos6-64')
-    assert_match(/ERROR/, result.raw_output)
+    assert_match(/ERROR(.+)--hosts/, result.raw_output)
     on(default, 'beaker init --hosts centos6-64')
     result = on(default, 'beaker provision')
     assert_match(/Using available host/, result.stdout)

--- a/acceptance/tests/subcommands/provision.rb
+++ b/acceptance/tests/subcommands/provision.rb
@@ -10,8 +10,10 @@ test_name 'use the provision subcommand' do
     delete_root_folder_contents
     on(default, 'beaker init')
     result = on(default, 'beaker provision --hosts centos6-64')
+    assert_match(/ERROR/, result.raw_output)
+    on(default, 'beaker init --hosts centos6-64')
+    result = on(default, 'beaker provision')
     assert_match(/Using available host/, result.stdout)
-
     subcommand_state = on(default, "cat #{SubcommandUtil::SUBCOMMAND_STATE}").stdout
     subcommand_state = YAML.parse(subcommand_state).to_ruby
     assert_equal(true, subcommand_state['provisioned'])

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -20,7 +20,6 @@ module Beaker
     # a Beaker::CLI object executes, it can pick up these options. Notably excluded from this
     # group are `help` and `version`. Please note that whenever the command_line_parser.rb is
     # updated, this list should also be updated as well.
-    class_option :hosts, :aliases => '-h', :type => :string, :group => 'Beaker run'
     class_option :'options-file', :aliases => '-o', :type => :string, :group => 'Beaker run'
     class_option :helper, :type => :string, :group => 'Beaker run'
     class_option :'load-path', :type => :string, :group => 'Beaker run'
@@ -62,6 +61,7 @@ module Beaker
       as necessary.
     LONGDESC
     option :help, :type => :boolean, :hide => true
+    method_option :hosts, :aliases => '-h', :type => :string
     def init()
       if options[:help]
         invoke :help, [], ["init"]

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -84,6 +84,10 @@ module Beaker
         expect(yaml_store_mock).to receive(:[]=).with('provisioned', true)
         subcommand.provision
       end
+      it 'does not allow hosts to be passed' do
+        subcommand.options = {:hosts => "myhost"}
+        expect{subcommand.provision()}.to raise_error(NotImplementedError)
+      end
     end
 
 


### PR DESCRIPTION
Removed hosts as a Thor class_option so it cannot be used by all subcommands. It is restricted to be used only with init command. Hosts is added as Thor method_option with init. Changed spec and acceptance tests accordingly.