### PR TITLE
(BKR-1155) Allow configurable ssh connection preference

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -274,7 +274,7 @@ module Beaker
       # create new connection object if necessary
       @connection ||= SshConnection.connect( { :ip => self['ip'], :vmhostname => self['vmhostname'], :hostname => @name },
                                              self['user'],
-                                             self['ssh'], { :logger => @logger } )
+                                             self['ssh'], { :logger => @logger, :ssh_connection_preference => self[:ssh_connection_preference] } )
       # update connection information
       if self['ip'] && (@connection.ip != self['ip'])
         @connection.ip = self['ip']

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -48,7 +48,7 @@ module Beaker
 
       hypervisor = hyper_class.new(hosts_to_provision, options)
       hypervisor.provision if options[:provision]
-
+      self.set_ssh_connection_preference(hosts_to_provision, hypervisor)
       hypervisor
     end
 
@@ -65,6 +65,29 @@ module Beaker
     #Cleanup steps to be run for a given hypervisor.  Default is nil.
     def cleanup
       nil
+    end
+
+    DEFAULT_CONNECTION_PREFERENCE = ['ip', 'vmhostname', 'hostname']
+    #SSH connection method preference. Can be overwritten by hypervisor to change the order
+    def connection_preference
+      DEFAULT_CONNECTION_PREFERENCE
+    end
+
+    #Check if overriding method returns correct array with ip, vmhostname hostname as elements
+    def self.set_ssh_connection_preference(hosts_to_provision, hypervisor)
+      if hypervisor.connection_preference.sort == DEFAULT_CONNECTION_PREFERENCE.sort
+        hosts_to_provision.each{ |h| h[:ssh_connection_preference] = hypervisor.connection_preference}
+      else
+        raise ArgumentError, <<-HEREDOC
+Hypervisor's overriding connection_pereference method is not matching the API.
+
+Make sure your hypervisor's connection_preference returns an array
+containing the following elements in any order you prefer:
+"ip", "hostname", "vmhostname"
+
+Please check hypervisor.rb file's "self.connection_preference" method for an example
+        HEREDOC
+      end
     end
 
     #Proxy package managers on tests hosts created by this hypervisor, runs before validation and configuration.

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -47,8 +47,8 @@ module Beaker
         end
 
       hypervisor = hyper_class.new(hosts_to_provision, options)
-      hypervisor.provision if options[:provision]
       self.set_ssh_connection_preference(hosts_to_provision, hypervisor)
+      hypervisor.provision if options[:provision]
       hypervisor
     end
 

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -6,7 +6,7 @@ module Beaker
   class SshConnection
 
     attr_accessor :logger
-    attr_accessor :ip, :vmhostname, :hostname
+    attr_accessor :ip, :vmhostname, :hostname, :ssh_connection_preference
 
     RETRYABLE_EXCEPTIONS = [
       SocketError,
@@ -33,6 +33,7 @@ module Beaker
       @ssh_opts = ssh_opts
       @logger = options[:logger]
       @options = options
+      @ssh_connection_preference = @options[:ssh_connection_preference]
     end
 
     def self.connect name_hash, user = 'root', ssh_opts = {}, options = {}
@@ -66,21 +67,13 @@ module Beaker
     # connect to the host
     def connect
       #try three ways to connect to host (vmhostname, ip, hostname)
-      methods = []
-      if @vmhostname
-        @ssh ||= connect_block(@vmhostname, @user, @ssh_opts)
-        methods << "vmhostname (#{@vmhostname})"
+      # Try each method in turn until we succeed
+      methods = @ssh_connection_preference.dup
+      while (not @ssh) && (not methods.empty?) do
+        @ssh = connect_block(instance_variable_get("@#{methods.shift}"), @user, @ssh_opts)
       end
-      if @ip && !@ssh
-        @ssh ||= connect_block(@ip, @user, @ssh_opts)
-        methods << "ip (#{@ip})"
-      end
-      if @hostname && !@ssh
-        @ssh ||= connect_block(@hostname, @user, @ssh_opts)
-        methods << "hostname (#{@hostname})"
-      end
-      if not @ssh
-        @logger.error "Failed to connect to #{@hostname}, attempted #{methods.join(', ')}"
+      unless @ssh
+        @logger.error "Failed to connect to #{@hostname}, attempted #{@ssh_connection_preference.join(', ')}"
         raise RuntimeError, "Cannot connect to #{@hostname}"
       end
       @ssh

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -2,15 +2,36 @@ require 'spec_helper'
 
 module Beaker
   describe Hypervisor do
-    let( :hypervisor ) { Beaker::Hypervisor }
+    let( :hosts ) { make_hosts( { :platform => 'el-5' } ) }
 
-    it "includes custom hypervisor" do
-      expect{ hypervisor.create('custom_hypervisor', [], make_opts() )}.to raise_error(RuntimeError, "Invalid hypervisor: custom_hypervisor")
+    context "#create" do
+      let( :hypervisor ) { Beaker::Hypervisor }
+
+      it "includes custom hypervisor and call set_ssh_connection_preference" do
+        allow(hypervisor).to receive(:set_ssh_connection_preference).with([], hypervisor)
+        expect{ hypervisor.create('custom_hypervisor', [], make_opts() )}.to raise_error(RuntimeError, "Invalid hypervisor: custom_hypervisor")
+      end
+
+      it "sets ssh connection preference if connection_preference method is not overwritten" do
+        hypervisor.create('none', hosts, make_opts())
+        expect(hosts[0][:ssh_connection_preference]).to eq(['ip', 'vmhostname', 'hostname'])
+      end
+
+      it "tests ssh connection methods array for valid elements" do
+        allow(hypervisor).to receive(:connection_preference).and_return(['my', 'invalid', 'method_name'])
+        expect{ hypervisor.set_ssh_connection_preference(hosts, hypervisor)}.to raise_error(ArgumentError, /overriding/)
+      end
+
+      it "sets to new preference if connection_preference is overridden" do
+        allow(hypervisor).to receive(:connection_preference).and_return(['vmhostname', 'hostname', 'ip'])
+        hypervisor.set_ssh_connection_preference(hosts, hypervisor)
+        expect(hosts[0][:ssh_connection_preference]).to eq(['vmhostname', 'hostname', 'ip'])
+      end
+
     end
 
     context "#configure" do
       let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
-      let( :hosts ) { make_hosts( { :platform => 'el-5' } ) }
       let( :hypervisor ) { Beaker::Hypervisor.new( hosts, options ) }
 
       context 'if :timesync option set true on host' do

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -5,7 +5,7 @@ module Beaker
   describe SshConnection do
     let( :user )      { 'root'    }
     let( :ssh_opts )  { { keepalive: true, keepalive_interval: 2 } }
-    let( :options )   { { :logger => double('logger').as_null_object }  }
+    let( :options )   { { :logger => double('logger').as_null_object, :ssh_connection_preference => ["ip", "vmhostname", "hostname"]} }
     let( :ip )        { "default.ip.address" }
     let( :vmhostname ){ "vmhostname" }
     let( :hostname)   { "my_host" }
@@ -18,25 +18,24 @@ module Beaker
 
     it 'self.connect creates connects and returns a proxy for that connection' do
       # grrr
-      expect( Net::SSH ).to receive(:start).with( vmhostname, user, ssh_opts ).and_return(true)
+      expect( Net::SSH ).to receive(:start).with( ip, user, ssh_opts ).and_return(true)
       connection_constructor = SshConnection.connect name_hash, user, ssh_opts, options
       expect( connection_constructor ).to be_a_kind_of SshConnection
     end
 
     it 'connect creates a new connection' do
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true)
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true)
       connection.connect
     end
 
     it 'connect caches its connection' do
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts ).once.and_return true
-      connection.connect
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts ).once.and_return true
       connection.connect
     end
 
