### PR TITLE
Issue where beaker gets stuck when an invalid Vagrantfile had been generated

### DIFF
--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -420,6 +420,13 @@ EOF
         vagrant.provision
       end
 
+      it "notifies user of failed provision" do
+        vagrant.provision
+        expect( vagrant ).to receive( :vagrant_cmd ).with( "destroy --force" ).and_raise( RuntimeError )
+        expect( options['logger'] ).to receive( :debug ).with( /Vagrantfile/ )
+        expect{ vagrant.provision }.to raise_error( RuntimeError )
+      end
+
       it "can cleanup" do
         expect( vagrant ).to receive( :vagrant_cmd ).with( "destroy --force" ).once
         expect( FileUtils ).to receive( :rm_rf ).once


### PR DESCRIPTION
I'm not sure what the correct solution is here. In one case if beaker generates an invalid Vagrantfile then beaker will remain stuck without a way to get unstuck unless you manually go find the Vagrantfile and delete it.

In another case if the destroy fails to destroy an existing VM and the original Vagrantfile is deleted the user might be in a very bad state where there's a VM but Vagrant will not work with that existing VM unless the Vagrantfile is restored. I'm not sure what the chances of this actually happening.

Another solution might be to try to destroy then raise a custom exception to let the user know about these 2 states and extend beaker's cleanup rake task to clear the Vagrantfile. This moves the decision from here to the user's judgment.

Let me know what the best choice is and I can make whatever changes need to happen. I found myself in this situation where beaker kept failing even though I knew it should of been fine. I had to inspect the source code to realize I needed to clear out the old Vagrantfile.

Thanks!!