### PR TITLE
(BKR-994) Read subcommands options from home directory

### DIFF
--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -205,7 +205,8 @@ module Beaker
       #   3.  the 'CONFIG' section of the hosts file
       #   4.  options file values
       #   5.  subcommand options, if executing beaker subcommands
-      #   6.  default or preset values are given the lowest priority
+      #   6.  subcommand options from $HOME/.beaker/subcommand_options.yaml
+      #   7.  default or preset values are given the lowest priority
       #
       # @param [Array] args ARGV or a provided arguments array
       # @raise [ArgumentError] Raises error on bad input
@@ -216,7 +217,12 @@ module Beaker
         cmd_line_options[:command_line] = ([$0] + args).join(' ')
         @attribution = @attribution.merge(tag_sources(cmd_line_options, "flag"))
 
-        # Subcommands are the first to get merged into presets
+        # Global subcommand options from $HOME/.beaker/subcommand_options.yaml are first to get merged into presets
+        homedir_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, home_dir=true)
+        @attribution = @attribution.merge(tag_sources(homedir_options, "homedir"))
+        @options.merge!(homedir_options)
+
+        # Subcommands are the second to get merged into presets
         subcommand_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args)
         @attribution = @attribution.merge(tag_sources(subcommand_options, 'subcommand'))
         @options.merge!(subcommand_options)

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -218,12 +218,12 @@ module Beaker
         @attribution = @attribution.merge(tag_sources(cmd_line_options, "flag"))
 
         # Global subcommand options from $HOME/.beaker/subcommand_options.yaml are first to get merged into presets
-        homedir_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, home_dir=true)
+        homedir_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, ENV['HOME']+'/.beaker/subcommand_options.yaml')
         @attribution = @attribution.merge(tag_sources(homedir_options, "homedir"))
         @options.merge!(homedir_options)
 
         # Subcommands are the second to get merged into presets
-        subcommand_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args)
+        subcommand_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
         @attribution = @attribution.merge(tag_sources(subcommand_options, 'subcommand'))
         @options.merge!(subcommand_options)
 

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -217,15 +217,16 @@ module Beaker
         cmd_line_options[:command_line] = ([$0] + args).join(' ')
         @attribution = @attribution.merge(tag_sources(cmd_line_options, "flag"))
 
-        # Global subcommand options from $HOME/.beaker/subcommand_options.yaml are first to get merged into presets
-        homedir_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, ENV['HOME']+'/.beaker/subcommand_options.yaml')
-        @attribution = @attribution.merge(tag_sources(homedir_options, "homedir"))
-        @options.merge!(homedir_options)
+        subcommand_options_file = Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS
+        options_files = {"homedir" => "#{ENV['HOME']}/#{subcommand_options_file}", "subcommand" => subcommand_options_file}
 
+        # Global subcommand options from $HOME/.beaker/subcommand_options.yaml are first to get merged into presets
         # Subcommands are the second to get merged into presets
-        subcommand_options = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
-        @attribution = @attribution.merge(tag_sources(subcommand_options, 'subcommand'))
-        @options.merge!(subcommand_options)
+        options_files.each do |src, path|
+          opts = Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(args, path)
+          @attribution = @attribution.merge(tag_sources(opts, src))
+          @options.merge!(opts)
+        end
 
         file_options                    = Beaker::Options::OptionsFileParser.parse_options_file(cmd_line_options[:options_file])
         @attribution = @attribution.merge(tag_sources(file_options, "options_file"))

--- a/lib/beaker/options/subcommand_options_file_parser.rb
+++ b/lib/beaker/options/subcommand_options_file_parser.rb
@@ -3,18 +3,30 @@ module Beaker
     #A set of functions to read options files
     module SubcommandOptionsParser
 
-      # @return [OptionsHash, Hash] returns an empty OptionHash or loads subcommand options yaml
-      #   from disk
-      def self.parse_subcommand_options(argv)
+      HOMEDIR_OPTIONS_FILE_PATH = ENV['HOME']+'/.beaker/subcommand_options.yaml'
+
+      def self.parse_options_file(options_file_path)
         result = OptionsHash.new
