### PR TITLE
(BKR-1466) Accept comma-separated tests for exec subcommand

### DIFF
--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -16,6 +16,7 @@ module Beaker
       # the options are parsed and replaced with a new logger based on what is passed
       # in to configure the logger.
       @logger = Beaker::Logger.new
+      @options = {}
     end
 
     def parse_options

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -6,6 +6,7 @@ module Beaker
   class Subcommand < Thor
     SubcommandUtil = Beaker::Subcommands::SubcommandUtil
 
+    attr_reader :cli
 
     def initialize(*args)
       super

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -172,8 +172,9 @@ module Beaker
       end
 
       beaker_suites = [:pre_suite, :tests, :post_suite, :pre_cleanup]
-
-      if Pathname(resource).exist?
+      resources = resource.split(',')
+      paths = resources.map { |r| Pathname(r) }
+      if paths.all?(&:exist?)
         # If we determine the resource is a valid file resource, then we empty
         # all the suites and run that file resource in the tests suite. In the
         # future, when we have the ability to have custom suites, we should change
@@ -181,12 +182,14 @@ module Beaker
         beaker_suites.each do |suite|
           @cli.options[suite] = []
         end
-        if Pathname(resource).directory?
-          @cli.options[:tests] = Dir.glob("#{Pathname(resource)}/**/*.rb")
-        else
-          @cli.options[:tests] = [Pathname(resource).to_s]
-        end
-      elsif resource.match(/pre-suite|tests|post-suite|pre-cleanup/)
+        @cli.options[:tests] = paths.map do |path|
+          if path.directory?
+            Dir.glob("#{path}/**/*.rb")
+          else
+            path.to_s
+          end
+        end.flatten
+      elsif resources.all? { |r| r =~ /^(pre-suite|tests|post-suite|pre-cleanup)$/ }
         # The regex match here is loose so that users can supply multiple suites,
         # such as `beaker exec pre-suite,tests`.
         beaker_suites.each do |suite|
@@ -195,6 +198,7 @@ module Beaker
       else
         raise ArgumentError, "Unable to parse #{resource} with beaker exec"
       end
+
       @cli.execute!
     end
 

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -9,9 +9,9 @@ module Beaker
 
     context '#initialize' do
       it 'creates a cli object' do
-        expect(Beaker::CLI).to receive(:new).once
-        subcommand
+        expect(subcommand.cli).to be
       end
+
       describe 'File operation initialization for subcommands' do
         it 'checks to ensure subcommand file resources exist' do
           expect(FileUtils).to receive(:mkdir_p).with(SubcommandUtil::CONFIG_DIR)
@@ -28,7 +28,6 @@ module Beaker
           expect(FileUtils).to receive(:touch).with(SubcommandUtil::SUBCOMMAND_STATE)
           subcommand
         end
-
       end
     end
 
@@ -80,6 +79,9 @@ module Beaker
 
       it 'should not error with valid beaker options' do
         beaker_options_list.each do |option|
