### PR TITLE
(BKR-437) Correctly detect public/private keys

### DIFF
--- a/lib/beaker/hypervisor/aws_sdk.rb
+++ b/lib/beaker/hypervisor/aws_sdk.rb
@@ -688,10 +688,9 @@ module Beaker
       keys = Array(@options[:ssh][:keys])
       keys << '~/.ssh/id_rsa'
       keys << '~/.ssh/id_dsa'
-      key_file = nil
-      keys.each do |key|
-        key_filename = File.expand_path(key + '.pub')
-        key_file = key_filename if File.exists?(key_filename)
+      key_file = keys.find do |key|
+        key_pub = key + '.pub'
+        File.exist?(File.expand_path(key_pub)) && File.exist?(File.expand_path(key))
       end
 
       if key_file
@@ -699,7 +698,7 @@ module Beaker
       else
         raise RuntimeError, "Expected to find a public key, but couldn't in #{keys}"
       end
-      File.read(key_file)
+      File.read(File.expand_path(key_file + '.pub'))
     end
 
     # Generate a key prefix for key pair names

--- a/spec/beaker/hypervisor/aws_sdk_spec.rb
+++ b/spec/beaker/hypervisor/aws_sdk_spec.rb
@@ -630,7 +630,6 @@ module Beaker
 	  end
           expect(set_hostnames).to eq(@hosts)
           @hosts.each do |host|
-            puts host[:name]
             expect(host[:vmhostname]).to eq(host[:name])
             expect(host[:vmhostname]).to eq(host.hostname)
           end
@@ -652,8 +651,10 @@ module Beaker
       it "retrieves contents from local ~/.ssh/id_rsa.pub file" do
         # Stub calls to file read/exists
         key_value = 'foobar_Rsa'
-        allow(File).to receive(:exists?).with(/id_dsa.pub/) { false }
-        allow(File).to receive(:exists?).with(/id_rsa.pub/) { true }
+        allow(File).to receive(:exist?).with(/id_dsa.pub/) { false }
+        allow(File).to receive(:exist?).with(/id_dsa/) { false }
+        allow(File).to receive(:exist?).with(/id_rsa.pub/) { true }
+        allow(File).to receive(:exist?).with(/id_rsa/) { true }
         allow(File).to receive(:read).with(/id_rsa.pub/) { key_value }
 
         # Should return contents of allow( previously ).to receivebed id_rsa.pub
@@ -663,8 +664,10 @@ module Beaker
       it "retrieves contents from local ~/.ssh/id_dsa.pub file" do
         # Stub calls to file read/exists
         key_value = 'foobar_Dsa'
-        allow(File).to receive(:exists?).with(/id_rsa.pub/) { false }
-        allow(File).to receive(:exists?).with(/id_dsa.pub/) { true }
+        allow(File).to receive(:exist?).with(/id_rsa.pub/) { false }
+        allow(File).to receive(:exist?).with(/id_rsa/) { false }
+        allow(File).to receive(:exist?).with(/id_dsa.pub/) { true }
+        allow(File).to receive(:exist?).with(/id_dsa/) { true }
         allow(File).to receive(:read).with(/id_dsa.pub/) { key_value }
 
         expect(public_key).to be === key_value
@@ -680,8 +683,8 @@ module Beaker
         aws.instance_variable_set( :@options, opts )
 
         key_value = 'foobar_Custom2'
-        allow(File).to receive(:exists?).with(anything) { false }
-        allow(File).to receive(:exists?).with(/fake_key2/) { true }
+        allow(File).to receive(:exist?).with(anything) { false }
+        allow(File).to receive(:exist?).with(/fake_key2/) { true }
         allow(File).to receive(:read).with(/fake_key2/) { key_value }
 
         expect(public_key).to be === key_value


### PR DESCRIPTION
The private_key() method was previously wrong. It used the last key
found in a loop, but did not verify that both the public and private key
exists for the chosen key before continuing. This meant that the ssh key
specified in the hosts file was ignored.