### PR TITLE
(maint) Allow fine-grained, structured timing for the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.26.0...master)
 
+### Added
+
+- fine-grained, structured timing for tests
+
 # [3.26.0](https://github.com/puppetlabs/beaker/compare/3.25.0...3.26.0) - 2017-10-05
 
 ### Added

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'open_uri_redirections', '~> 0.2.1'
   s.add_runtime_dependency 'in-parallel', '~> 0.1'
   s.add_runtime_dependency 'thor', '~> 0.19'
+  s.add_runtime_dependency 'rubytree', '~> 0.9.2'
 
   # Run time dependencies that are Beaker libraries
   s.add_runtime_dependency 'stringify-hash', '~> 0.0'

--- a/docs/how_to/obtain_fine_grained_structured_timing.md
+++ b/docs/how_to/obtain_fine_grained_structured_timing.md
@@ -1,0 +1,70 @@
+For each suite (`pre-suite`, `tests`, `post-suite`, `pre-cleanup`) that's run, Beaker will generate a `#{suite}-times.txt` file in the log/latest and log/{log-prefix} dated directories. This file provides more fine-grained runtimes for each test case, and also shows how it is structured. It is outputted in a manner that makes it easy to parse for further post-processing (e.g. to run timing experiments across different platforms).
+
+# Example
+
+Assume that we are running the `tests` suite, and we have two files representing our test cases: `file-one.rb` and `file-two.rb`. Here are their contents:
+
+## file-one.rb
+```
+test_name "1" do
+  step "1" do
+  end
+  step "2" do
+  end
+  step "3" do
+  end
+end
+```
+
+## file-two.rb
+```
+test_name "1" do
+  step "1" do
+    step "2" do
+    end
+  end
+  step "3" do
+    raise "This step is meant to fail!"
+  end
+  step "4" do
+  end
+end
+```
+
+Further, assume that both test cases ran to completion under the slow failure mode. The structured timing tree would then be something like:
+
+## file-one.rb
+```
+                                        ("file-one.rb", 30s)
+                                          ("Test 1", 20s)                               
+                        ("Step 1", 10s)   ("Step 2", 5s)    ("Step 3", 5s)
+```
+
+## file-two.rb
+```
+                                        ("file-two.rb", X)
+                                          ("Test 1", X)
+                       ("Step 1", 20s)                      ("Step 3", X) 
+                       ("Step 2", 20s)
+```
+
+where notice that for `file-two.rb` since we had a failure, the overall test case failed. Failures are marked with an `X`. Any preceding steps that succeeded are preseved, and ensuing steps are skipped (which is why there is no node for "Step 4").
+
+Using these trees, our `tests-times.txt` file would have the following output:
+```
+("file-one.rb", 30s)
+  ("Test 1", 20s)
+    ("Step 1", 10s)
+    ("Step 2", 5s)
+    ("Step 3", 5s)
+ 
+("file-two.rb", X)
+  ("Test 1", X)
+    ("Step 1", 20s)
+      ("Step 2", 20s)
+    ("Step 3", X)
+```
+
+# Aside
+
+This extension is a prototype, and thus does not properly handle skipped or pending test cases (although it would not be a substantial task to do so). Furthermore, Steps and Tests with the same name are allowed (e.g. step `2` in `file-one.rb` can be named step `1`). Also, the timing information does not print to `STDOUT`, unlike the corresponding `#{suite}-summary.txt` file. So this information can only be viewed by opening the `#{suite}-times.txt` file.

--- a/lib/beaker.rb
+++ b/lib/beaker.rb
@@ -55,4 +55,7 @@ module Beaker
     # do nothing
   end
 
+  # For the timing extension
+  require 'tree'
+
 end

--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -88,6 +88,15 @@ module Beaker
     # {Beaker::DSL::Helpers#on}.
     attr_accessor :result
 
+    # The tree that stores the timing information for the test case.
+    # Due to the possibility of there being steps with the same name
+    # (or tests with the same name), a node's label will be a 3-tuple
+    # (<kind>, <uuid>, <name>) where <kind> is whether that node is a
+    # "Test" or a "Step"; <uuid> is the UUID; and <name> is the name of
+    # the "Test"/"Step". Note: The root node (test-case itself) will not
+    # have this label.
+    attr_accessor :timed_node
+
     # @param [Hosts,Array<Host>] these_hosts The hosts to execute this test
     #                                        against/on.
     # @param [Logger] logger A logger that implements
@@ -107,6 +116,7 @@ module Beaker
       @teardown_procs = []
       @metadata = {}
       @exports  = []
+      @timed_node = Tree::TreeNode.new(@path.to_s, 0.0)  
       set_current_test_filename(@path ? File.basename(@path, '.rb') : nil)
 
 
@@ -151,6 +161,7 @@ module Beaker
               @logger.info('End teardown')
             end
           end
