### PR TITLE
(MAINT) Adding underscore to get valid XML file

### DIFF
--- a/acceptance/tests/base/test_suite/export.rb
+++ b/acceptance/tests/base/test_suite/export.rb
@@ -1,7 +1,7 @@
 test_name 'ensure tests can export arbitrary data' do
 
   step 'export nested hash' do
-    export({'middle earth' => {
+    export({'middle_earth' => {
               'Hobbits' => ['Bilbo', 'Frodo'],
               'Elves' => 'Arwen',
               :total => {'numbers' => 42}


### PR DESCRIPTION
The space between middle and earth generates invalid XML file. Adding an
underscore to avoid that.

Nokogiri is powerful enough to parse the space but no other XML parser can parse it :/