### PR TITLE
(BKR-1168) beaker version causes error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,9 @@ git logs & PR history.
 
 - concept of `manual_test` and `manual_step`
 
+### Bug fixes
+
+- Fixed corruption of `opts[:ignore]` when using `rsync`
+
 # [3.25.0](https://github.com/puppetlabs/beaker/compare/3.24.0...3.25.0) - 2017-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,9 @@ git logs & PR history.
 
 - concept of `manual_test` and `manual_step`
 
+### Fixed
+
+- beaker --version causes error output
+
 # [3.25.0](https://github.com/puppetlabs/beaker/compare/3.24.0...3.25.0) - 2017-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.26.0...master)
 
+### Added
+
+- support amazon as a platform
+
 # [3.26.0](https://github.com/puppetlabs/beaker/compare/3.25.0...3.26.0) - 2017-10-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@ Tracking in this Changelog began for this project in version 3.25.0.
 If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 
-# [Unreleased](https://github.com/puppetlabs/beaker/compare/3.26.0...master)
+# [Unreleased](https://github.com/puppetlabs/beaker/compare/3.27.0...master)
+
+# [3.27.0](https://github.com/puppetlabs/beaker/compare/3.26.0...3.27.0) - 2017-10-19
 
 ### Added
 
 - support amazon as a platform
+- add codenames for MacOS 10.13 and Ubuntu Artful
 
 # [3.26.0](https://github.com/puppetlabs/beaker/compare/3.25.0...3.26.0) - 2017-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ Tracking in this Changelog began for this project in version 3.25.0.
 If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 
-# [Unreleased](https://github.com/puppetlabs/beaker/compare/3.27.0...master)
+# [Unreleased](https://github.com/puppetlabs/beaker/compare/3.28.0...master)
+
+# [3.28.0](https://github.com/puppetlabs/beaker/compare/3.27.0...3.28.0) - 2017-11-01
+
+### Fixed
+
+- corruption of `opts[:ignore]` when using `rsync`
 
 # [3.27.0](https://github.com/puppetlabs/beaker/compare/3.26.0...3.27.0) - 2017-10-19
 
@@ -25,10 +31,6 @@ git logs & PR history.
 ### Added
 
 - concept of `manual_test` and `manual_step`
-
-### Bug fixes
-
-- Fixed corruption of `opts[:ignore]` when using `rsync`
 
 # [3.25.0](https://github.com/puppetlabs/beaker/compare/3.24.0...3.25.0) - 2017-09-26
 

--- a/acceptance/lib/beaker/acceptance/install_utils.rb
+++ b/acceptance/lib/beaker/acceptance/install_utils.rb
@@ -3,7 +3,7 @@ module Beaker
     module InstallUtils
 
       PLATFORM_PATTERNS = {
-        :redhat        => /fedora|el|centos/,
+        :redhat        => /fedora|el|centos|amazon/,
         :debian        => /debian|ubuntu/,
         :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
         :solaris_10    => /solaris-10/,

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -72,7 +72,7 @@ module Beaker
     #Provision, validate and configure all hosts as defined in the hosts file
     def provision
       # return self if only invoking the OptionsParser help
-      return self if @options[:help]
+      return self if @options[:help] or @options[:beaker_version_print]
 
       begin
         @hosts =  []

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -559,10 +559,7 @@ module Beaker
       end
 
       if opts.has_key?(:ignore) and not opts[:ignore].empty?
-        opts[:ignore].map! do |value|
-          "--exclude '#{value}'"
-        end
-        rsync_args << opts[:ignore].join(' ')
+        rsync_args << opts[:ignore].map { |value| "--exclude '#{value}'" }.join(' ')
       end
 
       # We assume that the *contents* of the directory 'from_path' needs to be

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -168,7 +168,7 @@ module Unix::Exec
       exec(Beaker::Command.new("service ssh restart"))
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
       exec(Beaker::Command.new("systemctl restart sshd.service"))
-    when /el-|centos|fedora|redhat|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
       exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/
       exec(Beaker::Command.new("rcsshd restart"))
@@ -196,7 +196,7 @@ module Unix::Exec
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
-    when /el-|centos|fedora|redhat|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -39,7 +39,7 @@ module Unix::Pkg
       when /el-4/
         @logger.debug("Package query not supported on rhel4")
         return false
-      when /cisco|fedora|centos|eos|el-/
+      when /cisco|fedora|amazon|centos|eos|el-/
         result = execute("rpm -q #{name}", opts) { |result| result }
       when /ubuntu|debian|cumulus|huaweios/
         result = execute("dpkg -s #{name}", opts) { |result| result }
@@ -407,8 +407,8 @@ module Unix::Pkg
     when /^(solaris)$/
       release_path_end, release_file = solaris_puppet_agent_dev_package_info(
         puppet_collection, puppet_agent_version, opts )
-    when /^(sles|aix|el|centos|oracle|redhat|scientific)$/
-      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|scientific)/)
+    when /^(sles|aix|el|centos|oracle|redhat|amazon|scientific)$/
+      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|amazon|scientific)/)
       arch = 'ppc' if variant == 'aix' && arch == 'power'
       version = '7.1' if variant == 'aix' && version == '7.2'
       release_path_end = "#{variant}/#{version}/#{puppet_collection}/#{arch}"

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -444,7 +444,7 @@ module Beaker
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|fedora-(1[4-9]|2[0-9])/
           host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
