### PR TITLE
(BKR-1136) Use kill instead of stop on docker containers

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -145,7 +145,7 @@ module Beaker
         if container = host['docker_container']
           @logger.debug("stop container #{container.id}")
           begin
-            container.stop
+            container.kill
             sleep 2 # avoid a race condition where the root FS can't unmount
           rescue Excon::Errors::ClientError => e
             @logger.warn("stop of container #{container.id} failed: #{e.response.body}")

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -65,7 +65,7 @@ module Beaker
           },
         },
       })
-      allow( container ).to receive(:stop)
+      allow( container ).to receive(:kill)
       allow( container ).to receive(:delete)
       allow( container ).to receive(:exec)
       container
@@ -338,7 +338,7 @@ module Beaker
 
       it 'should stop the containers' do
         allow( docker ).to receive( :sleep ).and_return(true)
-        expect( container ).to receive(:stop)
+        expect( container ).to receive(:kill)
         docker.cleanup
       end
 


### PR DESCRIPTION
The stop command is called during the cleanup phase for the docker hypervisor
in order to shut containers down prior to removing them. This command defaults
to waiting for 10 seconds before sending a SIGKILL to whatever process the
container is running. For containers running a process like init that ignores
the initial stop and term signals, this results in significant time being spent
on politeness when the container is going to be completely destroyed anyway.

This patch switches the stop command out for a simple kill.