### PR TITLE
(BKR-1163) update minitar to newest version

### DIFF
--- a/acceptance/tests/base/dsl/helpers/host_helpers/archive_file_from_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/archive_file_from_test.rb
@@ -40,7 +40,7 @@ test_name "dsl::helpers::host_helpers #archive_file_from" do
       expected_path = File.join(tmpdir, default)
 
       tgz = Zlib::GzipReader.new(File.open(tar_path, 'rb'))
-      Archive::Tar::Minitar.unpack(tgz, expected_path)
+      Minitar.unpack(tgz, expected_path)
       assert_equal('number of the beast', File.read(expected_path + '/' + filepath).strip)
     end
   end

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
-  s.add_runtime_dependency 'minitar', '~> 0.5.4'
+  s.add_runtime_dependency 'minitar', '~> 0.6'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '~> 4.0'

--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -260,7 +260,7 @@ module Beaker
         #
         # @return [Result] Returns the result of the #scp_from operation.
         def archive_file_from(host, from_path, opts = {}, archive_root = 'archive/sut-files', archive_name = 'sut-files.tgz')
-          require 'archive/tar/minitar'
+          require 'minitar'
           filedir = File.dirname(from_path)
           targetdir = File.join(archive_root, host.hostname, filedir)
           # full path to check for existance later
@@ -277,7 +277,7 @@ module Beaker
         # @visibility private
         def create_tarball(path, archive_name)
           tgz = Zlib::GzipWriter.new(File.open(archive_name, 'wb'))
-          Archive::Tar::Minitar.pack(path, tgz)
+          Minitar.pack(path, tgz)
         end
         private :create_tarball
 


### PR DESCRIPTION
minitar 0.5.4 has a security issue in some code beaker doesn't use. Still,
updating will avoid this to be flagged on security scans.