-        elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        elsif host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
         elsif host['platform'] =~ /(free|open)bsd/
           host.exec(Command.new("sudo /etc/rc.d/sshd restart"))
@@ -463,7 +463,7 @@ module Beaker
     def disable_se_linux host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           @logger.debug("Disabling se_linux on #{host.name}")
           host.exec(Command.new("sudo su -c \"setenforce 0\""), {:pty => true})
         else
@@ -479,7 +479,7 @@ module Beaker
     def disable_iptables host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           logger.debug("Disabling iptables on #{host.name}")
           host.exec(Command.new("sudo su -c \"/etc/init.d/iptables stop\""), {:pty => true})
         else
@@ -502,7 +502,7 @@ module Beaker
         case host['platform']
           when /ubuntu/, /debian/, /cumulus/
             host.exec(Command.new("echo 'Acquire::http::Proxy \"#{opts[:package_proxy]}/\";' >> /etc/apt/apt.conf.d/10proxy"))
-          when /^el-/, /centos/, /fedora/, /redhat/, /eos/
+          when /^el-/, /centos/, /fedora/, /redhat/, /amazon/, /eos/
             host.exec(Command.new("echo 'proxy=#{opts[:package_proxy]}/' >> /etc/yum.conf"))
         else
           logger.debug("Attempting to enable package manager proxy support on non-supported platform: #{host.name}: #{host['platform']}")
@@ -596,7 +596,7 @@ module Beaker
     #
     # @return [Boolean] if the host is el_based
     def el_based? host
-      ['centos','redhat','scientific','el','oracle'].include?(host['platform'].variant)
+      ['centos','redhat','amazon','scientific','el','oracle'].include?(host['platform'].variant)
     end
 
   end

--- a/lib/beaker/perf.rb
+++ b/lib/beaker/perf.rb
@@ -4,8 +4,8 @@ module Beaker
 
     PERF_PACKAGES = ['sysstat']
     # SLES does not treat sysstat as a service that can be started
-    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
-    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|centos|oracle|scientific|fedora|el|eos|cumulus/
+    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
+    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus/
 
     # Create the Perf instance and runs setup_perf_on_host on all hosts if --collect-perf-data
     # was used as an option on the Baker command line invocation. Instances of this class do not
@@ -50,7 +50,7 @@ module Beaker
         @logger.perf_output("Enabling aggressive sysstat polling")
         if host['platform'] =~ /debian|ubuntu/
           host.exec(Command.new('sed -i s/5-55\\\/10/*/ /etc/cron.d/sysstat'))
-        elsif host['platform'] =~ /centos|el|fedora|oracle|redhats|scientific/
+        elsif host['platform'] =~ /centos|el|fedora|oracle|redhats|amazon|scientific/
           host.exec(Command.new('sed -i s/*\\\/10/*/ /etc/cron.d/sysstat'))
         end
       end

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -11,7 +11,8 @@ module Beaker
                      "wheezy"  => "7",
                      "squeeze" => "6",
                    },
-        :ubuntu => { "zesty"   => "1704",
+        :ubuntu => { "artful"  => "1710",
+                     "zesty"   => "1704",
                      "yakkety" => "1610",
                      "xenial"  => "1604",
                      "wily"    => "1510",
@@ -24,10 +25,11 @@ module Beaker
                      "precise" => "1204",
                      "lucid"   => "1004",
                    },
-        :osx =>    { "sierra"    => "1012",
-                     "elcapitan" => "1011",
-                     "yosemite"  => "1010",
-                     "mavericks" => "109",
+        :osx =>    { "highsierra" => "1013",
+                     "sierra"     => "1012",
+                     "elcapitan"  => "1011",
+                     "yosemite"   => "1010",
+                     "mavericks"  => "109",
                    }
       }
 

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
+    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|amazon|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
       { :debian => { "stretch" => "9",

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module Version
-    STRING = '3.26.0'
+    STRING = '3.27.0'
   end
 end

--- a/lib/beaker/version.rb
+++ b/lib/beaker/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module Version
-    STRING = '3.27.0'
+    STRING = '3.28.0'
   end
 end

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -50,6 +50,19 @@ module Beaker
       Beaker::CLI.new.parse_options
     }
 
+    describe '#print_version' do
+      before do
+        options  = Beaker::Options::OptionsHash.new
+        options[:beaker_version] = 'version_number'
+        options[:beaker_version_print] = true
+        cli.instance_variable_set('@options', options)
+      end
+      it 'prints the version options withour error' do
+        expect(cli.logger).to receive(:info).exactly(3).times
+        cli.print_version_and_options
+      end
+    end
+
     context '#configured_options' do
       it 'returns a list of options that were not presets' do
         attribution = cli.instance_variable_get(:@attribution)

--- a/spec/beaker/host/mac_spec.rb
+++ b/spec/beaker/host/mac_spec.rb
@@ -7,7 +7,7 @@ module Mac
       if @platform
         { :platform => Beaker::Platform.new( @platform) }
       else
-        { :platform => Beaker::Platform.new( 'osx-10.9-x86_64' ) }
+        { :platform => Beaker::Platform.new( 'osx-10.12-x86_64' ) }
       end
     }
     let(:host)    { make_host( 'name', options.merge(platform) ) }
@@ -39,11 +39,11 @@ module Mac
       end
 
       it 'adds the version dot correctly if not supplied' do
-        @platform = 'osx-109-x86_64'
+        @platform = 'osx-10.12-x86_64'
         allow( host ).to receive( :link_exists? ) { true }
         release_path_end, release_file = host.puppet_agent_dev_package_info( 'PC3', 'pav3', :download_url => '' )
-        expect( release_path_end ).to match( /10\.9/ )
-        expect( release_file ).to match( /10\.9/ )
+        expect( release_path_end ).to match( /10\.12/ )
+        expect( release_file ).to match( /10\.12/ )
       end
 
       it 'runs the correct install for osx platforms (newest link format)' do
@@ -53,9 +53,9 @@ module Mac
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav4-/ )
         # verify the "newest hotness" is set correctly for the end of the mac package name
