### PR TITLE
(BKR-1153) Confine solaris 10 from git clone test

### DIFF
--- a/acceptance/tests/base/dsl/install_utils/clone_git_repo_on_test.rb
+++ b/acceptance/tests/base/dsl/install_utils/clone_git_repo_on_test.rb
@@ -7,6 +7,8 @@ begin
   extend Beaker::Acceptance::InstallUtils
 end
 
+confine :except, :platform => /^solaris-10/
+
 test_name 'Clone from git' do
 
   PACKAGES = {


### PR DESCRIPTION
On Solaris 10, git package installation poisons curl and libssl.
Tried installing git using the same command beaker uses on a fresh vmpooler
Solaris 10 instance and it is producing the same error.