### PR TITLE
(BKR-1169) Ensure indentation is balanced

### DIFF
--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -39,9 +39,10 @@ module Beaker
         logger.notify "\n* #{step_name}\n"
         set_current_step_name(step_name)
         if block_given?
-          logger.step_in()
           begin
-            yield
+            logger.with_indent do
+              yield
+            end
           rescue Exception => e
             if(@options.has_key?(:debug_errors) && @options[:debug_errors] == true)
               logger.info("Exception raised during step execution and debug-errors option is set, entering pry. Exception was: #{e.inspect}")
@@ -50,7 +51,6 @@ module Beaker
             end
             raise e
           end
-          logger.step_out()
         end
       end
 
@@ -120,9 +120,9 @@ module Beaker
         logger.notify "\n#{my_name}\n"
         set_current_test_name(my_name)
         if block_given?
-          logger.step_in()
-          yield
-          logger.step_out()
+          logger.with_indent do
+            yield
+          end
         end
       end
 

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -332,11 +332,11 @@ module Beaker
         # the options should come at the end of the method signature (rubyism)
         # and they shouldn't be ssh specific
 
-        @logger.step_in()
         seconds = Benchmark.realtime {
-          result = connection.execute(cmdline, options, output_callback)
+          @logger.with_indent do
+            result = connection.execute(cmdline, options, output_callback)
+          end
         }
-        @logger.step_out()
 
         if not options[:silent]
           @logger.debug "\n#{log_prefix} executed in %0.2f seconds" % seconds

--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -232,9 +232,19 @@ module Beaker
       end
     end
 
+    # Indent the step level for the duration of block.
+    def with_indent(&block)
+      old_line_prefix = self.line_prefix.dup
+      self.line_prefix << '  '
+      yield
+    ensure
+      self.line_prefix = old_line_prefix
+    end
+
     # Sets the step level appropriately for logging to be indented correctly
     #
     # @return nil
+    # @deprecated use {Logger#with_indent}
     def step_in
       self.line_prefix = self.line_prefix + '  '
     end
@@ -242,6 +252,7 @@ module Beaker
     # Sets the step level appropriately for logging to be indented correctly
     #
     # @return nil
+    # @deprecated use {Logger#with_indent}
     def step_out
       self.line_prefix = self.line_prefix.chop.chop
     end

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -28,10 +28,9 @@ describe ClassMixedWithDSLStructure do
     end
 
     it 'yields if a block is given' do
-      expect( subject ).to receive( :logger ).and_return( logger ).exactly(3).times
+      expect( subject ).to receive( :logger ).and_return( logger ).exactly(2).times
       allow(  subject ).to receive( :set_current_step_name )
-      expect( logger ).to receive( :step_in )
-      expect( logger ).to receive( :step_out )
+      allow( logger ).to receive(:with_indent) { |&block| block.call }
       expect( logger ).to receive( :notify )
       expect( subject ).to receive( :foo )
       subject.step 'blah' do
@@ -130,10 +129,9 @@ describe ClassMixedWithDSLStructure do
 
       it 'yields if a block is given' do
         subject.instance_variable_set(:@options, options)
-        expect( subject ).to receive( :logger ).and_return( logger ).exactly(3).times
+        expect( subject ).to receive( :logger ).and_return( logger ).exactly(2).times
         expect( logger ).to receive( :notify )
-        expect( logger ).to receive( :step_in )
-        expect( logger ).to receive( :step_out )
+        allow( logger ).to receive(:with_indent) { |&block| block.call }
         expect( subject ).to receive( :foo )
         subject.manual_test 'blah' do
           subject.foo
@@ -164,10 +162,9 @@ describe ClassMixedWithDSLStructure do
     end
 
     it 'yields if a block is given' do
-      expect( subject ).to receive( :logger ).and_return( logger ).exactly(3).times
+      expect( subject ).to receive( :logger ).and_return( logger ).exactly(2).times
       expect( logger ).to receive( :notify )
-      expect( logger ).to receive( :step_in )
-      expect( logger ).to receive( :step_out )
+      allow( logger ).to receive(:with_indent) { |&block| block.call }
       expect( subject ).to receive( :foo )
       subject.test_name 'blah' do
         subject.foo

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -209,8 +209,7 @@ module Beaker
         logger = double(:logger)
         allow( logger ).to receive(:host_output)
         allow( logger ).to receive(:debug)
-        allow( logger ).to receive(:step_in)
-        allow( logger ).to receive(:step_out)
+        allow( logger ).to receive(:with_indent) { |&block| block.call }
         host.instance_variable_set :@logger, logger
         conn = double(:connection)
         allow( conn ).to receive(:execute).and_return(result)

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -47,11 +47,18 @@ module Beaker
     end
 
     context '#prefix_log_line' do
-      def prefix_log_line_test_compare_helper(in_test, out_answer, step_in_loop=1)
+      around :each do |example|
         logger.line_prefix = ''
+        begin
+          example.run
+        ensure
+          logger.line_prefix = ''
+        end
+      end
+
+      def prefix_log_line_test_compare_helper(in_test, out_answer, step_in_loop=1)
         step_in_loop.times { logger.step_in() }
         expect( logger.prefix_log_line(in_test) ).to be === out_answer
-        logger.line_prefix = ''
       end
 
       it 'can be successfully called with a arrays' do
@@ -86,15 +93,21 @@ module Beaker
     end
 
     context '#step_* methods' do
-      it 'steps in correctly (simple case)' do
+      around :each do |example|
         logger.line_prefix = ''