-    it 'attempts to connect by ip address if vmhostname connection fails' do
-      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(false)
-      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(true).once
+    it 'attempts to connect by vmhostname address if ip connection fails' do
+      expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts).and_return(false)
+      expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts).and_return(true).once
       expect( Net::SSH ).to receive( :start ).with( hostname, user, ssh_opts).never
       connection.connect
     end
@@ -53,7 +52,7 @@ module Beaker
 
       it 'runs ssh close' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -63,7 +62,7 @@ module Beaker
 
       it 'sets the @ssh variable to nil' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -76,7 +75,7 @@ module Beaker
       it 'calls ssh shutdown & re-raises if ssh close fails with an unexpected Error' do
         mock_ssh = Object.new
         allow( mock_ssh ).to receive( :close ) { raise StandardError }
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( mock_ssh).to receive( :closed? ).once.and_return(false)
@@ -90,7 +89,7 @@ module Beaker
     describe '#execute' do
       it 'retries if failed with a retryable exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -102,7 +101,7 @@ module Beaker
 
       it 'raises an error if it fails both times' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         allow( subject ).to receive( :close )
@@ -115,7 +114,7 @@ module Beaker
     describe '#request_terminal_for' do
       it 'fails correctly by raising Net::SSH::Exception' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         mock_channel = Object.new
@@ -128,7 +127,7 @@ module Beaker
     describe '#register_stdout_for' do
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '7 of clubs'
@@ -164,7 +163,7 @@ module Beaker
 
       before :each do
         @mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
 
         @data = '3 of spades'
@@ -203,7 +202,7 @@ module Beaker
 
       it 'assigns the output\'s exit code correctly from the data' do
         mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
         data = '10 of jeromes'
@@ -236,7 +235,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :upload! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 
@@ -263,7 +262,7 @@ module Beaker
         @mock_scp = Object.new
         allow( @mock_scp ).to receive( :download! )
         allow( @mock_ssh ).to receive( :scp ).and_return( @mock_scp )
-        expect( Net::SSH ).to receive( :start ).with( vmhostname, user, ssh_opts) { @mock_ssh }
+        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { @mock_ssh }
         connection.connect
       end
 


### PR DESCRIPTION
This patch adds a new API method for hypervisors called connections_preference.
Hypervisor authors can overwrite this method to return an array of SSH
connection method preference of their choice when that hypervisor is used. This
option is then added to host_hash.

In host.rb file, we are sending ssh_connection.rb file an object of
:ssh_connection_pereference as an option. And we loop through each of the
element of the array in connect method of ssh_connection file.

The overall idea here is to create an API endpoint for hypervisor authors to set
their connection preference. As of now we dont want end user to set this in
their hosts config as there are no use case for it.