### PR TITLE
Update RHEL support for GCE

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --tty
+--fail-fast

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format documentation
 --color
 --tty
---fail-fast

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -166,9 +166,9 @@ module Unix::Exec
     case self['platform']
     when /debian|ubuntu|cumulus|huaweios/
       exec(Beaker::Command.new("service ssh restart"))
-    when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
+    when /el-7|centos-7|redhat-7|rhel-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
       exec(Beaker::Command.new("systemctl restart sshd.service"))
-    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|rhel|amazon|oracle|scientific|eos/
       exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/
       exec(Beaker::Command.new("rcsshd restart"))
@@ -192,11 +192,11 @@ module Unix::Exec
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
-    when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7/
+    when /el-7|centos-7|redhat-7|rhel-7|oracle-7|scientific-7|eos-7/
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
-    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|rhel|amazon|oracle|scientific|eos/
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -39,7 +39,7 @@ module Unix::File
   # @return [String] Path to package config dir
   def package_config_dir
     case self['platform']
-    when /fedora|el-|centos/
+    when /fedora|el-|rhel|redhat|centos/
       '/etc/yum.repos.d/'
     when /sles/
       '/etc/zypp/repos.d/'
@@ -64,8 +64,9 @@ module Unix::File
     repo_filename = "pl-%s-%s-" % [ package_name, build_version ]
 
     case variant
-    when /fedora|el|centos|cisco_nexus|cisco_ios_xr|sles/
-      variant = 'el' if variant == 'centos'
+    when /fedora|el|rhel|redhat|centos|cisco_nexus|cisco_ios_xr|sles/
+      variant = 'el' if ['centos', 'redhat', 'rhel'].include?(variant)
+
       if variant == 'cisco_nexus'
         variant = 'cisco-wrlinux'
         version = '5'
@@ -103,7 +104,7 @@ module Unix::File
   # @return [String] Type of repo (rpm|deb)
   def repo_type
     case self['platform']
-    when /fedora|el-|centos|sles/
+    when /fedora|el-|rhel|redhat|centos|sles/
       'rpm'
     when /debian|ubuntu|cumulus|huaweios/
       'deb'

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -39,7 +39,7 @@ module Unix::Pkg
       when /el-4/
         @logger.debug("Package query not supported on rhel4")
         return false
-      when /cisco|fedora|amazon|centos|eos|el-/
+      when /cisco|fedora|centos|rhel|redhat|amazon|eos|el-/
         result = execute("rpm -q #{name}", opts) { |result| result }
       when /ubuntu|debian|cumulus|huaweios/
         result = execute("dpkg -s #{name}", opts) { |result| result }
@@ -82,7 +82,7 @@ module Unix::Pkg
           name = "#{name}-#{version}"
         end
         execute("dnf -y #{cmdline_args} install #{name}", opts)
-      when /cisco|fedora|centos|eos|el-/
+      when /cisco|fedora|centos|redhat|rhel|eos|el-/
         if version
           name = "#{name}-#{version}"
         end
@@ -170,7 +170,7 @@ module Unix::Pkg
         @logger.debug("Package uninstallation not supported on rhel4")
       when /edora-(2[2-9])/
         execute("dnf -y #{cmdline_args} remove #{name}", opts)
-      when /cisco|fedora|centos|eos|el-/
+      when /cisco|fedora|centos|redhat|rhel|eos|el-/
         execute("yum -y #{cmdline_args} remove #{name}", opts)
       when /ubuntu|debian|cumulus|huaweios/
         execute("apt-get purge #{cmdline_args} -y #{name}", opts)
@@ -200,7 +200,7 @@ module Unix::Pkg
         @logger.debug("Package upgrade is not supported on rhel4")
       when /fedora-(2[2-9])/
         execute("dnf -y #{cmdline_args} update #{name}", opts)
-      when /cisco|fedora|centos|eos|el-/
+      when /cisco|fedora|centos|redhat|rhel|eos|el-/
         execute("yum -y #{cmdline_args} update #{name}", opts)
       when /ubuntu|debian|cumulus|huaweios/
         update_apt_if_needed
@@ -277,7 +277,7 @@ module Unix::Pkg
     case self['platform']
       when /el-4/
         @logger.debug("Package repo deploy is not supported on rhel4")
-      when /fedora|centos|eos|el-/
+      when /fedora|centos|redhat|rhel|eos|el-/
         deploy_yum_repo(path, name, version)
       when /ubuntu|debian|cumulus|huaweios/
         deploy_apt_repo(path, name, version)
