### PR TITLE
(BKR-1472) Tidy Markdown in Docs

### DIFF
--- a/DOCUMENTING.md
+++ b/DOCUMENTING.md
@@ -1,5 +1,5 @@
 
-## Contributing Documentation to Puppetlabs Test Harness ##
+# Contributing Documentation to Beaker
 
 
 All inline documentation uses YARD, below is an example usage, a quick
@@ -47,9 +47,7 @@ be worth more than the 154 it’s composed of:
 
 ```
 
-
-## Documentation Guide: ##
-
+## Documentation Guide
 
 Most of our documentation is done with the @tag syntax. With a few
 execptions tags follow this format:
@@ -90,8 +88,8 @@ Wait for the documentation to compile and then point your browser to:
     http://localhost:8808
 
 
-## A Simple YARD Reference: ##
 
+## A Simple YARD Reference
 
 A Hash that must be in `{:symbol => ‘string’}` format:
 

--- a/docs/concepts/testing_beaker_itself.md
+++ b/docs/concepts/testing_beaker_itself.md
@@ -16,9 +16,11 @@ The platforms that beaker covers in its regression testing are largely what is s
 ## Test Suite Phases
 
 ### Beaker Spec
+
 The initial step in Beaker's pipeline is to execute spec testing with supported and future rubies; 2.2.5 and 2.3.1.
 
 ### Beaker Acceptance
+
 All acceptance tests use actual OS's with beaker installed and use beaker itself to verify that its own methods and classes are working.
 
 * The Base tests are tests that do not require puppet be installed on the SUT. This includes much of the DSL and host helpers.

--- a/docs/how_to/change_terminal_output_coloring.md
+++ b/docs/how_to/change_terminal_output_coloring.md
@@ -5,14 +5,17 @@ Beaker uses a set of colors to output different types of messages on to the term
    If you do not provide any values, the defaults are: [Default colors](https://github.com/puppetlabs/beaker/blob/master/lib/beaker/logger.rb#L85-L95)
 
 ## Beaker Color Codes:
+
 In addition, Beaker can support few other colors. List of all colors supported by Beaker:  [Colors Supported by Beaker] (https://github.com/puppetlabs/beaker/blob/master/lib/beaker/logger.rb#L14-L32)
 
 ## How to Customize:
+
 Changes to the default options can be made by editing the configuration file.
 
 Here are some examples:
 
 **Eg 1: Changing color of a particular type of message**
+
 Add the following to the hosts file to change the color of `success` messages to `GREEN` and `warning` messages to `YELLOW`.
 To get the color-code corresponding to a color, refer to: [Colors Supported by Beaker] (https://github.com/puppetlabs/beaker/blob/master/lib/beaker/logger.rb#L14-L32)
 
@@ -24,6 +27,7 @@ To get the color-code corresponding to a color, refer to: [Colors Supported by B
           warn: "\e[00;33m"
 
 **Eg 2: Turning off colors.**
+
 The following option in the hosts file will print the whole output in one single color.
 
       HOSTS:

--- a/docs/how_to/debug_beaker_tests.md
+++ b/docs/how_to/debug_beaker_tests.md
@@ -7,6 +7,7 @@ beaker includes [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug), a 
 [Pry](http://pryrepl.org/) is a powerful Ruby editing and debugging tool.  Beaker uses Pry runtime invocation to create a developer console.
 
 ### What is byebug?
+
 [Byebug](https://github.com/deivid-rodriguez/byebug) is a powerful debugger for ruby. It allows for flexible control of breakpoints, stepping through lines or the call stack. It lacks some features of pry such as source code editing and replaying code execution from within the debugging session, but can be used in combination with pry.
 
 There are several ways to have your tests break and enter debugging:
@@ -21,7 +22,9 @@ Add Pry to individual tests by adding `require 'pry'` to the Ruby test file.
 Then add the statement `binding.pry` at the point in code where you want access to the full, current Beaker environment.
 
 ### Example
+
 #### Example test trypry.rb
+
 Here's a test file that exercises different ways of running commands on Beaker hosts.  At the end of the main `hosts.each` loop I've included `binding.pry` to invoke the console.
 
 ```
