### PR TITLE
(BKR-1268) Load project options from .beaker.yml

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -41,7 +41,6 @@ module Beaker
         return self
       end
 
-
       #add additional paths to the LOAD_PATH
       if not @options[:load_path].empty?
         @options[:load_path].each do |path|

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -47,6 +47,7 @@ module Beaker
 
     let(:cli)      {
       allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:exists?).with('.beaker.yml').and_return(false)
       Beaker::CLI.new.parse_options
     }
 


### PR DESCRIPTION
If .beaker.yml is present in the current working directory, then load
the project's options. The overall precedence from lowest to highest is:

    defaults
    .beaker.yml
    ~/.beaker/subcommand_options.yaml
    ./beaker/subcommand_options.yaml
    etc

The project options (.beaker.yml) are essentially project defaults, so
they come after beaker defaults and before the subcommand options.

It is also possible for the project options to specify the options_file
to load so that it doesn't need to be specified on the command line.

Note this fixes a spec test that was stubbing part of the parse_args
method that it was trying to test.
