### PR TITLE
(BKR-1132) adds concept of manual_test and manual_step

### DIFF
--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -94,6 +94,12 @@ module Beaker
             @cmd_options[:debug_errors] = bool
           end
 
+          opts.on '--exec-manual-tests',
+                  'Execute manual tests',
+                  '(default: false)' do |bool|
+            @cmd_options[:exec_manual_tests] = bool
+          end
+
           opts.on '--root-keys',
                   'Install puppetlabs pubkeys for superuser',
                   '(default: false)' do |bool|

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -52,6 +52,7 @@ module Beaker
     class_option :'exclude-tags', :type => :string, :group => 'Beaker run'
     class_option :'xml-time-order', :type => :boolean, :group => 'Beaker run'
     class_option :'debug-errors', :type => :boolean, :group => 'Beaker run'
+    class_option :'exec_manual_tests', :type => :boolean, :group => 'Beaker run'
 
     # The following are listed as deprecated in beaker --help, but needed now for
     # feature parity for beaker 3.x.


### PR DESCRIPTION
Adds an option --exec-manual-tests

adds manual_tests. This allows use to do some automated setup for manual
test cases, but also skips them when run in CI

adds manual_step. This allows us to pass or fail a test after prompting
the tester