### PR TITLE
(BKR-1084) Add --debug-errors option to enter pry on a test failing

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'fakefs', '~> 0.6'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 10.0'
 
   # Documentation dependencies
@@ -33,6 +32,9 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'minitar', '~> 0.6'
+  s.add_runtime_dependency 'pry-byebug', '~> 3.4.2'
+  # pry-byebug can have issues with native readline libs so add rb-readline
+  s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '~> 4.0'

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -31,7 +31,7 @@ module Beaker
     #     end
     #
     module Structure
-
+      require 'pry'
       # Provides a method to help structure tests into coherent steps.
       # @param [String] step_name The name of the step to be logged.
       # @param [Proc] block The actions to be performed in this step.
@@ -40,7 +40,16 @@ module Beaker
         set_current_step_name(step_name)
         if block_given?
           logger.step_in()
-          yield
+          begin
+            yield
+          rescue Exception => e
+            if(@options.has_key?(:debug_errors) && @options[:debug_errors] == true)
+              logger.info("Exception raised during step execution and debug-errors option is set, entering pry. Exception was: #{e.inspect}")
+              logger.info("HINT: Use the pry 'backtrace' and 'up' commands to navigate to the test code")
+              binding.pry
+            end
+            raise e
+          end
           logger.step_out()
         end
       end

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -88,6 +88,12 @@ module Beaker
             @cmd_options[:preserve_hosts] = mode || 'always'
           end
 
+          opts.on '--debug-errors',
+                  'Enter a pry console if or when a test fails',
+                  '(default: false)' do |bool|
+            @cmd_options[:debug_errors] = bool
+          end
+
           opts.on '--root-keys',
                   'Install puppetlabs pubkeys for superuser',
                   '(default: false)' do |bool|

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -51,6 +51,7 @@ module Beaker
     class_option :tag, :type => :string, :group => 'Beaker run'
     class_option :'exclude-tags', :type => :string, :group => 'Beaker run'
     class_option :'xml-time-order', :type => :boolean, :group => 'Beaker run'
+    class_option :'debug-errors', :type => :boolean, :group => 'Beaker run'
 
     # The following are listed as deprecated in beaker --help, but needed now for
     # feature parity for beaker 3.x.


### PR DESCRIPTION
Adds a --debug-errors option. When used, beaker will drop the runner into a pry console if/when a test fails or errors.
This is intended for the beaker run subcommand.