### PR TITLE
(BKR-1444) Recursively glob the tests directory

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -181,7 +181,7 @@ module Beaker
           @cli.options[suite] = []
         end
         if Pathname(resource).directory?
-          @cli.options[:tests] = Dir.glob("#{Pathname(resource)}/*.rb")
+          @cli.options[:tests] = Dir.glob("#{Pathname(resource)}/**/*.rb")
         else
           @cli.options[:tests] = [Pathname(resource).to_s]
         end


### PR DESCRIPTION
Recursively glob directories when using the beaker exec subcommand.