@@ -49,6 +52,7 @@ end
 ```
 
 #### Sample output to the first `binding.pry` call:
+
 ```
 $ bundle exec beaker --tests tests/trypry.rb --hosts configs/fusion/winfusion.cfg --no-provision
 {
@@ -128,7 +132,9 @@ From: /Users/anode/beaker/tests/trypry.rb @ line 19 self.run_test:
 
 [1] pry(#<Beaker::TestCase>)>
 ```
+
 #### Using the console
+
 At this point I have access to the console.  I have full access to Beaker hosts, the Beaker DSL and Ruby.
 
 Here's some sample console calls:
@@ -216,8 +222,11 @@ w2k8r2 executed in 0.08 seconds
 [5] pry(#<Beaker::TestCase>)> result.stdout.chomp
 => "Application Data\nDesktop\nDocuments\nFavorites\nMicrosoft\nPackage Cache\nStart Menu\nTemplates\nVMware\nbeaker.gemspec\nntuser.pol"
 ```
+
 #### Continue regular test execution
+
 Simply `exit` the console.
+
 ```
 [6] pry(#<Beaker::TestCase>)> exit
 ```
@@ -305,11 +314,13 @@ The arrow indicates pry is showing code at the top of the stack trace. At positi
 From here, you can examine variables in your test. If you have hosts provisioned, you can send them commands using the [on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#on-instance_method) method, or in a separate terminal ssh into them to investigate their state at the point of failure.
 
 ## Defining external breakpoints with byebug
+
 This method is perhaps the least intuitive to use; but combines the advantages of letting you pick the line(s) of code to set breakpoints on; and being able to debug without needing to edit your test code directly. It is sometimes desirable to debug a test without changing the test's code at all; for example, if you want to compare a test at two or more different git commits, your test source needs to remain unmodified from its committed form.
 
 byebug allows you to externally define breakpoints to keep them separate from your source code.
 
 ### Example
+
 Consider the following test file test.rb:
 
 ```ruby

--- a/docs/how_to/hosts/archlinux.md
+++ b/docs/how_to/hosts/archlinux.md
@@ -1,14 +1,16 @@
 # Arch Linux
 
 > Arch Linux is an independently developed, i686/x86-64 general-purpose GNU/Linux distribution that strives to provide the latest stable versions of most software by following a rolling-release model. The default installation is a minimal base system, configured by the user to only add what is purposely required.
-**Source: https://wiki.archlinux.org/index.php/Arch_Linux**
+
+Source: https://wiki.archlinux.org/index.php/Arch_Linux
 
 # Installation
 
 ## Specifying a version to install
 
 > Arch Linux strives to maintain the latest stable release versions of its software as long as systemic package breakage can be reasonably avoided.
-**Source: https://wiki.archlinux.org/index.php/Arch_Linux**
+
+Source: https://wiki.archlinux.org/index.php/Arch_Linux
 
 Since Arch is a rolling release, the Puppet version installed by Pacman will always be the latest avaliable release from the upstream.
 

--- a/docs/how_to/rake_tasks.md
+++ b/docs/how_to/rake_tasks.md
@@ -1,7 +1,5 @@
 # Rake test tasks for running beaker
 
-## How does it work?
-
 There are some rake tasks that you can use to run Beaker tests from your local project dir.
 
 To use them from within your own project, you will need to require the following file in your project's rakefile:

--- a/docs/how_to/recipes.md
+++ b/docs/how_to/recipes.md
@@ -3,11 +3,18 @@
 Patterns for best-use solutions to (not so) common problems
 
 ## How do i set persistent environment variables on a SUT, such as PATH?
+
+```ruby
     host.add_env_var('PATH', '/opt/puppetlabs/bin:$PATH')
+```
 
 ## How do i run commands on a SUT as a non-root user?
-(warning) this should be abstracted into a beaker helper, or part of on():   BKR-168 - Beaker::DSL::Helpers needs "as" method READY FOR ENGINEERING
 
-###create the user, then su with --command:
+(warning) this should be abstracted into a beaker helper, or part of `on()`: BKR-168 - Beaker::DSL::Helpers needs "as" method READY FOR ENGINEERING
+
+Create the user, then `su` with `--command`:
+
+```ruby
     on(host, puppet("resource user #{username} ensure=present managehome-true"))
     on(host, "su #{username} --command '#{command}'")
+```

--- a/docs/how_to/run_in_parallel.md
+++ b/docs/how_to/run_in_parallel.md
@@ -13,9 +13,11 @@ Including 'configure' causes timesync to execute in parallel (if timesync=true f
 Including 'install' causes as much of the puppet install to happen in parallel as possible.
 
 ## run_in_parallel command option
+
 The run_in_parallel command option is a boolean value, specifying whether to execute each iteration (usually of hosts)
 in parallel, or not.  The block_on method is the primary method accepting the run_in_parallel command option,
 however many methods that call into block_on respect it as well:
+
 - on
 - run_block_on
 - block_on
@@ -25,9 +27,9 @@ however many methods that call into block_on respect it as well:
 - execute_powershell_script_on
 
 ## Using InParallel in your test scripts
-In addition to the options, you can use InParallel within your test scripts as well.
 
-Examples:
+In addition to the options, you can use InParallel within your test scripts as well. Examples:
+
 ```ruby
 include InParallel
 

--- a/docs/how_to/ssh_agent_forwarding.md
+++ b/docs/how_to/ssh_agent_forwarding.md
@@ -3,12 +3,12 @@
 `ssh(1)` agent forwarding can is activated in the `CONFIG` section of the hosts
 file:
 
-~~~yaml
+```yaml
 HOSTS:
   ...
 CONFIG:
   forward_ssh_agent: true
-~~~
+```
 
 Beaker will then make the ssh agent running on the beaker coordinator available to the Systems Under Test (SUT).  There is
 a gotcha though: the agent socket file in the SUT is only available
@@ -20,7 +20,7 @@ and relying on `$SSH_AUTH_SOCK`.
 
 Example:
 
-~~~puppet
+```puppet
 exec { '/bin/chmod -R 777 /tmp/ssh-*':
 } ->
 vcsrepo { '/var/www/app':
@@ -28,7 +28,7 @@ vcsrepo { '/var/www/app':
   source   => 'https://example.com/git/app.git',
   user     => 'deploy'
 }
-~~~
+```
 
 ## Cross-SUT access
 

--- a/docs/how_to/ssh_agent_forwarding.md
+++ b/docs/how_to/ssh_agent_forwarding.md
@@ -30,6 +30,6 @@ vcsrepo { '/var/www/app':
 }
 ~~~
 
-## Cross SUT access
+## Cross-SUT access
 
 If you need to be able to SSH between SUTs while running Beaker acceptance tests, please refer to the [enabling cross SUT access](enabling_cross_sut_access.md) document

--- a/docs/how_to/ssh_connection_preference.md
+++ b/docs/how_to/ssh_connection_preference.md
@@ -24,7 +24,7 @@ End users can override the connection preference that is default or set by their
 
 Example of a host file:
 
-```
+```yaml
 HOSTS:
   ubuntu1604-64-1:
     hypervisor: vmpooler

--- a/docs/how_to/test_arbitrary_beaker_versions.md
+++ b/docs/how_to/test_arbitrary_beaker_versions.md
@@ -6,7 +6,6 @@ existence of ENV variables in the shell that beaker is executing from. The code
 itself looks like this:
 
 ```ruby
-
 def location_for(place, fake_version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
@@ -16,7 +15,6 @@ def location_for(place, fake_version = nil)
     [place, { :require => false }]
   end
 end
-
 ```
 
 Once this method definition is in place in the Gemfile, we can call it in a gem command, like
@@ -37,9 +35,11 @@ git://github.com/puppetlabs/beaker.git#master
 ```
 
 ### file locations
+
 ```
 file://../relative/path/to/beaker
 ```
+
 By adjusting the shell environment that beaker is running in, we can modify what version of
 beaker is installed by bundler on your test coordinator without modifying any of the test
 code. This strategy can be used for any gem dependency, and is often used when testing

--- a/docs/how_to/the_beaker_dsl.md
+++ b/docs/how_to/the_beaker_dsl.md
@@ -3,6 +3,7 @@ Beaker maintains yard documentation, which covers the [Beaker DSL](http://www.ru
 
 
 ## Assertions ##
+
 To be used for confirming the result of a test is as expected.  Beaker include all Minitest assertions, plus some custom built assertions.
 
 * [Minitest assertions](http://docs.seattlerb.org/minitest/Minitest/Assertions.html)
@@ -10,15 +11,18 @@ To be used for confirming the result of a test is as expected.  Beaker include a
 * [assert_no_match](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Assertions#assert_no_match-instance_method)
 
 ## Helpers ##
+
 DSL methods designed to help you interact with installed projects (like facter and puppet), with hosts (like running arbitrary commands on hosts) or interacting with the web (checking is a given URL is alive or not).
 
 ### Facter ###
+
 DSL methods for interacting with facter.
 
 * [fact_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/FacterHelpers#fact_on-instance_method)
 * [fact](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/FacterHelpers#fact-instance_method)
 
 ### Host ###
+
 DSL methods for host manipulation.
 
 * [on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#on-instance_method)
@@ -46,7 +50,9 @@ DSL methods for host manipulation.
 * [echo_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#echo_on-instance_method)
 
 ### Puppet ###
+
 DSL methods for interacting with puppet.
+
 * [puppet_user](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#puppet_user-instance_method)
 * [puppet_group](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#puppet_group-instance_method)
 * [with_puppet_running_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#with_puppet_running_on-instance_method)
@@ -79,12 +85,14 @@ DSL methods for interacting with puppet.
 * [create_tmpdir_for_user](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#create_tmpdir_for_user-instance_method)
 
 ### TK ###
+
 Convenience methods for TrapperKeeper configuration.
 
 * [modify_tk_config](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TkHelpers#modify_tk_config-instance_method)
 * [read_tk_config_string](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TkHelpers#read_tk_config_string-instance_method)
 
 ### Web ###
+
 Helpers for web actions.
 
 * [port_open_within?](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/WebHelpers#port_open_within?-instance_method)
@@ -93,6 +101,7 @@ Helpers for web actions.
 * [fetch_http_dir](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/WebHelpers#fetch_http_dir-instance_method)
 
 ### Test ###
+
 DSL methods for setting information about the current test.
 
 * [current_test_name](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TestHelpers#current_test_name-instance_method)
@@ -103,10 +112,13 @@ DSL methods for setting information about the current test.
 * [set_current_step_name](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TestHelpers#set_current_step_name-instance_method)
 
 ## Install Utilities ##
+
 DSL methods for installing PuppetLabs projects.
 
 ### EZBake ###
+
 EZBake convenience methods.
+
 * [install_from_ezbake](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#install_from_ezbake-instance_method)
 * [install_termini_from_ezbake](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#install_termini_from_ezbake-instance_method)
 * [ezbake_dev_build](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#ezbake_dev_build-instance_method)
@@ -123,6 +135,7 @@ EZBake convenience methods.
 * [conditionally_clone](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#conditionally_clone-instance_method)
 
 ### AIO ###
+
 Agent-only installation utilities.
 
 * [add_platform_aio_defaults](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/AIODefaults#add_platform_aio_defaults-instance_method)
@@ -131,6 +144,7 @@ Agent-only installation utilities.
 * [remove_aio_defaults_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/AIODefaults#remove_aio_defaults_on-instance_method)
 
 ### FOSS ###
+
 DSL methods for installing FOSS PuppetLabs projects.
 
 * [add_platform_foss_defaults](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/FOSSDefaults#add_platform_foss_defaults-instance_method)
@@ -168,6 +182,7 @@ DSL methods for installing FOSS PuppetLabs projects.
 * [install_cert_on_windows](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/FOSSUtils#install_cert_on_windows-instance_method)
 
 ### PE ###
+
 DSL methods for installing Puppet Enterprise.
 
 * [add_platform_pe_defaults](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PeDefaults#add_platform_pe_defaults-instance_method)
@@ -194,6 +209,7 @@ DSL methods for installing Puppet Enterprise.
 * [fetch_and_push_pe](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PeUtils#fetch_and_push_pe-instance_method)
 
 ### Puppet ###
+
 DSL methods that can be used for both FOSS/PE puppet installations.
 
 * [normalize_type](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PuppetUtils#normalize_type-instance_method)
@@ -205,6 +221,7 @@ DSL methods that can be used for both FOSS/PE puppet installations.
 * [remove_defaults_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PuppetUtils#remove_defaults_on-instance_method)
 
 ### Windows ###
+
 DSL convenience methods for installing packages on Windows SUTs.
 
 * [get_temp_path](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/WindowsUtils#get_temp_path-instance_method)
@@ -213,6 +230,7 @@ DSL convenience methods for installing packages on Windows SUTs.
 * [install_msi_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/WindowsUtils#install_msi_on-instance_method)
 
 ### Module ###
+
 DSL methods for installing puppet modules.
 
 * [install_dev_puppet_module_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/ModuleUtils#install_dev_puppet_module_on-instance_method)
@@ -227,6 +245,7 @@ DSL methods for installing puppet modules.
 * [build_ignore_list](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/ModuleUtils#build_ignore_list-instance_method)
 
 ## Outcomes ##
+
 Methods that indicate how the given test completed (fail, pass, skip or pending).
 
 * [fail_test](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Outcomes#fail_test-instance_method)
@@ -236,11 +255,13 @@ Methods that indicate how the given test completed (fail, pass, skip or pending)
 * [formatted_message](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Outcomes#formatted_message-instance_method)
 
 ## Patterns ##
+
 Shared methods used as building blocks of other DSL methods.
 
 * [block_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Patterns#block_on-instance_method)
 
 ## Roles ##
+
 DSL methods for accessing hosts of various roles.
 
 * [agents](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Roles#agents-instance_method)
@@ -261,6 +282,7 @@ DSL methods for accessing hosts of various roles.
 * [find_at_most_one](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Roles#find_at_most_one-instance_method)
 
 ## Structure ##
+
 DSL methods that describe and define how a test is executed.
 
 * [step](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Structure#step-instance_method)
@@ -274,6 +296,7 @@ DSL methods that describe and define how a test is executed.
 * [inspect_host](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Structure#inspect_host-instance_method)
 
 ## Wrappers ##
+
 Wrappers around commonly used commands.
 
 * [facter](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Wrappers#facter-instance_method)

--- a/docs/how_to/the_beaker_dsl.md
+++ b/docs/how_to/the_beaker_dsl.md
@@ -2,7 +2,7 @@ Beaker maintains yard documentation, which covers the [Beaker DSL](http://www.ru
 
 
 
-## Assertions ##
+## Assertions
 
 To be used for confirming the result of a test is as expected.  Beaker include all Minitest assertions, plus some custom built assertions.
 
@@ -10,18 +10,18 @@ To be used for confirming the result of a test is as expected.  Beaker include a
 * [assert_output](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Assertions#assert_output-instance_method)
 * [assert_no_match](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Assertions#assert_no_match-instance_method)
 
-## Helpers ##
+## Helpers
 
 DSL methods designed to help you interact with installed projects (like facter and puppet), with hosts (like running arbitrary commands on hosts) or interacting with the web (checking is a given URL is alive or not).
 
-### Facter ###
+### Facter
 
 DSL methods for interacting with facter.
 
 * [fact_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/FacterHelpers#fact_on-instance_method)
 * [fact](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/FacterHelpers#fact-instance_method)
 
-### Host ###
+### Host
 
 DSL methods for host manipulation.
 
@@ -49,7 +49,7 @@ DSL methods for host manipulation.
 * [create_tmpdir_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#create_tmpdir_on-instance_method)
 * [echo_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HostHelpers#echo_on-instance_method)
 
-### Puppet ###
+### Puppet
 
 DSL methods for interacting with puppet.
 
@@ -84,14 +84,14 @@ DSL methods for interacting with puppet.
 * [sign_certificate](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#sign_certificate-instance_method)
 * [create_tmpdir_for_user](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/PuppetHelpers#create_tmpdir_for_user-instance_method)
 
-### TK ###
+### TK
 
 Convenience methods for TrapperKeeper configuration.
 
 * [modify_tk_config](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TkHelpers#modify_tk_config-instance_method)
 * [read_tk_config_string](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TkHelpers#read_tk_config_string-instance_method)
 
-### Web ###
+### Web
 
 Helpers for web actions.
 
@@ -100,7 +100,7 @@ Helpers for web actions.
 * [fetch_http_file](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/WebHelpers#fetch_http_file-instance_method)
 * [fetch_http_dir](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/WebHelpers#fetch_http_dir-instance_method)
 
-### Test ###
+### Test
 
 DSL methods for setting information about the current test.
 
@@ -111,11 +111,11 @@ DSL methods for setting information about the current test.
 * [set_current_test_filename](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TestHelpers#set_current_test_filename-instance_method)
 * [set_current_step_name](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/TestHelpers#set_current_step_name-instance_method)
 
-## Install Utilities ##
+## Install Utilities
 
 DSL methods for installing PuppetLabs projects.
 
-### EZBake ###
+### EZBake
 
 EZBake convenience methods.
 
@@ -134,7 +134,7 @@ EZBake convenience methods.
 * [ezbake_installsh](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#ezbake_installsh-instance_method)
 * [conditionally_clone](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/EzbakeUtils#conditionally_clone-instance_method)
 
-### AIO ###
+### AIO
 
 Agent-only installation utilities.
 
@@ -143,7 +143,7 @@ Agent-only installation utilities.
 * [remove_platform_aio_defaults](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/AIODefaults#remove_platform_aio_defaults-instance_method)
 * [remove_aio_defaults_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/AIODefaults#remove_aio_defaults_on-instance_method)
 
-### FOSS ###
+### FOSS
 
 DSL methods for installing FOSS PuppetLabs projects.
 
@@ -181,7 +181,7 @@ DSL methods for installing FOSS PuppetLabs projects.
 * [install_puppet_agent_pe_promoted_repo_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/FOSSUtils#install_puppet_agent_pe_promoted_repo_on-instance_method)
 * [install_cert_on_windows](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/FOSSUtils#install_cert_on_windows-instance_method)
 
-### PE ###
+### PE
 
 DSL methods for installing Puppet Enterprise.
 
@@ -208,7 +208,7 @@ DSL methods for installing Puppet Enterprise.
 * [install_higgs](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PeUtils#install_higgs-instance_method)
 * [fetch_and_push_pe](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PeUtils#fetch_and_push_pe-instance_method)
 
-### Puppet ###
+### Puppet
 
 DSL methods that can be used for both FOSS/PE puppet installations.
 
@@ -220,7 +220,7 @@ DSL methods that can be used for both FOSS/PE puppet installations.
 * [configure_type_defaults_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PuppetUtils#configure_type_defaults_on-instance_method)
 * [remove_defaults_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/PuppetUtils#remove_defaults_on-instance_method)
 
-### Windows ###
+### Windows
 
 DSL convenience methods for installing packages on Windows SUTs.
 
@@ -229,7 +229,7 @@ DSL convenience methods for installing packages on Windows SUTs.
 * [create_install_msi_batch_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/WindowsUtils#create_install_msi_batch_on-instance_method)
 * [install_msi_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/WindowsUtils#install_msi_on-instance_method)
 
-### Module ###
+### Module
 
 DSL methods for installing puppet modules.
 
@@ -244,7 +244,7 @@ DSL methods for installing puppet modules.
 * [split_author_modulename](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/ModuleUtils#split_author_modulename-instance_method)
 * [build_ignore_list](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/InstallUtils/ModuleUtils#build_ignore_list-instance_method)
 
-## Outcomes ##
+## Outcomes
 
 Methods that indicate how the given test completed (fail, pass, skip or pending).
 
@@ -254,13 +254,13 @@ Methods that indicate how the given test completed (fail, pass, skip or pending)
 * [skip_test](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Outcomes#skip_test-instance_method)
 * [formatted_message](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Outcomes#formatted_message-instance_method)
 
-## Patterns ##
+## Patterns
 
 Shared methods used as building blocks of other DSL methods.
 
 * [block_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Patterns#block_on-instance_method)
 
-## Roles ##
+## Roles
 
 DSL methods for accessing hosts of various roles.
 
@@ -281,7 +281,7 @@ DSL methods for accessing hosts of various roles.
 * [find_only_one](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Roles#find_only_one-instance_method)
 * [find_at_most_one](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Roles#find_at_most_one-instance_method)
 
-## Structure ##
+## Structure
 
 DSL methods that describe and define how a test is executed.
 
@@ -295,7 +295,7 @@ DSL methods that describe and define how a test is executed.
 * [select_hosts](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Structure#select_hosts-instance_method)
 * [inspect_host](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Structure#inspect_host-instance_method)
 
-## Wrappers ##
+## Wrappers
 
 Wrappers around commonly used commands.
 

--- a/docs/how_to/use_hocon_helpers.md
+++ b/docs/how_to/use_hocon_helpers.md
@@ -1,4 +1,4 @@
-# How-to Use Hocon Helpers
+# How to Use Hocon Helpers
 
 Beaker provides a few convenience methods to help you use the
 [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md)
@@ -7,14 +7,14 @@ what each method does, but if you'd like more in-depth information, please
 checkout our
 [Hocon Helpers Rubydocs](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker/DSL/Helpers/HoconHelpers).
 
-# #hocon_file_read_on
+## hocon_file_read_on
 
 If you'd just like to read the contents of a HOCON file from a System Under Test
 (SUT), this is the method for you. Note that you will get back a
 [ConfigValueFactory object](https://github.com/puppetlabs/ruby-hocon#basic-usage)
 like in the other helper methods here.
 
-# #hocon_file_edit_in_place_on
+## hocon_file_edit_in_place_on
 
 This method is specifically for editing a file on a SUT and saving it in-place,
 meaning it'll save your changes in the place of the original file you read from.
@@ -23,7 +23,7 @@ The special thing to take note of here is that the Proc you pass to this method
 will need to return the doc that you'd like saved in order for saving to work as
 specified.
 
-# #hocon_file_edit_on
+## hocon_file_edit_on
 
 This method is our generic open-ended method for editing a file from a SUT. This
 is the most flexible method, doing nothing but providing you with the contents

--- a/docs/how_to/use_user_password_authentication.md
+++ b/docs/how_to/use_user_password_authentication.md
@@ -2,7 +2,7 @@ By default Beaker connects to hosts using public key authentication, but that ma
 
 ## Example 1: Use 'password' authentication
 
-```
+```yaml
 HOSTS:
   pe-centos6:
     roles:
@@ -12,10 +12,10 @@ HOSTS:
       - database
       - myrole
     platform: el-6-i386
-    snapshot : clean-w-keys
-    hypervisor : fusion
+    snapshot: clean-w-keys
+    hypervisor: fusion
     ssh:
-      password : anode
+      password: anode
       user: anode
       auth_methods:
         - password
@@ -34,7 +34,7 @@ _/snip_
 
 If you want to try a sequence of authentication techniques that fall through on failure simply include them (in their desired order) in your list of _auth_methods_.  If one of your methods is user/password be warned, after a failure Net::SSH will attempt keyboard-interactive password entry - if you do not want this behavior add _number_of_password_prompts: 0_.
 
-```
+```yaml
 HOSTS:
   pe-centos6:
     roles:
@@ -44,13 +44,13 @@ HOSTS:
       - database
       - myrole
     platform: el-6-i386
-    snapshot : clean-w-keys
-    hypervisor : fusion
+    snapshot: clean-w-keys
+    hypervisor: fusion
 CONFIG:
   ssh:
     auth_methods:
       - password
       - publickey
     number_of_password_prompts: 0
-    password : wootwoot
+    password: wootwoot
 ```

--- a/docs/how_to/use_user_password_authentication.md
+++ b/docs/how_to/use_user_password_authentication.md
@@ -1,6 +1,7 @@
 By default Beaker connects to hosts using public key authentication, but that may not be correct method for your particular testing set up.  To have beaker connect to a host using a username/password combination edit your hosts configuration file.  You will need to create a new ssh hash to be used for logging into your SUT that includes (at least) entries for _user_, _password_, and _auth_method_.  You may also include any additional supported [Net::SSH Options](http://net-ssh.github.io/ssh/v1/chapter-2.html#s3).
 
 ## Example 1: Use 'password' authentication
+
 ```
 HOSTS:
   pe-centos6:
@@ -30,7 +31,9 @@ Attempting ssh connection to pe-centos6, user: anode, opts: {:config=>false, :ve
 _/snip_
 
 ## Example 2: Use a list of authentication methods
+
 If you want to try a sequence of authentication techniques that fall through on failure simply include them (in their desired order) in your list of _auth_methods_.  If one of your methods is user/password be warned, after a failure Net::SSH will attempt keyboard-interactive password entry - if you do not want this behavior add _number_of_password_prompts: 0_.
+
 ```
 HOSTS:
   pe-centos6:

--- a/docs/how_to/write_a_beaker_test_for_a_module.md
+++ b/docs/how_to/write_a_beaker_test_for_a_module.md
@@ -1,11 +1,14 @@
 # Beaker for Modules
+
 ## Read the Beaker Docs
 
 [Beaker How To](../tutorials/how_to_beaker.md)
 [Beaker DSL API](http://rubydoc.info/github/puppetlabs/beaker/frames)
 
 ## Understand the Difference Between beaker and beaker-rspec
+
 [beaker vs. beaker-rspec](../concepts/beaker_vs_beaker_rspec.md)
 
 ## beaker-rspec Details
+
 See the [beaker-rspec README](https://github.com/puppetlabs/beaker-rspec/blob/master/README.md) for details on how to use beaker-rspec with modules.

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -29,7 +29,8 @@ Example hosts file:
       nfs_server: none
       consoleport: 443
 
-## Host Requirements ##
+## Host Requirements
+
 Hosts, or SUTs (Systems Under Test), must meet the following requirements:
 
 * The SUT will need a properly configured network, hosts will need to be able to reach each other by hostname.
@@ -39,7 +40,7 @@ Hosts, or SUTs (Systems Under Test), must meet the following requirements:
 * On Windows, `Cygwin` must be installed (with `curl`, `sshd`, `bash`) and the necessary windows gems (`sys-admin`, `win32-dir`, etc).
 * FOSS install: you must have `git`, `ruby`, and `rdoc` installed on your SUT.
 
-## Required Host Settings ##
+## Required Host Settings
 
 To properly define a host you must provide:
 
@@ -47,8 +48,8 @@ To properly define a host you must provide:
   * The string identifying this host.
 * platform
   * One of the Beaker supported platforms.
+## Optional Host Settings
 
-## Optional Host Settings ##
 Additionally, Beaker supports the following host options:
 
 * ip
@@ -67,7 +68,7 @@ Additionally, Beaker supports the following host options:
 * vagrant_memsize
   * The memory size (in MB) for this host
 
-## Supported Platforms ##
+## Supported Platforms
 
 Beaker depends upon each host in the configuration file having a platform type that is correctly formatted and supported.  The platform is used to determine how various operations are carried out internally (such as installing packages using the correct package manager for the given operating system).
 
@@ -86,4 +87,4 @@ The platform's format is `/^OSFAMILY-VERSION-ARCH.*$/` where `OSFAMILY` is one o
 
 `VERSION`'s format is not enforced, but should reflect the `OSFAMILY` selected (ie, ubuntu-1204-i386-master, scientific-6-i386-agent, etc).  `ARCH`'s format is also not enforced, but should be appropriate to the `OSFAMILY` selected (ie, ubuntu-1204-i386-master, sles-11-x86_64-master, debian-7-amd64-master, etc).
 
-## [Supported Virtualization Providers](../how_to/hypervisors/README.md#external-hypervisors) ##
+## [Supported Virtualization Providers](../how_to/hypervisors/README.md#external-hypervisors)

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -5,29 +5,31 @@ anywhere and used with `beaker --hosts yourhost.yaml`
 
 Example hosts file:
 
-    HOSTS:
-      ubuntu-1404-x64-master:
-        roles:
-          - master
-          - agent
-          - dashboard
-          - database
-        platform: ubuntu-1404-x86_64
-        hypervisor: vagrant
-        box: puppetlabs/ubuntu-14.04-64-nocm
-        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
-        ip: 192.168.20.20
-      ubuntu-1404-x64-agent:
-        roles:
-          - agent
-        platform: ubuntu-1404-x86_64
-        hypervisor: vagrant
-        box: puppetlabs/ubuntu-14.04-64-nocm
-        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
-        ip: 192.168.21.21
-    CONFIG:
-      nfs_server: none
-      consoleport: 443
+```yaml
+  HOSTS:
+    ubuntu-1404-x64-master:
+      roles:
+        - master
+        - agent
+        - dashboard
+        - database
+      platform: ubuntu-1404-x86_64
+      hypervisor: vagrant
+      box: puppetlabs/ubuntu-14.04-64-nocm
+      box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+      ip: 192.168.20.20
+    ubuntu-1404-x64-agent:
+      roles:
+        - agent
+      platform: ubuntu-1404-x86_64
+      hypervisor: vagrant
+      box: puppetlabs/ubuntu-14.04-64-nocm
+      box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+      ip: 192.168.21.21
+  CONFIG:
+    nfs_server: none
+    consoleport: 443
+```
 
 ## Host Requirements
 

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -31,6 +31,7 @@ Example hosts file:
 
 ## Host Requirements ##
 Hosts, or SUTs (Systems Under Test), must meet the following requirements:
+
 * The SUT will need a properly configured network, hosts will need to be able to reach each other by hostname.
 * On the SUT, you must configure passwordless SSH authentication for the root user.
 * The SUT must have the `ntpdate` binary installed.
@@ -39,6 +40,7 @@ Hosts, or SUTs (Systems Under Test), must meet the following requirements:
 * FOSS install: you must have `git`, `ruby`, and `rdoc` installed on your SUT.
 
 ## Required Host Settings ##
+
 To properly define a host you must provide:
 
 * name
@@ -66,6 +68,7 @@ Additionally, Beaker supports the following host options:
   * The memory size (in MB) for this host
 
 ## Supported Platforms ##
+
 Beaker depends upon each host in the configuration file having a platform type that is correctly formatted and supported.  The platform is used to determine how various operations are carried out internally (such as installing packages using the correct package manager for the given operating system).
 
 The platform's format is `/^OSFAMILY-VERSION-ARCH.*$/` where `OSFAMILY` is one of:

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -46,29 +46,21 @@ Hosts, or SUTs (Systems Under Test), must meet the following requirements:
 
 To properly define a host you must provide:
 
-* name
-  * The string identifying this host.
-* platform
-  * One of the Beaker supported platforms.
+* name: The string identifying this host.
+* platform: One of the Beaker supported platforms.
+
 ## Optional Host Settings
 
 Additionally, Beaker supports the following host options:
 
-* ip
-  * The IP address of the SUT.
-* hypervisor
-  * One of `docker`, `solaris`, `ec2`, `vsphere`, `fusion`, `aix`, `vcloud` or `vagrant`.
+* ip: The IP address of the SUT.
+* hypervisor: One of `docker`, `solaris`, `ec2`, `vsphere`, `fusion`, `aix`, `vcloud` or `vagrant`.
   * Additional settings may be required depending on the selected hypervisor (ie, template, box, box_url, etc).  Check the documentation below for your hypervisor for details.
-* snapshot
-  * The name of the snapshot to revert to before testing.
-* roles
-  * The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string.
-* pe_dir
-  * The directory where PE builds are located, may be local directory or a URL.
-* pe_ver
-  * The version number of PE to install.
-* vagrant_memsize
-  * The memory size (in MB) for this host
+* snapshot: The name of the snapshot to revert to before testing.
+* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string.
+* pe_dir: The directory where PE builds are located, may be local directory or a URL.
+* pe_ver: The version number of PE to install.
+* vagrant_memsize: The memory size (in MB) for this host
 
 ## Supported Platforms
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -11,18 +11,24 @@ In most cases, beaker is running on a system separate from the SUT; we will comm
 
 On a Debian or Ubuntu system you can install these using the command
 
-    sudo apt-get install ruby-dev libxml2-dev libxslt1-dev g++ zlib1g-dev
+```console
+  $ sudo apt-get install ruby-dev libxml2-dev libxslt1-dev g++ zlib1g-dev
+```
 
 On an EL or Fedora system use:
 
-    sudo yum install make gcc gcc-c++ libxml2-devel libxslt-devel ruby-devel
+```console
+  $ sudo yum install make gcc gcc-c++ libxml2-devel libxslt-devel ruby-devel
+```
 
 ## Installing Beaker
 
 ### From Gem (Preferred)
 
+```console
     $ gem install beaker
     $ beaker --help
+```
 
 ### From Latest Git
 
@@ -30,26 +36,30 @@ If you need the latest and greatest (and mostly likely broken/untested/no warran
 
 * Uses <a href = "http://bundler.io/">bundler</a>
 
-<!-- end of list -->
+```console
     $ git clone https://github.com/puppetlabs/beaker
     $ cd beaker
     $ bundle install
     $ bundle exec beaker --help
+```
 
 ### From Latest Git, As Installed Gem
 
 If you need the latest and greatest, but prefer to work from gem instead of through bundler.
 
+```console
     $ gem uninstall beaker
     $ git clone https://github.com/puppetlabs/beaker
     $ cd beaker
     $ gem build beaker.gemspec
     $ gem install ./beaker-*.gem
+```
 
 ### Special Case Installation
 
 The beaker gem can be built and installed in the context of the current test suite by adding the github repos as the source in the Gemspec file (see <a href = "http://bundler.io/git.html">bundler git documentation</a>).
 
+```ruby
     source 'https://rubygems.org'
     group :testing do
       gem 'cucumber', '~> 1.3.6'
@@ -58,6 +68,7 @@ The beaker gem can be built and installed in the context of the current test sui
       gem 'chromedriver2-helper'
       gem 'beaker', :github => 'puppetlabs/beaker', :branch => 'master', :ref => 'fffe7'
     end
+```
 
 ## Ruby Version
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -18,6 +18,7 @@ On an EL or Fedora system use:
     sudo yum install make gcc gcc-c++ libxml2-devel libxslt-devel ruby-devel
 
 ## Installing Beaker
+
 ### From Gem (Preferred)
 
     $ gem install beaker

--- a/docs/tutorials/lets_write_a_test.md
+++ b/docs/tutorials/lets_write_a_test.md
@@ -1,6 +1,7 @@
 ## The Task
 
 We will write a test to check if a package (specifically HTTPD) is installed and running. To do this we will write two files:
+
 1. `install.rb` - This file will install the package and start the service
 2. `mytest.rb` - This file will have our core tests that checks if the package is installed and running
 
@@ -18,6 +19,7 @@ What needs to happen in this test:
   * Test HTTPD service is running
 
 ## Create a host configuration file
+
     $ beaker-hostgenerator redhat7-64 > redhat7-64.yaml
 
 This command will generate a host file for our system under test (SUT). It will use vmpooler as hypervisor for the host. Please check out [this](https://github.com/puppetlabs/beaker/tree/master/docs/how_to/hypervisors) doc to learn more about hypervisors for beaker.
@@ -81,6 +83,7 @@ end
 ```
 
 ## Run it!
+
 You can now run this with
 
     beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb

--- a/docs/tutorials/lets_write_a_test.md
+++ b/docs/tutorials/lets_write_a_test.md
@@ -20,7 +20,9 @@ What needs to happen in this test:
 
 ## Create a host configuration file
 
+```console
     $ beaker-hostgenerator redhat7-64 > redhat7-64.yaml
+```
 
 This command will generate a host file for our system under test (SUT). It will use vmpooler as hypervisor for the host. Please check out [this](https://github.com/puppetlabs/beaker/tree/master/docs/how_to/hypervisors) doc to learn more about hypervisors for beaker.
 
@@ -86,6 +88,8 @@ end
 
 You can now run this with
 
-    beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
+```console
+    $ beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
+```
 
 Next up you may want to look at the [Beaker test for a module](../how_to/write_a_beaker_test_for_a_module.md) page.

--- a/docs/tutorials/quick_start_rake_tasks.md
+++ b/docs/tutorials/quick_start_rake_tasks.md
@@ -14,19 +14,25 @@ and running. See the docs on how to setup [Vmpooler](https://github.com/puppetla
 
 To use the tasks, you need to put the following line at the top of your project's rake file:
 
+```rake
     require 'beaker/tasks/quick_start'
+```
 
 To check that you have access to the quickstart tasks from your project, run:
 
+```console
     rake --tasks
+```
+
 You should see them listed along with any rake tasks you have defined in your local project rakefile:
 
+```rake
     rake beaker_quickstart:gen_hosts[hypervisor]  # Generate Default Beaker Host Config File, valid options are: vmpooler or vagrant
     rake beaker_quickstart:gen_pre_suite           # Generate Default Pre-Suite
     rake beaker_quickstart:gen_smoke_test          # Generate Default Smoke Test
-    rake beaker_quickstart:run_test[hypervisor]   # Run Default Smoke Test, after generating default host config and test files, valid 
+    rake beaker_quickstart:run_test[hypervisor]   # Run Default Smoke Test, after generating default host config and test files, valid
     options are: vmpooler or vagrant
-
+```
 
 ## Tasks
 
@@ -37,11 +43,15 @@ task will default to using 'vagrant'.
 
 Example:
 
-    rake beaker_quickstart:gen_hosts[vmpooler]
+```console
+    $ rake beaker_quickstart:gen_hosts[vmpooler]
+```
 
 If you have the zsh shell then you will need to escape the square brackets:
 
+```console
     rake beaker_quickstart:gen_hosts\[vmpooler\]
+```
 
 ### Generate tasks
 
@@ -55,7 +65,9 @@ These tasks are standalone and can be run independently from each other to gener
 
 To run:
 
-    rake beaker_quickstart:gen_hosts[hypervisor]
+```console
+    $ rake beaker_quickstart:gen_hosts[hypervisor]
+```
 
 The gen_hosts task will create a file 'default_hypervisor_hosts.yaml' in acceptance/config.
 
@@ -65,13 +77,14 @@ editing the file or by using beaker-hostgenerator to generate a new hosts config
 
 Vmpooler file (redhat 7 master and agent):
 
+```yaml
     ---
     HOSTS:
       redhat7-64-1:
-        pe_dir: 
-        pe_ver: 
-        pe_upgrade_dir: 
-        pe_upgrade_ver: 
+        pe_dir:
+        pe_ver:
+        pe_upgrade_dir:
+        pe_upgrade_ver:
         hypervisor: vmpooler
         platform: el-7-x86_64
         template: redhat-7-x86_64
@@ -83,10 +96,10 @@ Vmpooler file (redhat 7 master and agent):
         - classifier
         - default
       redhat7-64-2:
-        pe_dir: 
-        pe_ver: 
-        pe_upgrade_dir: 
-        pe_upgrade_ver: 
+        pe_dir:
+        pe_ver:
+        pe_upgrade_dir:
+        pe_upgrade_ver:
         hypervisor: vmpooler
         platform: el-7-x86_64
         template: redhat-7-x86_64
@@ -97,16 +110,18 @@ Vmpooler file (redhat 7 master and agent):
       nfs_server: none
       consoleport: 443
       pooling_api: http://vmpooler.delivery.puppetlabs.net/
+```
 
 Vagrant file (ubuntu 14 master and agent):
 
+```yaml
     ---
     HOSTS:
       ubuntu1404-64-1:
-        pe_dir: 
-        pe_ver: 
-        pe_upgrade_dir: 
-        pe_upgrade_ver: 
+        pe_dir:
+        pe_ver:
+        pe_upgrade_dir:
+        pe_upgrade_ver:
         platform: ubuntu-14.04-amd64
         hypervisor: vagrant
         roles:
@@ -117,10 +132,10 @@ Vagrant file (ubuntu 14 master and agent):
         - classifier
         - default
       ubuntu1404-64-2:
-        pe_dir: 
-        pe_ver: 
-        pe_upgrade_dir: 
-        pe_upgrade_ver: 
+        pe_dir:
+        pe_ver:
+        pe_upgrade_dir:
+        pe_upgrade_ver:
         platform: ubuntu-14.04-amd64
         hypervisor: vagrant
         roles:
@@ -131,7 +146,7 @@ Vagrant file (ubuntu 14 master and agent):
       consoleport: 443
       box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
       box: puppetlabs/ubuntu-14.04-64-nocm
-
+```
 
 For more info on host generation and what these configs represent see - [Creating A Test Environment](creating_a_test_environment.md)
 
@@ -139,8 +154,9 @@ For more info on host generation and what these configs represent see - [Creatin
 
 To run:
 
-    rake beaker_quickstart:gen_pre_suite
-This task will generate a default Beaker pre-suite file.
+```console
+    $ rake beaker_quickstart:gen_pre_suite
+```
 
 The gen_pre-suite task will create a file 'default_pre_suite.rb' in acceptance/setup.
 
@@ -148,16 +164,20 @@ If the file already exists, it will not be overwritten. This will allow you to e
 
 pre_suite file:
 
+```ruby
     install_puppet
+```
+
 See the [Test Suites doc](test_suites.md) in this directory for more information on pre-suites.
 
-
-### gen_smoke_test
+### `gen_smoke_test`
 
 To run:
 
+```console
     rake beaker_quickstart:gen_smoke_test
-    
+```
+
 This task will generate a default Beaker smoke test file.
 
 The gen_smoke_test task will create a file 'default_smoke_test.rb' in acceptance/tests.
@@ -166,6 +186,7 @@ If the file already exists, it will not be overwritten. This will allow you to e
 
 smoke test file:
 
+```ruby
     test_name 'puppet install smoketest' do
       step 'puppet install smoketest: verify \'puppet help\' can be successfully called on
       all hosts' do
@@ -174,7 +195,8 @@ smoke test file:
             end
       end
     end
-  
+```
+
 This smoke test will check that Puppet has been successfully installed on the hosts.
 
 For more information on the Beaker dsl methods available to you in your tests see - [Beaker dsl](../how_to/the_beaker_dsl.md)
@@ -189,13 +211,16 @@ location) then they will not be overwritten.
 #### run_test
 
 To run:
-  
-    rake beaker_quickstart:run_test[hypervisor]
-    
+
+```console
+    $ rake beaker_quickstart:run_test[hypervisor]
+```
+
 This task will run the above 3 tasks in sequential order and then execute a Beaker test run using all 3 files.
 
-    beaker --hosts acceptance/config/default_vmpooler_hosts.yaml --pre-suite acceptance/setup/default_pre_suite.rb --tests 
-    acceptance/tests/default_smoke_test.rb
+```console
+    $ beaker --hosts acceptance/config/default_vmpooler_hosts.yaml --pre-suite acceptance/setup/default_pre_suite.rb --tests acceptance/tests/default_smoke_test.rb
+```
 
 You will end up with provisioned hosts with puppet installed and a test check executed to verify that puppet was installed.
 

--- a/docs/tutorials/quick_start_rake_tasks.md
+++ b/docs/tutorials/quick_start_rake_tasks.md
@@ -135,7 +135,7 @@ Vagrant file (ubuntu 14 master and agent):
 
 For more info on host generation and what these configs represent see - [Creating A Test Environment](creating_a_test_environment.md)
 
-### gen_pre_suite
+### `gen_pre_suite`
 
 To run:
 

--- a/docs/tutorials/quick_start_rake_tasks.md
+++ b/docs/tutorials/quick_start_rake_tasks.md
@@ -2,7 +2,6 @@
 
 We have developed some rake tasks to help new Beaker users get up and running quickly with writing and running tests.
 
-
 ## Pre-requisites
 
 * You will need to have already completed the Beaker installation tutorial - [Beaker Installation](installation.md)
@@ -20,7 +19,6 @@ To use the tasks, you need to put the following line at the top of your project'
 To check that you have access to the quickstart tasks from your project, run:
 
     rake --tasks
-    
 You should see them listed along with any rake tasks you have defined in your local project rakefile:
 
     rake beaker_quickstart:gen_hosts[hypervisor]  # Generate Default Beaker Host Config File, valid options are: vmpooler or vagrant
@@ -44,7 +42,6 @@ Example:
 If you have the zsh shell then you will need to escape the square brackets:
 
     rake beaker_quickstart:gen_hosts\[vmpooler\]
-    
 
 ### Generate tasks
 
@@ -100,8 +97,6 @@ Vmpooler file (redhat 7 master and agent):
       nfs_server: none
       consoleport: 443
       pooling_api: http://vmpooler.delivery.puppetlabs.net/
-    
-
 
 Vagrant file (ubuntu 14 master and agent):
 
@@ -140,13 +135,11 @@ Vagrant file (ubuntu 14 master and agent):
 
 For more info on host generation and what these configs represent see - [Creating A Test Environment](creating_a_test_environment.md)
 
-
 ### gen_pre_suite
 
 To run:
 
     rake beaker_quickstart:gen_pre_suite
-    
 This task will generate a default Beaker pre-suite file.
 
 The gen_pre-suite task will create a file 'default_pre_suite.rb' in acceptance/setup.
@@ -156,7 +149,6 @@ If the file already exists, it will not be overwritten. This will allow you to e
 pre_suite file:
 
     install_puppet
-  
 See the [Test Suites doc](test_suites.md) in this directory for more information on pre-suites.
 
 
@@ -186,7 +178,6 @@ smoke test file:
 This smoke test will check that Puppet has been successfully installed on the hosts.
 
 For more information on the Beaker dsl methods available to you in your tests see - [Beaker dsl](../how_to/the_beaker_dsl.md)
-
 
 ### Run task
 

--- a/docs/tutorials/subcommands.md
+++ b/docs/tutorials/subcommands.md
@@ -44,13 +44,13 @@ Execute this command to deprovision your systems under test(SUTs).
 
 ## Basic workflow
 
-```
-beaker init -h hosts_file -o options_file --keyfile ssh_key --pre-suite ./setup/pre-suit/my_presuite.rb
-beaker provision
+```console
+$ beaker init -h hosts_file -o options_file --keyfile ssh_key --pre-suite ./setup/pre-suit/my_presuite.rb
+$ beaker provision
 # Note: do not pass in hosts file, or use the '-t' flag! Just the file
 # or directory. Do not pass GO. Do not collect $200.
-beaker exec ./tests/my_test.rb
+$ beaker exec ./tests/my_test.rb
 # Repeating the above command as needed
 # When you're done testing using the VM that Beaker provisioned
-beaker destroy
+$ beaker destroy
 ```

--- a/docs/tutorials/subcommands.md
+++ b/docs/tutorials/subcommands.md
@@ -39,6 +39,7 @@ this command executes the suites as they are defined in the configuration in the
 `subcommand_options.yaml`.
 
 ### beaker destroy
+
 Execute this command to deprovision your systems under test(SUTs).
 
 ## Basic workflow

--- a/docs/tutorials/test_run.md
+++ b/docs/tutorials/test_run.md
@@ -4,20 +4,20 @@ A Beaker test run consists of two primary phases: an SUT provision phase and a
 suite execution phase. After suite execution, Beaker defaults to cleaning up and
 destroying the SUTs. Leave SUTs running with the `--preserve-hosts` flag.
 
+## Provisioning
 
-* **Provision**
-  * Using supported hypervisors provision SUTs for testing on
-  * Do any initial configuration to ensure that the SUTs can communicate with beaker and each other
-  * skip with `--no-provision`
-  * Provisioning also runs some basic setup on the SUTs
-    * Validation
-      * Check the SUTs for necessary packages (curl, ntpdate)
-      * skip with `--no-validate`
-    * Configuration
-      * Do any post-provisioning configuration to the SUTs
-      * skip with `--no-configure`
+* Using supported hypervisors, provision SUTs for testing on
+* Do any initial configuration to ensure that the SUTs can communicate with beaker and each other
+* skip with `--no-provision`
+* Provisioning also runs some basic setup on the SUTs
+  * Validation
+    * Check the SUTs for necessary packages (curl, ntpdate)
+    * skip with `--no-validate`
+  * Configuration
+    * Do any post-provisioning configuration to the SUTs
+    * skip with `--no-configure`
 
+## Execution
 
-* **Execution**
-  * Execute the files specified in each of the suites; for further documentation,
+* Execute the files specified in each of the suites; for further documentation,
   please refer to [Test Suites & Failure Modes](test_suites.md)

--- a/docs/tutorials/the_command_line.md
+++ b/docs/tutorials/the_command_line.md
@@ -2,11 +2,15 @@
 
 * Using the gem
 
-        $ beaker --log-level debug --hosts sample.cfg --tests test.rb
+```console
+    $ beaker --log-level debug --hosts sample.cfg --tests test.rb
+```
 
 * Using latest git
 
-        $ bundle exec beaker --log-level debug --hosts sample.cfg --tests test.rb
+```console
+    $ bundle exec beaker --log-level debug --hosts sample.cfg --tests test.rb
+```
 
 ## Useful options
 
@@ -22,8 +26,12 @@ See all options with
 
 * Using the gem
 
+```console
         $ beaker --help
+```
 
 * Using latest git
 
+```console
         $ bundle exec beaker --help
+```

--- a/docs/tutorials/the_command_line.md
+++ b/docs/tutorials/the_command_line.md
@@ -1,4 +1,5 @@
 # The Command Line
+
 * Using the gem
 
         $ beaker --log-level debug --hosts sample.cfg --tests test.rb
@@ -8,6 +9,7 @@
         $ bundle exec beaker --log-level debug --hosts sample.cfg --tests test.rb
 
 ## Useful options
+
 * `-h, --hosts FILE `, the hosts that you are going to be testing with
 * `--log-level debug`, for providing verbose logging and full stacktraces on failure
 * `--[no-]provision`, indicates if beaker should provision new boxes upon test execution. If `no` is selected then beaker will attempt to connect to the hosts as defined in `--hosts FILE` without first creating/running them through their hypervisors
@@ -15,7 +17,9 @@
 * `--parse-only`, read and parse all command line options, environment options and file options; report the parsed options and exit.
 
 ## The Rest
+
 See all options with
+
 * Using the gem
 
         $ beaker --help


### PR DESCRIPTION
Numerous but straightforward Markdown formatting cleanup in `docs/`:

- Makes whitespace around headings and code blocks more uniform
- Unifies headings to Markdown style
- Applies language tag to code blocks, making fenced blocks where needed
- Cleans up list formatting

Split from #1513

[skip ci]