### PR TITLE
(MAINT) fix CHANGELOG format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,9 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.25.0...master)
 
-# 3.25.0 - 2017-09-26
+### Added
 
-### Removed
+- concept of `manual_test` and `manual_step`
 
-- mention of the CLA bot in CONTRIBUTING doc
+# [3.25.0](https://github.com/puppetlabs/beaker/compare/3.24.0...3.25.0) - 2017-09-26
 
-### Fixed
-
-- "tests" CLI argument in "Let's Write a Test" doc


### PR DESCRIPTION
We decided that in order to keep some idea of
a link to the changes that went into a release,
we would have the compare links present for each
release & stop including MAINT changes in the
CHANGELOG. This commit changes the format &
adds in a missed CHANGELOG entry from
BKR-1132 (submitted in PR #1444)

[skip ci]