### PR TITLE
(BKR-1429) Configure host type for all hosts

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -558,32 +558,32 @@ module Beaker
 
       block_on host do |host|
         skip_msg = host.skip_set_env?
-        unless skip_msg.nil?
-          logger.debug( skip_msg )
-          next
+        if skip_msg.nil?
+          env = construct_env(host, opts)
+          logger.debug("setting local environment on #{host.name}")
+          if host['platform'] =~ /windows/ and host.is_cygwin?
+            env['CYGWIN'] = 'nodosfilewarning'
+          end
+          host.ssh_permit_user_environment
+          host.ssh_set_user_environment(env)
+        else
+          logger.debug(skip_msg)
         end
-
-        env = construct_env(host, opts)
-        logger.debug("setting local environment on #{host.name}")
-        if host['platform'] =~ /windows/ and host.is_cygwin?
-          env['CYGWIN'] = 'nodosfilewarning'
-        end
-        host.ssh_permit_user_environment()
-
-        host.ssh_set_user_environment(env)
 
         # REMOVE POST BEAKER 3: backwards compatability, do some setup based upon the global type
         # this is the worst and i hate it
         Class.new.extend(Beaker::DSL).configure_type_defaults_on(host)
 
-        #close the host to re-establish the connection with the new sshd settings
-        host.close
+        if skip_msg.nil?
+          #close the host to re-establish the connection with the new sshd settings
+          host.close
 
-        # print out the working env
-        if host.is_powershell?
-          host.exec(Command.new("SET"))
-        else
-          host.exec(Command.new("cat #{host[:ssh_env_file]}"))
+          # print out the working env
+          if host.is_powershell?
+            host.exec(Command.new("SET"))
+          else
+            host.exec(Command.new("cat #{host[:ssh_env_file]}"))
+          end
         end
 
       end


### PR DESCRIPTION
Previously, beaker didn't set the host type, e.g. aio, for network
device hosts during the `provision` subcommand, so the saved beaker
session file was missing `privatebindir` and other PATH related settings
for those hosts. The next `exec` subcommand would load the session file,
create new Host objects, and fail to find ruby during the
ruby_compiler_optimization.rb test.

This wasn't an issue prior to subcommands, because 1) puppet's pre-suite
always called `configure_type_defaults_on` after installing
puppet-agent[1], and 2) the `host['privatebindir']` settings stayed in
memory for the duration of the beaker run.

This commit ensures if `set_env` is called, then
`configure_type_defaults_on` will be too. It's important to do this
during the `provision` subcommand, as that's the last time beaker
updates its session file.

The `configure_type_defaults_on` method also updates
`~/.ssh/environment` to include `/opt/puppetlabs/bin`, but it's a noop
for network devices since `PermitUserEnvironment` is not enabled.

[1] https://github.com/puppetlabs/beaker-puppet/blob/49dbc51b6723782ce856190c9e5c0ec24afcc19f/lib/beaker-puppet/install_utils/puppet5.rb#L177