### PR TITLE
(BKR-871) Remove cygwin installation from package installation

### DIFF
--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -108,4 +108,14 @@ module Windows::Exec
     false
   end
 
+  # Determine if cygwin is actually installed on the SUT. Differs from
+  # is_cygwin?, which is just a type check for a Windows::Host.
+  #
+  # @return [Boolean]
+  def cygwin_installed?
+    output = exec(Beaker::Command.new('cygcheck --check-setup cygwin'), :accept_all_exit_codes => true).stdout 
+    return true if output.match(/cygwin/) && output.match(/OK/)
+    false
+  end
+
 end

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -107,6 +107,7 @@ module Beaker
         when host['platform'] =~ /cumulus/
           check_and_install_packages_if_needed(host, CUMULUS_PACKAGES)
         when (host['platform'] =~ /windows/ and host.is_cygwin?)
+          raise RuntimeError, "cygwin is not installed on #{host}" if !host.cygwin_installed?
           check_and_install_packages_if_needed(host, WINDOWS_PACKAGES)
         when (host['platform'] =~ /windows/ and not host.is_cygwin?)
           check_and_install_packages_if_needed(host, PSWINDOWS_PACKAGES)

--- a/spec/beaker/dsl/install_utils/windows_utils_spec.rb
+++ b/spec/beaker/dsl/install_utils/windows_utils_spec.rb
@@ -15,7 +15,7 @@ describe ClassMixedWithDSLInstallUtils do
   let( :batch_path )        { '/fake/batch/path' }
   let(:msi_path)            { 'c:\\foo\\puppet.msi' }
   let(:winhost)             { make_host( 'winhost',
-                              { :platform => 'windows',
+                            { :platform => Beaker::Platform.new('windows-2008r2-64'),
                                 :pe_ver => '3.0',
                                 :working_dir => '/tmp',
                                 :is_cygwin => true} ) }

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -60,5 +60,23 @@ module Beaker
         instance.reboot
       end
     end
+
+    describe '#cygwin_installed?' do
+      let (:response) { double( 'response' ) }
+
+      it 'uses cygcheck to see if cygwin is installed' do
+        expect( Beaker::Command ).to receive(:new).with("cygcheck --check-setup cygwin").and_return(:foo)
+        expect( instance ).to receive( :exec ).with(:foo, :accept_all_exit_codes => true).and_return(response)
+        expect( response ).to receive(:stdout).and_return('cygwin OK')
+        expect(instance.cygwin_installed?).to eq(true)
+      end
+
+      it 'returns false when unable to find matching text' do
+        expect( Beaker::Command ).to receive(:new).with("cygcheck --check-setup cygwin").and_return(:foo)
+        expect( instance ).to receive( :exec ).with(:foo, :accept_all_exit_codes => true).and_return(response)
+        expect( response ).to receive(:stdout).and_return('No matching text')
+        expect(instance.cygwin_installed?).to eq(false)
+      end
+    end
   end
 end

--- a/spec/beaker/host/windows/pkg_spec.rb
+++ b/spec/beaker/host/windows/pkg_spec.rb
@@ -39,17 +39,10 @@ module Beaker
         end
 
         it 'curls the SSL URL for cygwin\'s installer' do
-          expect( instance ).to receive( :execute ).with( /^curl.*https\:/  ).ordered
           allow(  instance ).to receive( :execute ).with( /^setup\-x86/     ).ordered
           instance.install_package( 'curl' )
         end
 
-        it 'falls back to the non-SSL URL if that one fails' do
-          allow(  instance ).to receive( :execute ).with( /^curl.*https\:/  ).and_raise( Beaker::Host::CommandFailure ).ordered
-          expect( instance ).to receive( :execute ).with( /^curl.*http\:/   ).ordered
-          allow(  instance ).to receive( :execute ).with( /^setup\-x86/     ).ordered
-          instance.install_package( 'curl' )
-        end
       end
     end
 

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -409,6 +409,7 @@ describe Beaker do
 
       hosts.each do |host|
         windows_pkgs.each do |pkg|
+          allow( host ).to receive( :cygwin_installed? ).and_return( true )
           allow( host ).to receive( :is_cygwin? ).and_return( true )
           expect( host ).to receive( :check_for_package ).with( pkg ).once.and_return( false )
           expect( host ).to receive( :install_package ).with( pkg ).once

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -122,62 +122,31 @@ module Beaker
         let(:cygwin64) { 'setup-x86_64.exe' }
         let(:package) { 'foo' }
 
-        before(:each) do
-          @platform = 'windows'
-          allow( host ).to receive(:check_for_package).and_return(true)
-        end
-
         context "testing osarchitecture" do
 
-          before(:each) do
-            expect( host ).to receive(:execute).with(/wmic os get osarchitecture/, anything).and_yield(success_osarch_check)
-          end
-
-          context "32 bit" do
-            let(:success_osarch_check) { double(:success, :exit_code => 0, :stdout => '32-bit') }
-
-            it "uses 32 bit cygwin" do
-              expect( host ).to receive(:execute).with(/#{cygwin}.*#{package}/)
-              host.install_package(package)
-            end
-          end
-
           context "64 bit" do
-            let(:success_osarch_check) { double(:success, :exit_code => 0, :stdout => '64-bit') }
+            before do
+              @platform = Beaker::Platform.new('windows-2008r2-64')
+            end
 
             it "uses 64 bit cygwin" do
               expect( host ).to receive(:execute).with(/#{cygwin64}.*#{package}/)
               host.install_package(package)
             end
           end
-        end
-
-        context "testing os name" do
-          let(:failed_osarch_check) { double(:failed, :exit_code => 1) }
-
-          before(:each) do
-            expect( host ).to receive(:execute).with(/wmic os get osarchitecture/, anything).and_yield(failed_osarch_check)
-            expect( host ).to receive(:execute).with(/wmic os get name/, anything).and_yield(name_check)
-          end
 
           context "32 bit" do
-            let(:name_check) { double(:failure, :exit_code => 1) }
+            before do
+              @platform = Beaker::Platform.new('windows-10ent-32')
+            end
 
             it "uses 32 bit cygwin" do
               expect( host ).to receive(:execute).with(/#{cygwin}.*#{package}/)
               host.install_package(package)
             end
           end
-
-          context "64 bit" do
-            let(:name_check) { double(:success, :exit_code => 0) }
-
-            it "uses 64 bit cygwin" do
-              expect( host ).to receive(:execute).with(/#{cygwin64}.*#{package}/)
-              host.install_package(package)
-            end
-          end
         end
+
       end
     end
 


### PR DESCRIPTION
Previous to this commit, beaker would ensure that the cygwin executable
was available prior to package installation and download the executable
if it was not found. Later versions of cygwin fixed a flaw in permissions
for the executable, which broke the way beaker ensured and downloaded
the cygwin executable.

This change removes the notion of checking for cygwin at all. Rather
than conflate the installation of cygwin with package installation,
beaker should separate those concerns. Cygwin should be downloaded and
installed separately from package installation, or handled at the image 
level for the VM used.

Also included in this PR is an optimization for determining the the
architecture of the host; rather than spend time introspecting the
system, a host should just examine its own platform string to determine
the architecture.

[Related JIRA Images ticket](https://tickets.puppetlabs.com/browse/IMAGES-6)