### PR TITLE
Fix `BEAKER_provision=no` workflow

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -38,7 +38,7 @@ module Beaker
 
       hypervisor = hyper_class.new(hosts_to_provision, options)
       self.set_ssh_connection_preference(hosts_to_provision, hypervisor)
-      hypervisor.provision if options[:provision]
+      hypervisor.provision
 
       hypervisor
     end


### PR DESCRIPTION
Fixes BKR-1111 and BKR-494.