### PR TITLE
(BKR-1139) Add /usr/local/bin to SSH PATH on OSX

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -294,6 +294,8 @@ module Unix::Exec
       add_env_var('PKG_PATH', "http://ftp.openbsd.org/pub/OpenBSD/#{version}/packages/#{arch}/")
     elsif self['platform'] =~ /solaris-10/
       add_env_var('PATH', '/opt/csw/bin')
+    elsif self['platform'] =~ /osx/
+      add_env_var('PATH', '/usr/local/bin')
     end
 
     #add the env var set to this test host

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -157,5 +157,83 @@ module Beaker
         expect(instance.selinux_enabled?).to be === false
       end
     end
+
+    describe '#ssh_set_user_environment' do
+      before :each do
+        allow( instance ).to receive( :exec )
+        allow( instance ).to receive( :[] ).with( 'platform' ).and_return( 'centos-6-x86' )
+        allow( instance ).to receive( :[] ).with( :ssh_env_file ).and_return( '' )
+      end
+
+      it 'adds the env argument hash to the environment' do
+        allow( instance ).to receive( :mkdir_p )
+        allow( instance ).to receive( :[] ).with( :ssh_env_file ).and_return( '' )
+
+        env_hash = {
+          'key1' => 'value1',
+          'key2' => 'value2',
+          'key3' => 'value3'
+        }
+        expect( instance ).to receive( :add_env_var ).with( 'PATH', '$PATH' )
+        env_hash.each do |k,v|
+          expect( instance ).to receive( :add_env_var ).with( k, v )
+        end
+        instance.ssh_set_user_environment( env_hash )
+      end
+
+      describe 'ssh env file setup' do
+        before :each do
+          @env_folder = '/not/real/fake/test'
+          @env_folder_pathname = Pathname.new( @env_folder )
+          @env_file = 'file.extension'
+          @env_file_path = "#{@env_folder}/#{@env_file}"
+          allow( instance ).to receive( :[] ).with( :ssh_env_file ).and_return( @env_file_path )
+        end
+
+        it 'creates the folder if needed' do
+          allow( instance ).to receive( :add_env_var )
+          expect( instance ).to receive( :mkdir_p ).with( @env_folder_pathname )
+          instance.ssh_set_user_environment( {} )
+        end
+
+        it 'sets up the env file' do
+          allow( instance ).to receive( :add_env_var )
+          allow( instance ).to receive( :mkdir_p )
+          expect( Beaker::Command ).to receive( :new ).with( /^chmod 0600 #{@env_folder}$/ )
+          expect( Beaker::Command ).to receive( :new ).with( /^touch #{@env_file_path}$/ )
+          instance.ssh_set_user_environment( {} )
+        end
+      end
+
+      describe 'platform-specific setup' do
+        def set_env_platform_test(platform_str, value_hash)
+          allow( instance ).to receive( :mkdir_p )
+          allow( instance ).to receive( :[] ).with( :ssh_env_file ).and_return( '' )
+          allow( instance ).to receive( :[] ).with( 'platform' ).and_return( platform_str )
+
+          expect( instance ).to receive( :add_env_var ).with( 'PATH', '$PATH' )
+          value_hash.each do |k, v|
+            expect( instance ).to receive( :add_env_var ).with( k, v )
+          end
+          instance.ssh_set_user_environment( {} )
+        end
+
+        it 'OSX : sets usr/local/bin' do
+          set_env_platform_test( 'osx-doesnt-matter', 'PATH' => '/usr/local/bin' )
+        end
+
+        it 'SOLARIS-10: sets /opt/csw/bin' do
+          set_env_platform_test( 'solaris-10-matter', 'PATH' => '/opt/csw/bin' )
+        end
+
+        it 'OPENBSD: sets PKG_PATH' do
+          arch = 'arch'
+          version = '9.5'
+          platform_str = "openbsd-#{version}-#{arch}"
+          pkg_path_regex = /^http.*openbsd.org.*#{version}.*#{arch}\/$/
+          set_env_platform_test( platform_str, 'PKG_PATH' => pkg_path_regex )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
 - Typically an interactive OSX SSH shell has /usr/local/bin added
   to PATH.

   However, for non-interactive SSH shells, OSX locks down security a
   bit tighter and doesn't add /usr/local/bin by default. Beaker has
   already added `PermitUserEnvironment yes` to /etc/ssh/sshd_config
   to be more lenient and allow additional elements to be added by
   the way of ~/.ssh/environment file written during Beaker host
   initialization.

 - This is necessary because of OSX SIP (System Integrity Protection)
   that marks /usr/bin read-only, and suggests /usr/local/bin be the
   target destination for any user installed binaries.

   For instance, should the Ruby `gem` command be used to install
   gems with binstubs (like Bundler), they are written to
   /usr/local/bin. Without this change the `bundle` command is not
   in PATH. This can prevent Puppet source based acceptance testing
   through ci:test:git from finding binaries it may install during
   setup.