### PR TITLE
make apt-get install non-interactive

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -92,7 +92,7 @@ module Unix::Pkg
           name = "#{name}=#{version}"
         end
         update_apt_if_needed
-        execute("apt-get install --force-yes #{cmdline_args} -y #{name}", opts)
+        execute("DEBIAN_FRONTEND=noninteractive apt-get install --force-yes #{cmdline_args} -y #{name}", opts)
       when /solaris-11/
         if opts[:acceptable_exit_codes]
           opts[:acceptable_exit_codes] << 4


### PR DESCRIPTION
I've been waiting ages for install_puppet_agent_on to finish, until I realized that it had hung up on apt-get install because of an already existing config file which should be updated but had conflicts. It was stuck on the interactive dialog...