+          @timed_node.content = @runtime
           @sublog = @logger.get_sublog
           @last_result = @logger.last_result
           return self

--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -90,6 +90,8 @@ module Beaker
       # has not studied the implementation in detail. --daniel 2011-03-14
       @test_suite_results.summarize( Logger.new(log_path("#{name}-summary.txt", @options[:log_dated_dir]), STDOUT) )
 
+      @test_suite_results.summarize_times( Logger.new(log_path("#{name}-times.txt", @options[:log_dated_dir]), { :quiet => true }) )
+
       junit_file_log  = log_path(@options[:xml_file], @options[:xml_dated_dir])
       if @options[:xml_time_enabled]
         junit_file_time = log_path(@options[:xml_time], @options[:xml_dated_dir])

--- a/lib/beaker/test_suite_result.rb
+++ b/lib/beaker/test_suite_result.rb
@@ -132,6 +132,36 @@ module Beaker
       summary_logger.notify("\n\n")
     end
 
+    #Plain text summay of the test suite's elapsed times for each test case,
+    #along with each test (and step) within the test case
+    #@param [Logger] summary_logger The logger we will print the summary to
+    def summarize_times(summary_logger)
+      @test_cases.each do |test_case|
+        summarize_times_helper(0, test_case.timed_node, summary_logger)
+        summary_logger.notify("")
+      end
+    end
+
+    # Unfortunately, rubytree's print_tree method is not very flexible with
+    # the "prefix" (i.e. indentation) when printing the tree. Their current
+    # implementation would generate a timing summary that, although structured,
+    # would be hard to parse-out. Thus, this method is used to print the information
+    # instead.
+    # @!visibility private
+    def summarize_times_helper(depth, subtree, summary_logger)
+      indent = '  ' * depth
+      if subtree.is_root?
+        prefix = ""
+        name = subtree.name
+      else
+        kind, _, name = subtree.name
+        prefix = kind + " "
+      end
+
+      summary_logger.notify("#{indent}(#{prefix}#{name}, #{subtree.content})")
+      subtree.children { |child| summarize_times_helper(depth + 1, child, summary_logger) }
+    end
+
     #A convenience method for printing the results of a {TestCase}
     #@param [TestCase] test_case The {TestCase} to examine and print results for
     def print_test_result(test_case)

--- a/spec/beaker/test_case_spec.rb
+++ b/spec/beaker/test_case_spec.rb
@@ -17,6 +17,8 @@ module Beaker
         testcase.run_test
         status = testcase.instance_variable_get(:@test_status)
         expect(status).to be === :pass
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'updates test_status to :skip on SkipTest' do
@@ -29,6 +31,8 @@ module Beaker
         testcase.run_test
         status = testcase.instance_variable_get(:@test_status)
         expect(status).to be === :skip
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'updates test_status to :pending on PendingTest' do
@@ -41,6 +45,8 @@ module Beaker
         testcase.run_test
         status = testcase.instance_variable_get(:@test_status)
         expect(status).to be === :pending
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'updates test_status to :fail on FailTest' do
@@ -53,6 +59,8 @@ module Beaker
         testcase.run_test
         status = testcase.instance_variable_get(:@test_status)
         expect(status).to be === :fail
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'correctly handles RuntimeError' do
@@ -63,6 +71,8 @@ module Beaker
         @path = path
         expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(RuntimeError))
         testcase.run_test
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'correctly handles ScriptError' do
@@ -73,6 +83,8 @@ module Beaker
         @path = path
         expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(ScriptError))
         testcase.run_test
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'correctly handles Timeout::Error' do
@@ -83,6 +95,8 @@ module Beaker
         @path = path
         expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(Timeout::Error))
         testcase.run_test
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'correctly handles CommandFailure' do
@@ -93,6 +107,8 @@ module Beaker
         @path = path
         expect( testcase ).to receive( :log_and_fail_test ).once.with(kind_of(Host::CommandFailure))
         testcase.run_test
+        timed_node = testcase.instance_variable_get(:@timed_node)
+        expect(timed_node.name).to eql(path)
       end
 
       it 'records a test failure if an assertion fails in a teardown block' do


### PR DESCRIPTION
Previously, Beaker stored information for the duration of a single
test case. However, there was no way to obtain the duration of each
piece of the test (e.g. how long a specific step or sub-test took).
This commit adds this capability -- refer to the comments above the
"timed_node" instance in the TestCase class for more details on how
it works/is stored. Note that the timing specific information is
written to a single file in the same directory as the existing
summary.txt files under the basename #{suite}-times.txt.

This commit allows for the possibility of more fine-grained metrics
tracking (e.g. which step in a test failed, which sub-test failed,
etc.) in the future by extending the timed_node object to instead
represent an AST for the test case.