### PR TITLE
(maint) fix missing colon for subcommand option

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -55,7 +55,7 @@ module Beaker
     class_option :'exec_manual_tests', :type => :boolean, :group => 'Beaker run'
     class_option :'test-tag-exclude', :type => :string, :group => 'Beaker run'
     class_option :'test-tag-and', :type => :string, :group => 'Beaker run'
-    class_option :'test-tag-or', type => :string, :group => 'Beaker run'
+    class_option :'test-tag-or', :type => :string, :group => 'Beaker run'
 
     # The following are listed as deprecated in beaker --help, but needed now for
     # feature parity for beaker 3.x.


### PR DESCRIPTION
[skip_ci]