### PR TITLE
(BKR-1426) Fully qualify sles ssh restart cmd

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -171,7 +171,7 @@ module Unix::Exec
     when /el-|centos|fedora|redhat|oracle|scientific|eos/
       exec(Beaker::Command.new("/sbin/service sshd restart"))
     when /sles/
-      exec(Beaker::Command.new("rcsshd restart"))
+      exec(Beaker::Command.new("/usr/sbin/rcsshd restart"))
     when /solaris/
       exec(Beaker::Command.new("svcadm restart svc:/network/ssh:default"))
     when /(free|open)bsd/


### PR DESCRIPTION
Previous to this commit, the sles SSH restart command was not fully
qualified. This lead to the command not being found if the user did not
have `/usr/sbin` in their path for some reason as we could not set the
path until after we modify the ssh service to permit user environments
(which requires a ssh restart).
This commit fully qualifies the sles `rcsshd` command. From testing
internally it appears the command exists at `/usr/sbin` for sles 11
32/64 bit and sles 12 64 bit.