### PR TITLE
(BKR-1430) Use relative paths for beaker exec

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -181,9 +181,9 @@ module Beaker
           @cli.options[suite] = []
         end
         if Pathname(resource).directory?
-          @cli.options[:tests] = Dir.glob("#{Pathname(resource).expand_path}/*.rb")
+          @cli.options[:tests] = Dir.glob("#{Pathname(resource)}/*.rb")
         else
-          @cli.options[:tests] = [Pathname(resource).expand_path.to_s]
+          @cli.options[:tests] = [Pathname(resource).to_s]
         end
       elsif resource.match(/pre-suite|tests|post-suite|pre-cleanup/)
         # The regex match here is loose so that users can supply multiple suites,

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -178,7 +178,6 @@ module Beaker
 
         expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
         expect_any_instance_of(Pathname).to receive(:directory?).and_return(false)
-        expect_any_instance_of(Pathname).to receive(:expand_path).once
         expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
         expect{subcommand.exec('resource')}.to_not raise_error
       end
@@ -187,7 +186,6 @@ module Beaker
         expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
         expect_any_instance_of(Pathname).to receive(:directory?).and_return(true)
         expect(Dir).to receive(:glob)
-        expect_any_instance_of(Pathname).to receive(:expand_path).once
         expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
         expect{subcommand.exec('resource')}.to_not raise_error
       end


### PR DESCRIPTION
Prior to this commit, beaker expanded out the entire file path for
beaker exec; this is unnecessary and results in including the "%"
character in the path for testing some of our internationalized
matrices.