### PR TITLE
(QENG-5106) Update Beaker to support amazon as a platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.26.0...master)
 
+### Added
+
+- support amazon as a platform
+
 # [3.26.0](https://github.com/puppetlabs/beaker/compare/3.25.0...3.26.0) - 2017-10-05
 
 ### Added

--- a/acceptance/lib/beaker/acceptance/install_utils.rb
+++ b/acceptance/lib/beaker/acceptance/install_utils.rb
@@ -3,7 +3,7 @@ module Beaker
     module InstallUtils
 
       PLATFORM_PATTERNS = {
-        :redhat        => /fedora|el|centos/,
+        :redhat        => /fedora|el|centos|amazon/,
         :debian        => /debian|ubuntu/,
         :debian_ruby18 => /debian|ubuntu-lucid|ubuntu-precise/,
         :solaris_10    => /solaris-10/,

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -168,7 +168,7 @@ module Unix::Exec
       exec(Beaker::Command.new("service ssh restart"))
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|fedora-(1[4-9]|2[0-9])|archlinux-/
       exec(Beaker::Command.new("systemctl restart sshd.service"))
-    when /el-|centos|fedora|redhat|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
       exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/
       exec(Beaker::Command.new("rcsshd restart"))
@@ -196,7 +196,7 @@ module Unix::Exec
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
-    when /el-|centos|fedora|redhat|oracle|scientific|eos/
+    when /el-|centos|fedora|redhat|amazon|oracle|scientific|eos/
       directory = create_tmpdir_on(self)
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -39,7 +39,7 @@ module Unix::Pkg
       when /el-4/
         @logger.debug("Package query not supported on rhel4")
         return false
-      when /cisco|fedora|centos|eos|el-/
+      when /cisco|fedora|amazon|centos|eos|el-/
         result = execute("rpm -q #{name}", opts) { |result| result }
       when /ubuntu|debian|cumulus|huaweios/
         result = execute("dpkg -s #{name}", opts) { |result| result }
@@ -407,8 +407,8 @@ module Unix::Pkg
     when /^(solaris)$/
       release_path_end, release_file = solaris_puppet_agent_dev_package_info(
         puppet_collection, puppet_agent_version, opts )
-    when /^(sles|aix|el|centos|oracle|redhat|scientific)$/
-      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|scientific)/)
+    when /^(sles|aix|el|centos|oracle|redhat|amazon|scientific)$/
+      variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|amazon|scientific)/)
       arch = 'ppc' if variant == 'aix' && arch == 'power'
       version = '7.1' if variant == 'aix' && version == '7.2'
       release_path_end = "#{variant}/#{version}/#{puppet_collection}/#{arch}"

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -444,7 +444,7 @@ module Beaker
           host.exec(Command.new("sudo su -c \"service ssh restart\""), {:pty => true})
         elsif host['platform'] =~ /arch|centos-7|el-7|redhat-7|fedora-(1[4-9]|2[0-9])/
           host.exec(Command.new("sudo -E systemctl restart sshd.service"), {:pty => true})
-        elsif host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        elsif host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           host.exec(Command.new("sudo -E /sbin/service sshd reload"), {:pty => true})
         elsif host['platform'] =~ /(free|open)bsd/
           host.exec(Command.new("sudo /etc/rc.d/sshd restart"))
@@ -463,7 +463,7 @@ module Beaker
     def disable_se_linux host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           @logger.debug("Disabling se_linux on #{host.name}")
           host.exec(Command.new("sudo su -c \"setenforce 0\""), {:pty => true})
         else
@@ -479,7 +479,7 @@ module Beaker
     def disable_iptables host, opts
       logger = opts[:logger]
       block_on host do |host|
-        if host['platform'] =~ /centos|el-|redhat|fedora|eos/
+        if host['platform'] =~ /centos|el-|redhat|amazon|fedora|eos/
           logger.debug("Disabling iptables on #{host.name}")
           host.exec(Command.new("sudo su -c \"/etc/init.d/iptables stop\""), {:pty => true})
         else
@@ -502,7 +502,7 @@ module Beaker
         case host['platform']
           when /ubuntu/, /debian/, /cumulus/
             host.exec(Command.new("echo 'Acquire::http::Proxy \"#{opts[:package_proxy]}/\";' >> /etc/apt/apt.conf.d/10proxy"))
-          when /^el-/, /centos/, /fedora/, /redhat/, /eos/
+          when /^el-/, /centos/, /fedora/, /redhat/, /amazon/, /eos/
             host.exec(Command.new("echo 'proxy=#{opts[:package_proxy]}/' >> /etc/yum.conf"))
         else
           logger.debug("Attempting to enable package manager proxy support on non-supported platform: #{host.name}: #{host['platform']}")
@@ -596,7 +596,7 @@ module Beaker
     #
     # @return [Boolean] if the host is el_based
     def el_based? host
-      ['centos','redhat','scientific','el','oracle'].include?(host['platform'].variant)
+      ['centos','redhat','amazon','scientific','el','oracle'].include?(host['platform'].variant)
     end
 
   end

--- a/lib/beaker/perf.rb
+++ b/lib/beaker/perf.rb
@@ -4,8 +4,8 @@ module Beaker
 
     PERF_PACKAGES = ['sysstat']
     # SLES does not treat sysstat as a service that can be started
-    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
-    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|centos|oracle|scientific|fedora|el|eos|cumulus/
+    PERF_SUPPORTED_PLATFORMS = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus|sles/
+    PERF_START_PLATFORMS     = /debian|ubuntu|redhat|amazon|centos|oracle|scientific|fedora|el|eos|cumulus/
 
     # Create the Perf instance and runs setup_perf_on_host on all hosts if --collect-perf-data
     # was used as an option on the Baker command line invocation. Instances of this class do not
@@ -50,7 +50,7 @@ module Beaker
         @logger.perf_output("Enabling aggressive sysstat polling")
         if host['platform'] =~ /debian|ubuntu/
           host.exec(Command.new('sed -i s/5-55\\\/10/*/ /etc/cron.d/sysstat'))
-        elsif host['platform'] =~ /centos|el|fedora|oracle|redhats|scientific/
+        elsif host['platform'] =~ /centos|el|fedora|oracle|redhats|amazon|scientific/
           host.exec(Command.new('sed -i s/*\\\/10/*/ /etc/cron.d/sysstat'))
         end
       end

--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
+    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|amazon|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
       { :debian => { "stretch" => "9",

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -85,7 +85,7 @@ describe Beaker do
     ]
   end
 
-  ['centos','el-','redhat','fedora','eos'].each do | rhel_like |
+  ['centos','el-','redhat','fedora','amazon','eos'].each do | rhel_like |
     it_should_behave_like 'enables_root_login', rhel_like, [
       "sudo su -c \"sed -ri 's/^#?PermitRootLogin no|^#?PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config\"",
       "sudo -E /sbin/service sshd reload"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -146,6 +146,7 @@ module PlatformHelpers
                       'fedora',
                       'redhat',
                       'oracle',
+                      'amazon',
                       'scientific',
                       'eos'].concat(FEDORASYSTEMV)
 end


### PR DESCRIPTION
We have converted two pipelines that require AWS resources to use ABS.  The pipelines previously used redhat as a platform when calling beaker.  Now that they will use ABS to acquire resources, the platform will be amazon which beaker did not yet support. 