+          allow_any_instance_of(Beaker::CLI).to receive(:parse_options)
+          allow_any_instance_of(Beaker::CLI).to receive(:configured_options).and_return({})
+
           allow(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
           allow(yaml_store_mock).to receive(:transaction).and_yield
           allow(yaml_store_mock).to receive(:[]=).with('provisioned', false)
@@ -87,6 +89,7 @@ module Beaker
           allow_any_instance_of(Beaker::Logger).to receive(:notify).twice
           expect(SubcommandUtil::SUBCOMMAND_OPTIONS).to receive(:exist?).and_return(true)
           expect(SubcommandUtil::SUBCOMMAND_STATE).to receive(:exist?).and_return(true)
+
           expect {Beaker::Subcommand.start(['init', '--hosts', 'centos', "--#{option}"])}.to_not output(/ERROR/).to_stderr
         end
       end
@@ -103,13 +106,16 @@ module Beaker
     end
 
     context '#init' do
-      let( :cli ) { subcommand.instance_variable_get(:@cli) }
+      let( :cli ) { subcommand.cli }
       let( :mock_options ) { {:timestamp => 'noon', :other_key => 'cordite'}}
       let( :yaml_store_mock ) { double('yaml_store_mock') }
-      it 'calculates options and writes them to disk and deletes the' do
-        expect(cli).to receive(:parse_options)
-        allow(cli).to receive(:configured_options).and_return(mock_options)
 
+      before :each do
+        allow(cli).to receive(:parse_options)
+        allow(cli).to receive(:configured_options).and_return(mock_options)
+      end
+
+      it 'calculates options and writes them to disk and deletes the' do
         allow(File).to receive(:open)
         allow(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
         allow(yaml_store_mock).to receive(:transaction).and_yield
@@ -117,13 +123,14 @@ module Beaker
         subcommand.init
         expect(mock_options).not_to have_key(:timestamp)
       end
+
       it 'requires hosts flag' do
         expect{subcommand.init}.to raise_error(NotImplementedError)
       end
     end
 
     context '#provision' do
-      let ( :cli ) { subcommand.instance_variable_get(:@cli) }
+      let ( :cli ) { subcommand.cli }
       let( :yaml_store_mock ) { double('yaml_store_mock') }
       let ( :host_hash ) { {'mynode.net' => {:name => 'mynode', :platform => Beaker::Platform.new('centos-6-x86_64')}}}
       let ( :cleaned_hosts ) {double()}
@@ -133,6 +140,7 @@ module Beaker
       let ( :hosts) {double('hosts')}
       let ( :hypervisors) {double('hypervisors')}
       let (:options) {double ('options')}
+
       it 'provisions the host and saves the host info' do
         expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
         allow(yaml_store_mock).to receive(:[]).and_return(false)
@@ -157,25 +165,27 @@ module Beaker
         expect(yaml_store_mock).to receive(:[]=).with('provisioned', true)
         subcommand.provision
       end
+
       it 'does not allow hosts to be passed' do
         subcommand.options = {:hosts => "myhost"}
         expect{subcommand.provision()}.to raise_error(NotImplementedError)
       end
     end
 
-
     context 'exec' do
+      before :each do
+        allow(subcommand.cli).to receive(:parse_options)
+        allow(subcommand.cli).to receive(:initialize_network_manager)
+      end
+
       it 'calls execute! when no resource is given' do
         expect_any_instance_of(Pathname).to_not receive(:directory?)
         expect_any_instance_of(Pathname).to_not receive(:exist?)
-        expect_any_instance_of(Beaker::CLI).to receive(:parse_options).once
-        expect_any_instance_of(Beaker::CLI).to receive(:initialize_network_manager).once
         expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
         expect{subcommand.exec}.to_not raise_error
       end
 
       it 'checks to to see if the resource is a file_resource' do
-
         expect_any_instance_of(Pathname).to receive(:exist?).and_return(true)
         expect_any_instance_of(Pathname).to receive(:directory?).and_return(false)
         expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
@@ -191,7 +201,6 @@ module Beaker
       end
 
       it 'allows a hard coded suite name to be specified' do
-
         allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
         expect_any_instance_of(Beaker::CLI).to receive(:execute!).once
         expect{subcommand.exec('tests')}.to_not raise_error
@@ -204,12 +213,18 @@ module Beaker
     end
 
     context 'destroy' do
-      let( :cli ) { subcommand.instance_variable_get(:@cli) }
+      let( :cli ) { subcommand.cli }
       let( :mock_options ) { {:timestamp => 'noon', :other_key => 'cordite'}}
       let( :yaml_store_mock ) { double('yaml_store_mock') }
+      let( :network_manager) {double('network_manager')}
+
       it 'calls destroy and updates the yaml store' do
+        allow(cli).to receive(:parse_options)
+        allow(cli).to receive(:initialize_network_manager)
+        allow(cli).to receive(:network_manager).and_return(network_manager)
+        expect(network_manager).to receive(:cleanup)
+
         expect(YAML::Store).to receive(:new).with(SubcommandUtil::SUBCOMMAND_STATE).and_return(yaml_store_mock)
-        allow(SubcommandUtil).to receive(:cleanup).with(cli).and_return(true)
         allow(yaml_store_mock).to receive(:transaction).and_yield
         allow(yaml_store_mock).to receive(:[]).with('provisioned').and_return(true)
         allow(yaml_store_mock).to receive(:delete).with('provisioned').and_return(true)


### PR DESCRIPTION
Beaker's exec subcommand will now accept a comma-separated list of
file/directories. Each directory will be recursively globbed. All other
suites, e.g. pre-suite, will be skipped.

This commit preserves the ability to specify a comma-separated list of
suites, e.g. beaker exec pre-suite,tests. Beaker will skip any suite not
listed.  Note the tests to run must have have been specified in the
options file or specified on the command line:

    beaker exec pre-suite --pre-suite step1.rb

It's kind of strange that the exec subcommand takes either a list of
testcases to execute or the names of suites to execute, because
specifying `beaker exec tests` is ambiguous. It could be "execute all of
the testcases in the tests directory", or "execute the 'tests' suite".
This commit preserves the ambiguity, but it means you can't specify a
suite name and a testcase name, e.g. pre-suite,tests/step1.rb.