### PR TITLE
(MAINT) add host_test-avoid script for vpool re-use test

### DIFF
--- a/acceptance/scripts/all_but_host_test.sh
+++ b/acceptance/scripts/all_but_host_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+top_level=$(git rev-parse --show-toplevel)
+acceptance_test_base="$top_level/acceptance/tests/base"
+
+find $acceptance_test_base -type f -name '*.rb' |
+grep -v host_test.rb |
+awk 'BEGIN {
+  comma_index = 1
+} {
+  if (comma_index == 1) {
+    comma_string = $0
+  } else {
+    comma_string = comma_string "," $0
+  }
+  comma_index = comma_index + 1
+} END {
+  print comma_string
+}'


### PR DESCRIPTION
This change adds a simple script that will get all `acceptance/tests/base`
files except `host_test.rb` & format them to be passed to the `--tests`
CLI parameter.

The reason we want this is that for our nightly master test on ubuntu
during the VM re-use test, the ssh `port_open?` method continues to
fail when it clearly isn't the case, since commands can be executed
over SSH in every other step.

This is not something that we could reproduce locally. Since that's the
case & this issue hasn't been reported elsewhere (that we're aware of),
it seems to be irrelevant to us. Since that's the case, I've made this
script to help us avoid running it in the re-use case.

# Job Changes

Created [this job](https://jenkins-beaker.delivery.puppetlabs.net/job/qe_beaker_intn-sys_beaker-acceptance-reuse-vpool-debug-beaker-puppet_host-test/configure) (private link)to test development of these changes.
The changes required in order for the script to be used are that you have
to run the script & store it in a variable:
```
TESTS_INDIVIDUALLY=$(source $(pwd)/acceptance/scripts/all_but_host_test.sh)
```
and then set the `--tests` parameter to be the variable.

# Post-Merge Tasks 

- [ ] Make job changes listed above
- [ ] delete actual job above used during development