-        if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(argv[0])
-          return result if argv[0] == 'init'
-          if Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS.exist?
-           result = YAML.load_file(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
-          end
+        if File.exist?(options_file_path)
+          result = YAML.load_file(options_file_path)
         end
         result
       end
+
+      # @return [OptionsHash, Hash] returns an empty OptionHash or loads subcommand options yaml
+      #   from disk
+      def self.parse_subcommand_options(argv, home_dir=false)
+        result = OptionsHash.new
+        if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(argv[0])
+          return result if argv[0] == 'init'
+          if home_dir
+            return SubcommandOptionsParser.parse_options_file(HOMEDIR_OPTIONS_FILE_PATH)
+          end
+          result = SubcommandOptionsParser.parse_options_file(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
+        end
+        result
+      end
+
     end
   end
 end

--- a/lib/beaker/options/subcommand_options_file_parser.rb
+++ b/lib/beaker/options/subcommand_options_file_parser.rb
@@ -3,8 +3,6 @@ module Beaker
     #A set of functions to read options files
     module SubcommandOptionsParser
 
-      HOMEDIR_OPTIONS_FILE_PATH = ENV['HOME']+'/.beaker/subcommand_options.yaml'
-
       def self.parse_options_file(options_file_path)
         result = OptionsHash.new
         if File.exist?(options_file_path)
@@ -15,14 +13,11 @@ module Beaker
 
       # @return [OptionsHash, Hash] returns an empty OptionHash or loads subcommand options yaml
       #   from disk
-      def self.parse_subcommand_options(argv, home_dir=false)
+      def self.parse_subcommand_options(argv, options_file)
         result = OptionsHash.new
         if Beaker::Subcommands::SubcommandUtil.execute_subcommand?(argv[0])
           return result if argv[0] == 'init'
-          if home_dir
-            return SubcommandOptionsParser.parse_options_file(HOMEDIR_OPTIONS_FILE_PATH)
-          end
-          result = SubcommandOptionsParser.parse_options_file(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
+          result = SubcommandOptionsParser.parse_options_file(options_file)
         end
         result
       end

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -140,28 +140,31 @@ module Beaker
           let(:env) { @env || {:level => 'highest'} }
           let(:argv) { @argv || {:level => 'second'} }
           let(:host_file) { @host_file || {:level => 'third'} }
-          let(:opt_file) { @opt_file || {:level => 'fourth', 
-                            :ssh => {
-                              :auth_methods => 'auth123',
-                              :user_known_hosts_file => 'hosts123'
-                            }                                
-          } }
-          let(:subcommand_file) {@subcommand_file || {:level => 'fifth'}}
-          let(:homedir_file) {@homedir_file || {:level => 'sixth',
-                                :ssh => {
-                                    :auth_methods => 'auth_home_123'
-                                }
+          let(:opt_file) { @opt_file || {
+              :level => 'fourth',
+              :ssh => {
+                  :auth_methods => 'auth123',
+                  :user_known_hosts_file => 'hosts123'
+              }
           }}
-          let(:presets) { {:level => 'lowest',
-                            :ssh => {
-                              :config => 'config123',
-                              :paranoid => 'paranoid123',
-                              :port => 'port123',
-                              :forward_agent => 'forwardagent123',
-                              :keys => 'keys123',
-                              :keepalive => 'keepalive123'
-                            } 
-          } }
+          let(:subcommand_file) {@subcommand_file || {:level => 'fifth'}}
+          let(:homedir_file) {@homedir_file || {
+              :level => 'sixth',
+              :ssh => {
+                  :auth_methods => 'auth_home_123'
+              }
+          }}
+          let(:presets) { {
+              :level => 'lowest',
+              :ssh => {
+                  :config => 'config123',
+                  :paranoid => 'paranoid123',
+                  :port => 'port123',
+                  :forward_agent => 'forwardagent123',
+                  :keys => 'keys123',
+                  :keepalive => 'keepalive123'
+              }
+          }}
 
           before :each do
             expect(parser).to receive(:normalize_args).and_return(true)

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -148,9 +148,9 @@ module Beaker
           } }
           let(:subcommand_file) {@subcommand_file || {:level => 'fifth'}}
           let(:homedir_file) {@homedir_file || {:level => 'sixth',
-                                                :ssh => {
-                                                    :auth_methods => 'auth_home_123'
-                                                }
+                                :ssh => {
+                                    :auth_methods => 'auth_home_123'
+                                }
           }}
           let(:presets) { {:level => 'lowest',
                             :ssh => {

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -147,6 +147,11 @@ module Beaker
                             }                                
           } }
           let(:subcommand_file) {@subcommand_file || {:level => 'fifth'}}
+          let(:homedir_file) {@homedir_file || {:level => 'sixth',
+                                                :ssh => {
+                                                    :auth_methods => 'auth_home_123'
+                                                }
+          }}
           let(:presets) { {:level => 'lowest',
                             :ssh => {
                               :config => 'config123',
@@ -175,17 +180,29 @@ module Beaker
             allow(OptionsFileParser).to receive(:parse_options_file).and_return(opt_file)
             allow(parser).to receive(:parse_hosts_options).and_return(host_file)
 
-            allow(SubcommandOptionsParser).to receive(:parse_subcommand_options).and_return(subcommand_file)
+            allow(SubcommandOptionsParser).to receive(:parse_subcommand_options).and_return(homedir_file, subcommand_file)
           end
 
           it 'presets have the lowest priority' do
-            @env = @argv = @host_file = @opt_file = @subcommand_file = {}
+            @env = @argv = @host_file = @opt_file = @subcommand_file = @homedir_file = {}
             mock_out_parsing
 
             opts = parser.parse_args([])
             attribution = parser.attribution
             expect(opts[:level]).to be == 'lowest'
             expect(attribution[:level]).to be == 'preset'
+          end
+
+          it 'home directory options should have sixth priority' do
+            @env = @argv = @host_file = @opt_file = @subcommand_file = {}
+            mock_out_parsing
+
+            opts = parser.parse_args([])
+            attribution = parser.attribution
+            expect(opts[:ssh][:auth_methods]).to be == 'auth_home_123'
+            expect(attribution[:ssh][:auth_methods]).to be == 'homedir'
+            expect(opts[:level]).to be == 'sixth'
+            expect(attribution[:level]).to be == 'homedir'
           end
 
           it 'subcommand_options should have fifth priority' do

--- a/spec/beaker/options/subcommand_options_parser_spec.rb
+++ b/spec/beaker/options/subcommand_options_parser_spec.rb
@@ -3,8 +3,11 @@ require 'spec_helper'
 module Beaker
   module Options
     describe '#parse_subcommand_options' do
-      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv)}
+      let(:home_options_file_path) {ENV['HOME']+'/.beaker/subcommand_options.yaml'}
+      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv, home_dir)}
+      let( :file_parser ){Beaker::Options::SubcommandOptionsParser.parse_options_file({})}
       let( :argv ) {[]}
+      let( :home_dir ) {false}
 
       it 'returns an empty OptionsHash if not executing a subcommand' do
         expect(parser).to be_kind_of(OptionsHash)
@@ -21,12 +24,25 @@ module Beaker
 
       describe 'when the subcommand is not init' do
         let( :argv ) {['provision']}
-        it 'checks for file existence and loads the YAML file' do
-          expect(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS).to receive(:exist?).and_return(true)
-          allow(YAML).to receive(:load_file).and_return({})
-          expect(parser).to be_kind_of(Hash)
-          expect(parser).not_to be_kind_of(OptionsHash)
+        it 'calls parse_options_file with subcommand options file when home_dir is false' do
+          allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
+          allow(parser).to receive(:parse_options_file).with(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
         end
+
+        let ( :home_dir ) {true}
+        it 'calls parse_options_file with home directory options file when home_dir is true' do
+          allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
+          allow(parser).to receive(:parse_options_file).with(home_options_file_path)
+        end
+
+        let ( :home_dir ) {false}
+        it 'checks for file existence and loads the YAML file' do
+          allow(File).to receive(:exist?).and_return true
+          allow(YAML).to receive(:load_file).and_return({})
+          expect(file_parser).to be_kind_of(Hash)
+          expect(file_parser).not_to be_kind_of(OptionsHash)
+        end
+
       end
     end
   end

--- a/spec/beaker/options/subcommand_options_parser_spec.rb
+++ b/spec/beaker/options/subcommand_options_parser_spec.rb
@@ -4,10 +4,10 @@ module Beaker
   module Options
     describe '#parse_subcommand_options' do
       let(:home_options_file_path) {ENV['HOME']+'/.beaker/subcommand_options.yaml'}
-      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv, home_dir)}
+      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv, options_file)}
       let( :file_parser ){Beaker::Options::SubcommandOptionsParser.parse_options_file({})}
       let( :argv ) {[]}