@@ -407,8 +407,8 @@ module Unix::Pkg
     when /^(solaris)$/
       release_path_end, release_file = solaris_puppet_agent_dev_package_info(
         puppet_collection, puppet_agent_version, opts )
-    when /^(sles|aix|el|centos|oracle|redhat|amazon|scientific)$/
-      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|amazon|scientific)/)
+    when /^(sles|aix|el|centos|oracle|redhat|rhel|amazon|scientific)$/
+      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|rhel|amazon|scientific)/)
       arch = 'ppc' if variant == 'aix' && arch == 'power'
       version = '7.1' if variant == 'aix' && version == '7.2'
       release_path_end = "#{variant}/#{version}/#{puppet_collection}/#{arch}"
@@ -436,8 +436,8 @@ module Unix::Pkg
 
     variant, version, arch, codename = self['platform'].to_array
     case variant
-    when /^(fedora|el|centos|sles)$/
-      variant = ((variant == 'centos') ? 'el' : variant)
+    when /^(fedora|el|centos|redhat|rhel|sles)$/
+      variant = ((['centos', 'redhat',' rhel'].include?(variant)) ? 'el' : variant)
       release_file = "/repos/#{variant}/#{version}/#{puppet_collection}/#{arch}/puppet-agent-*.rpm"
       download_file = "puppet-agent-#{variant}-#{version}-#{arch}.tar.gz"
     when /^(debian|ubuntu|cumulus)$/
@@ -494,7 +494,7 @@ module Unix::Pkg
   def install_local_package(onhost_package_file, onhost_copy_dir = nil)
     variant, version, arch, codename = self['platform'].to_array
     case variant
-    when /^(fedora|el|centos)$/
+    when /^(fedora|el|redhat|rhel|centos)$/
       command_name = 'yum'
       command_name = 'dnf 'if variant == 'fedora' && version > 21 && version <= 29
       execute("#{command_name} --nogpgcheck localinstall -y #{onhost_package_file}")
@@ -524,7 +524,7 @@ module Unix::Pkg
   def uncompress_local_tarball(onhost_tar_file, onhost_base_dir, download_file)
     variant, version, arch, codename = self['platform'].to_array
     case variant
-    when /^(fedora|el|centos|sles|debian|ubuntu|cumulus)$/
+    when /^(fedora|el|centos|redhat|rhel|sles|debian|ubuntu|cumulus)$/
       execute("tar -zxvf #{onhost_tar_file} -C #{onhost_base_dir}")
     when /^solaris$/
       # uncompress PE puppet-agent tarball

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -442,9 +442,9 @@ module Beaker
         #restart sshd
         if host['platform'] =~ /debian|ubuntu|cumulus/
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
-        elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|fedora-(1[4-9]|2[0-9])/
+        elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|rhel-7|fedora-(1[4-9]|2[0-9])/
           host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
-        elsif host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
+        elsif host['platform'] =~ /centos|el-|redhat|rhel|amazon|fedora|eos/
           host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
         elsif host['platform'] =~ /(free|open)bsd/
           host.exec(Command.new("sudo /etc/rc.d/sshd restart"))
@@ -463,7 +463,7 @@ module Beaker
     def disable_se_linux host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|rhel|amazon|fedora|eos/
           @logger.debug("Disabling se_linux on #{host.name}")
           host.exec(Command.new("sudo su -c \"setenforce 0\""), {:pty => true})
         else
@@ -479,7 +479,7 @@ module Beaker
     def disable_iptables host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|rhel|amazon|fedora|eos/
           logger.debug("Disabling iptables on #{host.name}")
           host.exec(Command.new("sudo su -c \"/etc/init.d/iptables stop\""), {:pty => true})
         else
@@ -502,7 +502,7 @@ module Beaker
         case host['platform']
           when /ubuntu/, /debian/, /cumulus/
             host.exec(Command.new("echo 'Acquire::http::Proxy \"#{opts[:package_proxy]}/\";' >> /etc/apt/apt.conf.d/10proxy"))
-          when /^el-/, /centos/, /fedora/, /redhat/, /amazon/, /eos/
+          when /^el-/, /centos/, /fedora/, /redhat/, /rhel/, /amazon/, /eos/
             host.exec(Command.new("echo 'proxy=#{opts[:package_proxy]}/' >> /etc/yum.conf"))
         else
           logger.debug("Attempting to enable package manager proxy support on non-supported platform: #{host.name}: #{host['platform']}")
