### PR TITLE
(BKR-1263) Preserve hosts using hostname

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -257,7 +257,7 @@ module Beaker
         file_host_hash = h.merge(file_host_hash)
         @hosts.each do |host|
           if host_name.to_s == host.name.to_s
-            newly_keyed_hosts_entries[host.reachable_name] = file_host_hash.merge(host.host_hash)
+            newly_keyed_hosts_entries[host.hostname] = file_host_hash.merge(host.host_hash)
             break
           end
         end

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -61,7 +61,7 @@ module Beaker
       end
     end
 
-    context '#combined_instance_and_options_hosts' do
+    describe '#combined_instance_and_options_hosts' do
       let (:options_host) { {'HOSTS' => {'ubuntu' => {:options_attribute => 'options'}} }}
       let (:instance_host ) {
         [Beaker::Host.create('ubuntu', {:platform => 'host'}, {} )]
@@ -77,6 +77,26 @@ module Beaker
         expect(merged_host['ubuntu']).to have_key(:platform)
         expect(merged_host['ubuntu'][:options_attribute]).to eq('options')
         expect(merged_host['ubuntu'][:platform]).to eq('host')
+      end
+
+      context 'when hosts share IP addresses' do
+        let (:options_host) do
+          {'HOSTS' => {'host1' => {:options_attribute => 'options'},
+                       'host2' => {:options_attribute => 'options'}}}
+        end
+        let (:instance_host ) do
+          [Beaker::Host.create('host1',
+                               {:platform => 'host', :ip => '127.0.0.1'}, {} ),
+           Beaker::Host.create('host2',
+                               {:platform => 'host', :ip => '127.0.0.1'}, {} )]
+        end
+
+        it 'creates separate entries for each host' do
+          expected_hosts = instance_host.map(&:hostname)
+          merged_hosts = cli.combined_instance_and_options_hosts
+
+          expect(merged_hosts.keys).to eq(expected_hosts)
+        end
       end
     end
 


### PR DESCRIPTION
This patch flips the logic that writes out the hosts_preserved.yml over from
using Beaker::Host#reachable_name to Beaker::Host#hostname. The reachable_name
method prefers to return a bare IP address if one is in use --- this makes it
unsuitable for identifying hosts from providers like Docker that put many SUTs
behind a single IP address using different SSH ports.