+        begin
+          example.run
+        ensure
+          logger.line_prefix = ''
+        end
+      end
+
+      it 'steps in correctly (simple case)' do
         logger.step_in()
         expect( logger.line_prefix ).to be === '  '
-        logger.line_prefix = ''
       end
 
       it 'sets length correctly in mixed scenario ' do
-        logger.line_prefix = ''
         logger.step_in()
         logger.step_in()
         logger.step_out()
@@ -102,47 +115,37 @@ module Beaker
         logger.step_in()
         logger.step_out()
         expect( logger.line_prefix ).to be === '    '
-        logger.line_prefix = ''
       end
 
       it 'can be unevenly stepped out, will remain at base: 0' do
-        logger.line_prefix = ''
         logger.step_in()
         10.times { logger.step_out() }
         expect( logger.line_prefix ).to be === ''
       end
 
       it 'can handle arbitrary strings as prefixes' do
-        logger.line_prefix = ''
         logger.line_prefix = 'Some string:'
         expect( logger.line_prefix ).to be === 'Some string:'
-        logger.line_prefix = ''
       end
 
       it 'can handle stepping in with arbitrary strings' do
-        logger.line_prefix = ''
         logger.line_prefix = 'Some string:'
         logger.step_in()
         logger.step_in()
         expect( logger.line_prefix ).to be === 'Some string:    '
-        logger.line_prefix = ''
       end
 
       it 'can handle stepping out with arbitrary strings' do
-        logger.line_prefix = ''
         logger.line_prefix = 'Some string:'
         10.times { logger.step_out() }
         expect( logger.line_prefix ).to be === ''
-        logger.line_prefix = ''
       end
 
       it 'can handle stepping in and out with arbitrary strings' do
-        logger.line_prefix = ''
         logger.line_prefix = 'Some string:'
         10.times { logger.step_in() }
         10.times { logger.step_out() }
         expect( logger.line_prefix ).to be === 'Some string:'
-        logger.line_prefix = ''
       end
     end
 

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -56,9 +56,10 @@ module Beaker
         end
       end
 
-      def prefix_log_line_test_compare_helper(in_test, out_answer, step_in_loop=1)
-        step_in_loop.times { logger.step_in() }
-        expect( logger.prefix_log_line(in_test) ).to be === out_answer
+      def prefix_log_line_test_compare_helper(in_test, out_answer)
+        logger.with_indent do
+          expect( logger.prefix_log_line(in_test) ).to be === out_answer
+        end
       end
 
       it 'can be successfully called with a arrays' do
@@ -88,11 +89,17 @@ module Beaker
       it 'can be nested' do
         line_arg = "\n\nwhy should this matter"
         answer = "      \n      \n      why should this matter"
-        prefix_log_line_test_compare_helper(line_arg, answer, 3)
+        logger.with_indent do
+          logger.with_indent do
+            logger.with_indent do
+              expect( logger.prefix_log_line(line_arg) ).to be === answer
+            end
+          end
+        end
       end
     end
 
-    context '#step_* methods' do
+    context 'when indenting' do
       around :each do |example|
         logger.line_prefix = ''
         begin
@@ -103,24 +110,19 @@ module Beaker
       end
 
       it 'steps in correctly (simple case)' do
-        logger.step_in()
-        expect( logger.line_prefix ).to be === '  '
+        logger.with_indent do
+          expect( logger.line_prefix ).to be === '  '
+        end
       end
 
       it 'sets length correctly in mixed scenario ' do
-        logger.step_in()
-        logger.step_in()
-        logger.step_out()
-        logger.step_in()
-        logger.step_in()
-        logger.step_out()
-        expect( logger.line_prefix ).to be === '    '
-      end
-
-      it 'can be unevenly stepped out, will remain at base: 0' do
-        logger.step_in()
-        10.times { logger.step_out() }
-        expect( logger.line_prefix ).to be === ''
+        logger.with_indent do
+          logger.with_indent {}
+          logger.with_indent do
+            logger.with_indent {}
+            expect( logger.line_prefix ).to be === '    '
+          end
+        end
       end
 
       it 'can handle arbitrary strings as prefixes' do
@@ -130,22 +132,27 @@ module Beaker
 
       it 'can handle stepping in with arbitrary strings' do
         logger.line_prefix = 'Some string:'
-        logger.step_in()
-        logger.step_in()
-        expect( logger.line_prefix ).to be === 'Some string:    '
-      end
-
-      it 'can handle stepping out with arbitrary strings' do
-        logger.line_prefix = 'Some string:'
-        10.times { logger.step_out() }
-        expect( logger.line_prefix ).to be === ''
+        logger.with_indent do
+          logger.with_indent do
+            expect( logger.line_prefix ).to be === 'Some string:    '
+          end
+        end
       end
 
       it 'can handle stepping in and out with arbitrary strings' do
         logger.line_prefix = 'Some string:'
-        10.times { logger.step_in() }
-        10.times { logger.step_out() }
+        10.times { logger.with_indent {} }
         expect( logger.line_prefix ).to be === 'Some string:'
+      end
+
+      it 'restores the original prefix if an argument is raised' do
+        logger.line_prefix = 'Some string:'
+        expect do
+          logger.with_indent do
+            raise "whoops"
+          end
+        end.to raise_error(RuntimeError, 'whoops')
+        expect(logger.line_prefix).to eq('Some string:')
       end
     end
 


### PR DESCRIPTION
Add `with_indent` method which indents the log for the duration of the
block. Use `ensure` so the indent level is always balanced, even if the
block raises an exception, e.g. due to skip_test.

Deprecate `step_in` and `step_out` since they can leave the indentation
unbalanced.