### PR TITLE
(maint) Add redhat_fips to the supported platforms regex

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -3,7 +3,7 @@ module Beaker
   # all String methods while adding several platform-specific use cases.
   class Platform < String
     # Supported platforms
-    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
+    PLATFORMS = /^(huaweios|cisco_nexus|cisco_ios_xr|(free|open)bsd|osx|centos|fedora|debian|oracle|redhat_fips|redhat|scientific|sles|ubuntu|windows|solaris|aix|archlinux|el|eos|cumulus|f5|netscaler)\-.+\-.+$/
     # Platform version numbers vs. codenames conversion hash
     PLATFORM_VERSION_CODES =
       { :debian => { "stretch" => "9",
@@ -59,6 +59,7 @@ module Beaker
     # * fedora
     # * debian
     # * oracle
+    # * redhat_fips
     # * redhat
     # * scientific
     # * sles


### PR DESCRIPTION
I *think* this is needed for beaker to work with the new redhat_fips platform definition, but please double-check to make sure that's the case.