### PR TITLE
(BKR-1384) Clean up ssh paranoid setting deprecation warnings

### DIFF
--- a/docs/concepts/argument_processing_and_precedence.md
+++ b/docs/concepts/argument_processing_and_precedence.md
@@ -266,7 +266,7 @@ Values already included in Beaker as defaults for required arguments.
           :run_in_parallel        => [],
           :ssh                    => {
                                      :config                => false,
-                                     :paranoid              => false,
+                                     :verify_host_key       => false,
                                      :auth_methods          => ["publickey"],
                                      :port                  => 22,
                                      :forward_agent         => true,

--- a/docs/how_to/use_user_password_authentication.md
+++ b/docs/how_to/use_user_password_authentication.md
@@ -25,7 +25,7 @@ The log will then read as:
 _snip_
 ```
 pe-centos6 20:19:16$ echo hello!
-Attempting ssh connection to pe-centos6, user: anode, opts: {:config=>false, :paranoid=>false, :timeout=>300, :auth_methods=>["password"], :port=>22, :forward_agent=>true, :keys=>["/Users/anode/.ssh/id_rsa"], :user_known_hosts_file=>"/Users/anode/.ssh/known_hosts", :password=>"anode", :user=>"anode"}
+Attempting ssh connection to pe-centos6, user: anode, opts: {:config=>false, :verify_host_key=>false, :timeout=>300, :auth_methods=>["password"], :port=>22, :forward_agent=>true, :keys=>["/Users/anode/.ssh/id_rsa"], :user_known_hosts_file=>"/Users/anode/.ssh/known_hosts", :password=>"anode", :user=>"anode"}
 ```
 _/snip_
 

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -196,7 +196,7 @@ module Beaker
           :use_fog_credentials    => true,
           :ssh                    => {
                                      :config                => false,
-                                     :paranoid              => false,
+                                     :verify_host_key       => false,
                                      :auth_methods          => ["publickey"],
                                      :port                  => 22,
                                      :forward_agent         => true,

--- a/spec/beaker/options/parser_spec.rb
+++ b/spec/beaker/options/parser_spec.rb
@@ -127,7 +127,7 @@ module Beaker
         before { FakeFS.deactivate! }
 
         it 'pulls the args into key called :command_line' do
-          my_args = ['--log-level', 'debug', '-h', hosts_path]  
+          my_args = ['--log-level', 'debug', '-h', hosts_path]
 
           expect(parser.parse_args(my_args)[:command_line]).to include(my_args.join(' '))
           expect(parser.attribution[:command_line]).to be == 'cmd'
@@ -164,7 +164,7 @@ module Beaker
               :level => 'lowest',
               :ssh => {
                   :config => 'config123',
-                  :paranoid => 'paranoid123',
+                  :verify_host_key => 'verify123',
                   :port => 'port123',
                   :forward_agent => 'forwardagent123',
                   :keys => 'keys123',
@@ -248,7 +248,7 @@ module Beaker
             expect(attribution[:ssh][:auth_methods]).to be == 'options_file'
             expect(attribution[:ssh][:user_known_hosts_file]).to be == 'options_file'
             expect(attribution[:ssh][:config]).to be == 'preset'
-            expect(attribution[:ssh][:paranoid]).to be == 'preset'
+            expect(attribution[:ssh][:verify_host_key]).to be == 'preset'
             expect(attribution[:ssh][:port]).to be == 'preset'
             expect(attribution[:ssh][:forward_agent]).to be == 'preset'
             expect(attribution[:ssh][:keys]).to be == 'preset'
@@ -321,7 +321,7 @@ module Beaker
           args   = ["-h", hosts_path, "--log-level", log_level, "--type", type, "--install", "PUPPET/1.0,HIERA/hello"]
           output = parser.parse_args(args)
           attribution = parser.attribution
-          expect(output[:hosts_file]).to be == hosts_path  
+          expect(output[:hosts_file]).to be == hosts_path
           expect(attribution[:hosts_file]).to be == 'cmd'
           expect(output[:jenkins_build_url]).to be == build_url
           expect(attribution[:jenkins_build_url]).to be == 'env'


### PR DESCRIPTION
Prior to this commit every time beaker made an SSH connection, it would
give a deprecation warning for the use of the `paranoid` setting, which
has been deprecated in favor of `verify_host_key`.
This commit removes all use of the `paranoid` setting in favor of
`verify_host_key`.

Example fixed output:

```
➜  frankenbuilder git:(master) ✗ BEAKER_VERSION="file:///s/beaker" ./frankenbuilder -v 2018.1 --install
Loading configs from ./.frankenbuilder
Cleaning /tmp/frankenmodules...
Done.
Using local copy of PE puppet-enterprise-2018.1.0-rc7-21-gc66e074-el-7-x86_64.tar
Extracting /s/frankenbuilder/tarballs/puppet-enterprise-2018.1.0-rc7-21-gc66e074-el-7-x86_64.tar...
PE 2018.1.0-rc7-21-gc66e074 has been extracted to /s/frankenbuilder/frankenbuild (2018.1.0-rc7-21-gc66e074)
:answers:
  console_admin_password: puppetlabs
CONFIG:
  log_level: debug
  nfs_server: none
  consoleport: 443
  pooling_api: http://vmpooler.delivery.puppetlabs.net/
  preserve_hosts: always
  keyfile: "/Users/highb/.ssh/id_rsa-acceptance"
HOSTS:
  master.vm-1:
    platform: el-7-x86_64
    pe_dir: /s/frankenbuilder/frankenbuild
    pe_ver: 2018.1.0-rc7-21-gc66e074
    pe_upgrade_dir:
    pe_upgrade_ver:
    roles:
      - master
      - database
      - dashboard
      - agent
    hypervisor: vmpooler
    template: centos-7-x86_64
Hypervisor for master.vm-1 is vmpooler
Beaker::Hypervisor, found some vmpooler boxes to create
Requesting VM set from vmpooler (with authentication token)
Using available host 'lxhqqt4tha84xke.delivery.puppetlabs.net' (master.vm-1)
Spent 0.02 seconds grabbing VMs
Tagging vmpooler VMs
Spent 0.01 seconds tagging VMs
Looking for disks to add...
No disks to add for lxhqqt4tha84xke

lxhqqt4tha84xke.delivery.puppetlabs.net (master.vm-1) 11:37:41$ rpm -q curl
  Warning: Beaker does not support vmhostname to SSH to host, trying next available method.
  Warning: Skipping ip method to ssh to host as its value is not set. Refer to https://github.com/puppetlabs/beaker/tree/master/docs/how_to/ssh_connection_preference.md to remove this warning
  Warning: Beaker does not support hostname to SSH to host, trying next available method.
  Warning: Skipping ip method to ssh to host as its value is not set. Refer to https://github.com/puppetlabs/beaker/tree/master/docs/how_to/ssh_connection_preference.md to remove this warning
  Attempting ssh connection to lxhqqt4tha84xke.delivery.puppetlabs.net, user: root, opts: {:config=>false, :verify_host_key=>false, :auth_methods=>["publickey"], :port=>22, :forward_agent=>true, :keys=>["/Users/highb/.ssh/id_rsa-acceptance"], :user_known_hosts_file=>"/Users/highb/.ssh/known_hosts", :keepalive=>true}
  curl-7.29.0-25.el7.centos.x86_64

lxhqqt4tha84xke.delivery.puppetlabs.net (master.vm-1) executed in 0.21 seconds

lxhqqt4tha84xke.delivery.puppetlabs.net (master.vm-1) 11:37:41$ rpm -q ntpdate
  package ntpdate is not installed

lxhqqt4tha84xke.delivery.puppetlabs.net (master.vm-1) executed in 0.07 seconds
Exited: 1
```