### PR TITLE
(maint) update yard dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.0'
 
   # Documentation dependencies
-  s.add_development_dependency 'yard', '< 0.9.6'
+  s.add_development_dependency 'yard', '~> 0.9.11'
 
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
This commit updates yard to ~> 0.9.11 [1].

[1]: https://nvd.nist.gov/vuln/detail/CVE-2017-17042