### PR TITLE
(CPR-439) auto import gpg keys with zypper

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -74,7 +74,7 @@ module Unix::Pkg
   def install_package(name, cmdline_args = '', version = nil, opts = {})
     case self['platform']
       when /sles-/
-        execute("zypper --non-interactive in #{name}", opts)
+        execute("zypper --non-interactive --gpg-auto-import-keys in #{name}", opts)
       when /el-4/
         @logger.debug("Package installation not supported on rhel4")
       when /fedora-(2[2-9])/


### PR DESCRIPTION
When enabling repos on sles, zypper doesn't seem to acknowledge the
gpgkey entry in the repo file. Generally this will cause yum to auto
import the specified gpg key, and everything is hunky dory. With zypper,
it fetches the gpg key from the repo itself (found in
repodata/repomd.xml.key). This will allow zypper to install the package
and verify the key without failing, assuming the key provided in the
repo is the correct key.