-        expect( release_file ).to match( /#{Regexp.escape("-1.osx10.9.dmg")}$/ )
+        expect( release_file ).to match( /#{Regexp.escape("-1.osx10.12.dmg")}$/ )
         # verify the release path end is set correctly
-        expect( release_path_end ).to be === "apple/10.9/PC4/x86_64"
+        expect( release_path_end ).to be === "apple/10.12/PC4/x86_64"
       end
 
       it 'runs the correct install for osx platforms (new link format)' do
@@ -65,9 +65,9 @@ module Mac
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav7-/ )
         # verify the "new hotness" is set correctly for the end of the mac package name
-        expect( release_file ).to match( /#{Regexp.escape("-1.mavericks.dmg")}$/ )
+        expect( release_file ).to match( /#{Regexp.escape("-1.sierra.dmg")}$/ )
         # verify the release path end isn't changed in the "new hotness" case
-        expect( release_path_end ).to be === "apple/10.9/PC7/x86_64"
+        expect( release_path_end ).to be === "apple/10.12/PC7/x86_64"
       end
 
       it 'runs the correct install for osx platforms (old link format)' do
@@ -77,7 +77,7 @@ module Mac
         # verify the mac package name starts the name correctly
         expect( release_file ).to match( /^puppet-agent-pav8-/ )
         # verify the old way is set correctly for the end of the mac package name
-        expect( release_file ).to match( /#{Regexp.escape("-osx-10.9-x86_64.dmg")}$/ )
+        expect( release_file ).to match( /#{Regexp.escape("-osx-10.12-x86_64.dmg")}$/ )
         # verify the release path end is set correctly to the older method
         expect( release_path_end ).to be === "apple/PC8"
       end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -85,7 +85,7 @@ describe Beaker do
     ]
   end
 
-  ['centos','el-','redhat','fedora','eos'].each do | rhel_like |
+  ['centos','el-','redhat','fedora','amazon','eos'].each do | rhel_like |
     it_should_behave_like 'enables_root_login', rhel_like, [
       "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\"",
       "sudo -E /sbin/service sshd reload"

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -651,6 +651,24 @@ module Beaker
         expect(Rsync).to receive(:run).with(*rsync_args).and_return(Beaker::Result.new(host, 'output!'))
         expect(host.do_rsync_to(*args).cmd).to eq('output!')
       end
+
+      it "doesn't corrupt :ignore option" do
+        create_files(['source'])
+
+        ignore_list = ['.bundle']
+        args = ['source', 'target', {:ignore => ignore_list}]
+
+        key = host['ssh']['keys']
+        if key.is_a? Array
+          key = key.first
+        end
+
+        rsync_args = ['source', 'target', ['-az', "-e \"ssh -i #{key} -p 22 -o 'StrictHostKeyChecking no'\"", "--exclude '.bundle'"]]
+        expect(Rsync).to receive(:run).twice.with(*rsync_args).and_return(Beaker::Result.new(host, 'output!'))
+
+        host.do_rsync_to *args
+        host.do_rsync_to *args
+      end
     end
 
     it 'interpolates to its "name"' do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -146,6 +146,7 @@ module PlatformHelpers
                       'fedora',
                       'redhat',
                       'oracle',
+                      'amazon',
                       'scientific',
                       'eos'].concat(FEDORASYSTEMV)
 end


### PR DESCRIPTION
The issue was happening because beaker will run the function that needs the HOSTS array, which is define as null when running beaker --version, therefore ruby thrown _noMethod for nilClass_.

This commit add an expression to return the code when using **--version** option, instead of continuing running the beaker code. 