### PR TITLE
(BKR-1155) Allow Configurable SSH Method

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -274,7 +274,7 @@ module Beaker
       # create new connection object if necessary
       @connection ||= SshConnection.connect( { :ip => self['ip'], :vmhostname => self['vmhostname'], :hostname => @name },
                                              self['user'],
-                                             self['ssh'], { :logger => @logger } )
+                                             self['ssh'], { :logger => @logger, :connection_method => self[:connection_method] } )
       # update connection information
       if self['ip'] && (@connection.ip != self['ip'])
         @connection.ip = self['ip']

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -18,25 +18,31 @@ module Beaker
 
     it 'self.connect creates connects and returns a proxy for that connection' do
       # grrr
-      expect( Net::SSH ).to receive(:start).with( vmhostname, user, ssh_opts ).and_return(true)
+      expect( Net::SSH ).to receive(:start).with( ip, user, ssh_opts ).and_return(true)
       connection_constructor = SshConnection.connect name_hash, user, ssh_opts, options
       expect( connection_constructor ).to be_a_kind_of SshConnection
     end
 
     it 'connect creates a new connection' do
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true)
+      connection.connect
+    end
+
+    it 'allows the connection method to be overidden' do
+      connection.instance_variable_set("@options", { :connection_method => 'vmhostname' })
       expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true)
       connection.connect
     end
 
     it 'connect caches its connection' do
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts ).once.and_return true
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts ).once.and_return true
       connection.connect
       connection.connect
     end
 
-    it 'attempts to connect by ip address if vmhostname connection fails' do
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(false)
-      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true).once
+    it 'attempts to connect by vmhostname if ip address connection fails' do
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(false)
+      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true).once
       expect( Net::SSH ).to receive( :start ).with( hostname, user, ssh_opts).never
       connection.connect
     end
@@ -53,7 +59,7 @@ module Beaker
 
       it 'runs ssh close' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -63,7 +69,7 @@ module Beaker
 
       it 'sets the @ssh variable to nil' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -76,7 +82,7 @@ module Beaker
       it 'calls ssh shutdown & re-raises if ssh close fails with an unexpected Error' do
         mock_ssh = Object.new
         allow( mock_ssh ).to receive( :close ) { raise StandardError }
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -90,7 +96,7 @@ module Beaker
     describe '#execute' do
       it 'retries if failed with a retryable exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -102,7 +108,7 @@ module Beaker
 
       it 'raises an error if it fails both times' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -115,7 +121,7 @@ module Beaker
     describe '#request_terminal_for' do
       it 'fails correctly by raising Net::SSH::Exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         mock_channel = Object.new
@@ -128,7 +134,7 @@ module Beaker
     describe '#register_stdout_for' do
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '7 of clubs'
@@ -164,7 +170,7 @@ module Beaker
 
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '3 of spades'
@@ -203,7 +209,7 @@ module Beaker
 
       it 'assigns the output\'s exit code correctly from the data' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         data = '10 of jeromes'
@@ -236,7 +242,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :upload! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 
@@ -263,7 +269,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :download! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 


### PR DESCRIPTION
The default method of connecting via SSH was updated from IP address to VM hostname.
This had the unfortunate effect of breaking tests on OpenStack hypervisors as where
it used to work first time via IP address it spins for a very long time trying to
connect to a totally made up VM hostname, causing timeouts and failed tests.

This reverts back to IP based addressing by default, however the vmpooler hypervisor
can now implicitly set the host's SSH connection type to vmhostname when not set
explicitly in the host/global configuration.