### PR TITLE
(RE-7005) Preserve hostname on amazon linux on reboots

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -649,6 +649,14 @@ module Beaker
           else
             next if host['platform'] =~ /netscaler/
             host.exec(Command.new("hostname #{host.name}"))
+            if host['vmname'] =~ /^amazon/
+              # Amazon Linux requires this to preserve host name changes across reboots.
+              # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-hostname.html
+              # Also note that without an elastic ip set, while this will
+              # preserve the hostname across a full shutdown/startup of the vm
+              # (as opposed to a reboot) -- the ip address will have changed. 
+              host.exec(Command.new("sed -ie '/^HOSTNAME/ s/=.*/=#{host.name}/' /etc/sysconfig/network"))
+            end
           end
         end
       else
@@ -660,6 +668,10 @@ module Beaker
           else
             next if host['platform'] =~ /netscaler/
             host.exec(Command.new("hostname #{host.hostname}"))
+            if host['vmname'] =~ /^amazon/
+              # See note above
+              host.exec(Command.new("sed -ie '/^HOSTNAME/ s/=.*/=#{host.hostname}/' /etc/sysconfig/network"))
+            end
           end
         end
       end


### PR DESCRIPTION
The aws_sdk hypervisor overrides the hostname to the public fqdn of the
vm so that puppet initializes with a cert matching it's public fqdn.
This allows agents to reach the master server, for example.

However these changes, on an Amazon Linux vm, are not preserved on
reboot. The host comes back with its hostname reset to the internal fqdn
(based on its private ip). This was causing a failure in PE
acceptance tests which expected the current facter fqdn output to
match the node's certname

Amazon Linux requires updating /etc/sysconfig/network to preserve
hostname changes across reboots.

http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-hostname.html

Also note that without an elastic ip set, while this will preserve the
hostname across a full shutdown/startup of the vm (as opposed to a
reboot) -- the public ip address/dns will have changed and the old
hostname will no longer resolve.