### PR TITLE
(BKR-1151) Add port 8142 for masters PXP/PCP

### DIFF
--- a/lib/beaker/hypervisor/ec2_helper.rb
+++ b/lib/beaker/hypervisor/ec2_helper.rb
@@ -19,6 +19,7 @@ module Beaker
 
       if roles.include? 'master'
         ports << 8140
+        ports << 8142
       end
 
       if roles.include? 'dashboard'


### PR DESCRIPTION
Orchestration (PXP/PCP) needs port 8142 opened on all masters, MoM and compile.