@@ -596,7 +596,7 @@ module Beaker
     #
     # @return [Boolean] if the host is el_based
     def el_based? host
-      ['centos','redhat','amazon','scientific','el','oracle'].include?(host['platform'].variant)
+      ['centos','redhat','rhel','amazon','scientific','el','oracle'].include?(host['platform'].variant)
     end
 
   end

--- a/lib/beaker/perf.rb
+++ b/lib/beaker/perf.rb
@@ -4,8 +4,8 @@ module Beaker
 
     PERF_PACKAGES = ['sysstat']
     # SLES does not treat sysstat as a service that can be started
-    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
-    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus/
+    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|rhel|amazon|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
+    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|rhel|amazon|centos|oracle|scientific|fedora|el|eos|cumulus/
 
     # Create the Perf instance and runs setup_perf_on_host on all hosts if --collect-perf-data
     # was used as an option on the Baker command line invocation. Instances of this class do not
@@ -50,7 +50,7 @@ module Beaker
         @logger.perf_output("Enabling aggressive sysstat polling")
         if host['platform'] =~ /debian|ubuntu/
           host.exec(Command.new('sed -i s/5-55\\\/10/*/ /etc/cron.d/sysstat'))
-        elsif host['platform'] =~ /centos|el|fedora|oracle|redhats|amazon|scientific/
+        elsif host['platform'] =~ /centos|rhel|el|fedora|oracle|redhat|amazon|scientific/
           host.exec(Command.new('sed -i s/*\\\/10/*/ /etc/cron.d/sysstat'))
         end
       end

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|amazon|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
+    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|rhel|amazon|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
       { :debian => { "stretch" => "9",
@@ -60,6 +60,7 @@ module Beaker
     # * debian
     # * oracle
     # * redhat
+    # * rhel
     # * scientific
     # * sles
     # * ubuntu

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module Version
-    STRING = '3.27.0'
+    STRING = '3.26.1'
   end
 end

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module Version
-    STRING = '3.26.1'
+    STRING = '3.26.0'
   end
 end

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -37,9 +37,11 @@ module Beaker
 
     describe '#repo_type' do
 
-      it 'returns correctly for el-based platforms' do
-        @platform = 'centos-6-x86_64'
-        expect( instance.repo_type ).to be === 'rpm'
+      ['rhel','centos','redhat'].each do |platform|
+        it "returns correctly for platform '#{platform}'" do
+          @platform = "#{platform}-5-x86_64"
+          expect( instance.repo_type ).to be === 'rpm'
+        end
       end
 
       it 'returns correctly for debian-based platforms' do
@@ -57,9 +59,11 @@ module Beaker
 
     describe '#package_config_dir' do
 
-      it 'returns correctly for el-based platforms' do
-        @platform = 'centos-6-x86_64'
-        expect( instance.package_config_dir ).to be === '/etc/yum.repos.d/'
+      ['rhel','centos','redhat'].each do |platform|
+        it "returns correctly for platform '#{platform}'" do
+          @platform = "#{platform}-5-x86_64"
+          expect( instance.package_config_dir ).to be === '/etc/yum.repos.d/'
+        end
       end
 
       it 'returns correctly for debian-based platforms' do
@@ -82,11 +86,13 @@ module Beaker
 
     describe '#repo_filename' do
 
-      it 'sets the el portion correctly for centos platforms' do
-        @platform = 'centos-5-x86_64'
-        allow( instance ).to receive( :is_pe? ) { false }
-        filename = instance.repo_filename( 'pkg_name', 'pkg_version7' )
-        expect( filename ).to match( /sion7\-el\-/ )
+      ['rhel','centos','redhat'].each do |platform|
+        it "sets the el portion correctly for '#{platform}'" do
+          @platform = "#{platform}-5-x86_64"
+          allow( instance ).to receive( :is_pe? ) { false }
+          filename = instance.repo_filename( 'pkg_name', 'pkg_version7' )
+          expect( filename ).to match( /sion7\-el\-/ )
+        end
       end
 
       it 'sets the sles portion correctly for sles platforms' do

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -111,12 +111,14 @@ module Beaker
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
-      it "checks correctly on centos" do
-        @opts = {'platform' => 'centos-is-me'}
-        pkg = 'centos_package'
-        expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
-        expect( instance.check_for_package(pkg) ).to be === true
+      ['rhel','centos','redhat'].each do |platform|
+        it "checks correctly on #{platform}" do
+          @opts = {'platform' => "#{platform}-is-me"}
+          pkg = "#{platform}_package"
+          expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
+          expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+          expect( instance.check_for_package(pkg) ).to be === true
+        end
       end
 
       it "checks correctly on EOS" do
@@ -298,6 +300,7 @@ module Beaker
                     'centos-7-x86_64' => ["el/7/#{puppet_collection}/x86_64", "puppet-agent-#{puppet_agent_version}-1.el7.x86_64.rpm"],
                     'oracle-7-x86_64' => ["el/7/#{puppet_collection}/x86_64", "puppet-agent-#{puppet_agent_version}-1.el7.x86_64.rpm"],
                     'redhat-7-x86_64' => ["el/7/#{puppet_collection}/x86_64", "puppet-agent-#{puppet_agent_version}-1.el7.x86_64.rpm"],
+                    'rhel-7-x86_64' => ["el/7/#{puppet_collection}/x86_64", "puppet-agent-#{puppet_agent_version}-1.el7.x86_64.rpm"],
                     'scientific-7-x86_64' => ["el/7/#{puppet_collection}/x86_64", "puppet-agent-#{puppet_agent_version}-1.el7.x86_64.rpm"]
                   }
       platforms.each do |p, v|
@@ -485,7 +488,7 @@ module Beaker
 
       it 'Centos & EL: uses yum' do
         package_file = 'testing_789.yay'
-        ['centos', 'el'].each do |platform|
+        ['rhel','centos','redhat'].each do |platform|
           @platform = platform
           expect( instance ).to receive( :execute ).with( /^yum.*#{package_file}$/ )
           instance.install_local_package( package_file )

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -364,9 +364,11 @@ module Beaker
         expect( host.touch('touched_file') ).to be == "c:\\\\windows\\\\system32\\\\cmd.exe /c echo. 2> touched_file"
       end
 
-      it "generates the right absolute command for a unix host" do
-        @platform = 'centos'
-        expect( host.touch('touched_file') ).to be == "/bin/touch touched_file"
+      ['rhel','centos','redhat'].each do |platform|
+        it "generates the right absolute command for a #{platform} host" do
+          @platform = platform
+          expect( host.touch('touched_file') ).to be == "/bin/touch touched_file"
+        end
       end
 
       it "generates the right absolute command for an osx host" do

--- a/spec/beaker/platform_spec.rb
+++ b/spec/beaker/platform_spec.rb
@@ -97,11 +97,12 @@ module Beaker
         expect( platform.with_version_codename ).to be === 'ubuntu-lucid-xxx'
       end
 
-      it "leaves centos-7-xxx alone" do
-        @name = 'centos-7-xxx'
-        expect( platform.with_version_codename ).to be === 'centos-7-xxx'
+      ['rhel','centos','redhat'].each do |p|
+        it "leaves #{p}-7-xxx alone" do
+          @name = "#{p}-7-xxx"
+          expect( platform.with_version_codename ).to be === "#{p}-7-xxx"
+        end
       end
-
     end
 
     context 'with_version_number' do
@@ -126,11 +127,12 @@ module Beaker
         expect( platform.with_version_number ).to be === 'ubuntu-1210-xxx'
       end
 
-      it "leaves centos-7-xxx alone" do
-        @name = 'centos-7-xxx'
-        expect( platform.with_version_number ).to be === 'centos-7-xxx'
+      ['rhel','centos','redhat'].each do |p|
+        it "leaves #{p}-7-xxx alone" do
+          @name = "#{p}-7-xxx"
+          expect( platform.with_version_number ).to be === "#{p}-7-xxx"
+        end
       end
-
     end
 
     context 'round tripping from yaml', if: RUBY_VERSION =~ /^1\.9/ do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -134,6 +134,7 @@ module PlatformHelpers
 
   SYSTEMDPLATFORMS = ['el-7',
                       'centos-7',
+                      'rhel-7',
                       'redhat-7',
                       'oracle-7',
                       'scientific-7',
@@ -144,6 +145,7 @@ module PlatformHelpers
   SYSTEMVPLATFORMS = ['el-',
                       'centos',
                       'fedora',
+                      'rhel',
                       'redhat',
                       'oracle',
                       'amazon',


### PR DESCRIPTION
Added /rhel/ matches to all appropriate areas to support GCE naming
conventions

This is required by the GCE fixes in beaker-google