### PR TITLE
(maint) Update the Ruby install of the pre-suite to force install bundler

### DIFF
--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -27,6 +27,6 @@ test_name 'Install and configure Ruby 2.2.5 on the SUT' do
   end
 
   step 'update gem on the SUT and install bundler' do
-    on default, 'gem update --system;gem install bundler'
+    on default, 'gem update --system;gem install --force bundler'
   end
 end


### PR DESCRIPTION
When a new VM is checked out from the vmpooler, bundler is already installed.
This bundler installation causes a conflict when the beaker acceptance tests
attempt to install bundler, which in turn, causes the acceptance tests to fail.
This change adds a --force flag to the bundler install, ignoring the conflict