### PR TITLE
Update lets_write_a_test.md

### DIFF
--- a/docs/tutorials/lets_write_a_test.md
+++ b/docs/tutorials/lets_write_a_test.md
@@ -83,6 +83,6 @@ end
 ## Run it!
 You can now run this with
 
-    beaker --host redhat7-64ma.yaml --pre-suite install.rb --test mytest.rb
+    beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
 
 Next up you may want to look at the [Beaker test for a module](../how_to/write_a_beaker_test_for_a_module.md) page.


### PR DESCRIPTION
When I tried using --test I got the following error:

```
OptionParser::AmbiguousOption: ambiguous option: --test
  /home/f5030161/.pdk/cache/ruby/2.4.0/gems/beaker-3.22.0/lib/beaker/options/command_line_parser.rb:290:in `parse'
  /home/f5030161/.pdk/cache/ruby/2.4.0/gems/beaker-3.22.0/lib/beaker/options/parser.rb:216:in `parse_args'
  /home/f5030161/.pdk/cache/ruby/2.4.0/gems/beaker-3.22.0/lib/beaker/cli.rb:23:in `parse_options'
  /home/f5030161/.pdk/cache/ruby/2.4.0/gems/beaker-3.22.0/bin/beaker:9:in `<top (required)>'
  /home/f5030161/.pdk/cache/ruby/2.4.0/bin/beaker:22:in `load'
  /home/f5030161/.pdk/cache/ruby/2.4.0/bin/beaker:22:in `<top (required)>'
```
After checking the beaker help files I changed this to --tests and it works.