### PR TITLE
(BKR-1140) Add LANG / LC_ALL en_us.UTF-8 for SSH 

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -296,6 +296,11 @@ module Unix::Exec
       add_env_var('PATH', '/opt/csw/bin')
     end
 
+    # some hosts may omit the LANG variable, which sets Ruby to US-ASCII
+    # UTF-8 is the accepted standard encoding for Puppet tools
+    add_env_var('LANG', 'en_US.UTF-8')
+    add_env_var('LC_ALL', 'en_US.UTF-8')
+
     #add the env var set to this test host
     env.each_pair do |var, value|
       add_env_var(var, value)


### PR DESCRIPTION
 - Without a default LANG variable set on hosts under test, Ruby will
   default to setting its Encoding.default_external to US-ASCII

   In particular, this appears to impact vmpooler host types:

   arista4-32
   cumulus25-64
   osx1009
   osx1010
   osx1011
   sles10

 - Alternatively, image templates could be modified, but injecting
   this with Beaker by default seems like a more robust solution.

 - Also alternatively, hosts can use the :host_env setting to inject
   the LANG variable.  However, this is currently difficult to do
   in conjunction with beaker-hostgenerator which is typically used
   in Puppet CI pipelines.