### PR TITLE
(BKR-1007) Use AIX 6.1 packages everywhere for puppet6

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -417,8 +417,15 @@ module Unix::Pkg
         puppet_collection, puppet_agent_version, opts )
     when /^(sles|aix|el|centos|oracle|redhat|scientific)$/
       variant = 'el' if variant.match(/(?:el|centos|oracle|redhat|scientific)/)
-      arch = 'ppc' if variant == 'aix' && arch == 'power'
-      version = '7.1' if variant == 'aix' && version == '7.2'
+      if variant == 'aix'
+        arch = 'ppc' if arch == 'power'
+        version_x, version_y = /^(\d+)\.(\d+)/.match(puppet_agent_version).captures.map(&:to_i)
+        if version_x < 5 || version_x == 5 && version_y < 99 # 5.99.z indicates pre-release puppet6
+          version = '7.1' if version == '7.2'
+        else
+          version = '6.1'
+        end
+      end
       release_path_end = "#{variant}/#{version}/#{puppet_collection}/#{arch}"
       release_file = "puppet-agent-#{puppet_agent_version}-1.#{variant}#{version}.#{arch}.rpm"
     else

--- a/spec/beaker/host/unix_spec.rb
+++ b/spec/beaker/host/unix_spec.rb
@@ -171,11 +171,11 @@ module Unix
       end
 
       it 'sets the arch correctly on aix-power platforms' do
-        @platform = 'aix-14-power'
+        @platform = 'aix-6.1-power'
         release_path_end, release_file = host.puppet_agent_dev_package_info(
-          'pa_collection', 'pa_version2' )
-        expect( release_path_end ).to be === "aix/14/pa_collection/ppc"
-        expect( release_file ).to be === "puppet-agent-pa_version2-1.aix14.ppc.rpm"
+          'pa_collection', '6.0.0' )
+        expect( release_path_end ).to be === "aix/6.1/pa_collection/ppc"
+        expect( release_file ).to be === "puppet-agent-6.0.0-1.aix6.1.ppc.rpm"
       end
     end
 


### PR DESCRIPTION
Adjusts the AIX package selection criteria: puppet-agent will use AIX
6.1 packages for both AIX 7.1 and 7.2 in puppet 6; puppet 5 maintains
existing behavior around these platforms.