-      let( :home_dir ) {false}
+      let( :options_file ) {""}
 
       it 'returns an empty OptionsHash if not executing a subcommand' do
         expect(parser).to be_kind_of(OptionsHash)
@@ -24,23 +24,30 @@ module Beaker
 
       describe 'when the subcommand is not init' do
         let( :argv ) {['provision']}
+        let(:options_file) {Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS}
         it 'calls parse_options_file with subcommand options file when home_dir is false' do
           allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
           allow(parser).to receive(:parse_options_file).with(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
         end
 
-        let ( :home_dir ) {true}
+        let( :options_file ) {home_options_file_path}
         it 'calls parse_options_file with home directory options file when home_dir is true' do
           allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
           allow(parser).to receive(:parse_options_file).with(home_options_file_path)
         end
 
-        let ( :home_dir ) {false}
         it 'checks for file existence and loads the YAML file' do
           allow(File).to receive(:exist?).and_return true
           allow(YAML).to receive(:load_file).and_return({})
           expect(file_parser).to be_kind_of(Hash)
           expect(file_parser).not_to be_kind_of(OptionsHash)
+        end
+
+        let(:options_file) {""}
+        it 'returns an empty options hash when file does not exist' do
+          allow(File).to receive(:exist?).and_return false
+          expect(parser).to be_kind_of(OptionsHash)
+          expect(parser).to be_empty
         end
 
       end


### PR DESCRIPTION
This patch changed options priority to read options from $HOME/.beaker/subcommands_options.yaml with the lowest priority after the presets.
Added respective spec tests and modified others to fit this in the priority chain. Please note that as the priority hierarchy is changing there are some places in the module and their spec files that require modification in order to fit this in.
The new options priority now (from highest to lowest):
1. ENV variables
2. ARGV variables
3. 'CONFIG' section of hosts file
4. Options file
5. Subcommand options
6. Subcommand options file from home directory (this patch)
7. Presets

PS - Also, there was an empty file (`lib/beaker/options/homedir_options_file_parser.rb`) merged from my poor github management that is being deleted here :(