### PR TITLE
BKR-1467 - add_el_extras - use "install_package_with_rpm"

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -258,7 +258,7 @@ module Beaker
           if result.exit_code == 1
             url_base = opts[:epel_url]
             url_base = opts[:epel_url_archive] if host['platform'].version == '5'
-            host.exec(Command.new("rpm -i#{debug_opt} #{url_base}/epel-release-latest-#{host['platform'].version}.noarch.rpm"))
+            host.install_package_with_rpm("#{url_base}/epel-release-latest-#{host['platform'].version}.noarch.rpm", '--replacepkgs', { :package_proxy => opts[:package_proxy] })
             #update /etc/yum.repos.d/epel.repo for new baseurl
             host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{url_base}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))
             #remove mirrorlist

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -318,9 +318,11 @@ describe Beaker do
       expect( Beaker::Command ).to receive( :new ).with(
         "rpm -qa | grep epel-release"
       ).exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with(
-        "rpm -i http://archive.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm"
-      ).exactly( 2 ).times
+      hosts.each do |host|
+        expect(host).to receive( :install_package_with_rpm ).with(
+          "http://archive.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm", "--replacepkgs", {:package_proxy => false}
+        ).once
+      end
       expect( Beaker::Command ).to receive( :new ).with(
         "sed -i -e 's;#baseurl.*$;baseurl=http://archive\\.fedoraproject\\.org/pub/archive/epel/5/$basearch;' /etc/yum.repos.d/epel.repo"
       ).exactly( 2 ).times
@@ -345,9 +347,11 @@ describe Beaker do
       expect( Beaker::Command ).to receive( :new ).with(
         "rpm -qa | grep epel-release"
       ).exactly( 4 ).times
-      expect( Beaker::Command ).to receive( :new ).with(
-        "rpm -i http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
-      ).exactly( 4 ).times
+      hosts.each do |host|
+        expect(host).to receive( :install_package_with_rpm ).with(
+          "http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm", "--replacepkgs", {:package_proxy => false}
+        ).once
+      end
       expect( Beaker::Command ).to receive( :new ).with(
         "sed -i -e 's;#baseurl.*$;baseurl=http://dl\\.fedoraproject\\.org/pub/epel/6/$basearch;' /etc/yum.repos.d/epel.repo"
       ).exactly( 4 ).times


### PR DESCRIPTION
The method uses to call "rpm -i" directly instead of using standardized "install_package_with_rpm"
This has been changed and package_proxy is passed, so the installation now works behind a proxy.