### PR TITLE
(BKR-834) Connect to host first with DNS name and then IP address

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -65,15 +65,15 @@ module Beaker
 
     # connect to the host
     def connect
-      #try three ways to connect to host (ip, vmhostname, hostname)
+      #try three ways to connect to host (vmhostname, ip, hostname)
       methods = []
-      if @ip
-        @ssh ||= connect_block(@ip, @user, @ssh_opts)
-        methods << "ip (#{@ip})"
-      end
-      if @vmhostname && !@ssh
+      if @vmhostname
         @ssh ||= connect_block(@vmhostname, @user, @ssh_opts)
         methods << "vmhostname (#{@vmhostname})"
+      end
+      if @ip && !@ssh
+        @ssh ||= connect_block(@ip, @user, @ssh_opts)
+        methods << "ip (#{@ip})"
       end
       if @hostname && !@ssh
         @ssh ||= connect_block(@hostname, @user, @ssh_opts)

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -18,25 +18,25 @@ module Beaker
 
     it 'self.connect creates connects and returns a proxy for that connection' do
       # grrr
-      expect( Net::SSH ).to receive(:start).with( ip, user, ssh_opts ).and_return(true)
+      expect( Net::SSH ).to receive(:start).with( vmhostname, user, ssh_opts ).and_return(true)
       connection_constructor = SshConnection.connect name_hash, user, ssh_opts, options
       expect( connection_constructor ).to be_a_kind_of SshConnection
     end
 
     it 'connect creates a new connection' do
-      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true)
+      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true)
       connection.connect
     end
 
     it 'connect caches its connection' do
-      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts ).once.and_return true
+      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts ).once.and_return true
       connection.connect
       connection.connect
     end
 
-    it 'attempts to connect by vmhostname if ip address connection fails' do
-      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(false)
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true).once
+    it 'attempts to connect by ip address if vmhostname connection fails' do
+      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(false)
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true).once
       expect( Net::SSH ).to receive( :start ).with( hostname, user, ssh_opts).never
       connection.connect
     end
@@ -53,7 +53,7 @@ module Beaker
 
       it 'runs ssh close' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -63,7 +63,7 @@ module Beaker
 
       it 'sets the @ssh variable to nil' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -76,7 +76,7 @@ module Beaker
       it 'calls ssh shutdown & re-raises if ssh close fails with an unexpected Error' do
         mock_ssh = Object.new
         allow( mock_ssh ).to receive( :close ) { raise StandardError }
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -90,7 +90,7 @@ module Beaker
     describe '#execute' do
       it 'retries if failed with a retryable exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -102,7 +102,7 @@ module Beaker
 
       it 'raises an error if it fails both times' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -115,7 +115,7 @@ module Beaker
     describe '#request_terminal_for' do
       it 'fails correctly by raising Net::SSH::Exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         mock_channel = Object.new
@@ -128,7 +128,7 @@ module Beaker
     describe '#register_stdout_for' do
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '7 of clubs'
@@ -164,7 +164,7 @@ module Beaker
 
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '3 of spades'
@@ -203,7 +203,7 @@ module Beaker
 
       it 'assigns the output\'s exit code correctly from the data' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
         connection.connect
 
         data = '10 of jeromes'
@@ -236,7 +236,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :upload! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 
@@ -263,7 +263,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :download! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 


### PR DESCRIPTION
Some hosts' IP address are changed on reboot. Connecting with IP first would fail and then it will try connecting with vmhostname (DNS) and this process takes time because of timeouts on retries.

This patch will try to connect with vmhostname (DNS) first and then attempt the same with IP address on failure.