### PR TITLE
(BKR-1084) Add --skip-last-teardown option

### DIFF
--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -88,6 +88,12 @@ module Beaker
             @cmd_options[:preserve_hosts] = mode || 'always'
           end
 
+          opts.on '--skip-last-teardown',
+                  'Do not execute teardown code for last test in suite',
+                  '(default: false)' do |bool|
+            @cmd_options[:skip_last_teardown] = bool
+          end
+
           opts.on '--root-keys',
                   'Install puppetlabs pubkeys for superuser',
                   '(default: false)' do |bool|

--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -322,7 +322,8 @@ module Beaker
       @test_files.each do |test_file|
         @logger.info "Begin #{test_file}"
         start = Time.now
-        test_case = TestCase.new(@hosts, @logger, options, test_file).run_test
+        last_test = test_file == @test_files.last
+        test_case = TestCase.new(@hosts, @logger, options, test_file, last_test).run_test
         duration = Time.now - start
         @test_suite_results.add_test_case(test_case)
         @test_cases << test_case


### PR DESCRIPTION
Add option to skip teardown in the last test, and leave SUT in last testing state.