### PR TITLE
(maint) Add beaker-abs to optional hypervisors on bundle install

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -55,6 +55,7 @@ Gem::Specification.new do |s|
   # Optional provisioner specific support
   s.add_runtime_dependency 'beaker-docker', '~> 0.1'
   s.add_runtime_dependency 'beaker-aws', '~> 0.1'
+  s.add_runtime_dependency 'beaker-abs', '~> 0.4'
   s.add_runtime_dependency 'beaker-vmpooler', '~> 1.0'
   s.add_runtime_dependency 'beaker-google', '~> 0.1'
   s.add_runtime_dependency 'beaker-vagrant', '~> 0.1'


### PR DESCRIPTION
This is needed for CI.Next support as some of the beaker acceptance
tests will be using always-be-scheduling. The beaker dependency in
beaker-abs has been removed as of 0.4.0, resolving the circular dependency
issue.