### PR TITLE
(BKR-1154) place prepend cmds before env vars in commands

### DIFF
--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -78,7 +78,7 @@ module Beaker
       end
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
-      cmd_line_array = [env_string, prepend_commands, cmd, options_string, args_string]
+      cmd_line_array = [prepend_commands, env_string, cmd, options_string, args_string]
       cmd_line_array << append_command unless (cmd =~ /ntpdate/ && host[:platform] =~ /cisco_nexus/)
       cmd_line_array.compact.reject( &:empty? ).join( ' ' )
     end


### PR DESCRIPTION
Previously, beaker put environment variables first, followed by the prepended command. This can break in a couple of ways:

* If the prepended command is a shell builtin, it will not work with `env`.
* Even if it could, the environment variables would be applied to the prepended command, not to the actual command.

An example of such a broken command is: `env LD_LIBRARY_PATH=/foo source /etc/profile; puppet --version`

Instead, beaker should put the prepended commands first. This allows it to work correctly if it's a shell builtin, and ensures that the environment variables are properly passed to the intended command.

An example of the fixed command is: `source /etc/profile; env LD_LIBRARY_PATH=foo puppet --version`