### PR TITLE
(BKR-1472) Add Glossary to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ git logs & PR history.
 
 - Installation instructions for contributors
 - Markdown formatting guidelines for `docs/`
+- Glossary for project jargon in `docs/concepts/glossary.md`
 
 # [3.35.0](https://github.com/puppetlabs/beaker/compare/3.34.0...3.35.0) - 2018-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ git logs & PR history.
 
 - Installation instructions for contributors
 - Markdown formatting guidelines for `docs/`
-- Glossary for project jargon in `docs/concepts/glossary.md`
+- Glossary for project jargon in [`docs/concepts/glossary.md`](docs/concepts/glossary.md)
 
 # [3.35.0](https://github.com/puppetlabs/beaker/compare/3.34.0...3.35.0) - 2018-05-16
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -4,7 +4,7 @@ Most terms used in Beaker documentation should be common. The following document
 
 ## Coordinator
 
-The Coordinator is the system on which Beaker itself is run. In many environments this will be a local host, typically a developer's primary machine. Used instead of [Master](#master) to avoid confusion.
+The Coordinator is the system on which Beaker itself is run. In many environments this will be a local host, typically a developer's primary machine. Used instead of Master to avoid confusion (see [Roles](/docs/concepts/roles_what_are_they.md)).
 
 ## System Under Test
 

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -6,10 +6,6 @@ Most terms used in Beaker documentation should be common. The following document
 
 The Coordinator is the system on which Beaker itself is run. In many environments this will be a local host, typically a developer's primary machine. Used instead of [Master](#master) to avoid confusion.
 
-## Master
-
-A System Under Test running as a Puppet Master.
-
 ## System Under Test
 
 A System Under Test (SUT) is one of the systems which is the subject of testing with Beaker. Contrast the [Beaker Coordinator](#coordinator).

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -1,0 +1,23 @@
+# Glossary
+
+Most terms used in Beaker documentation should be common. The following documents project jargon which may otherwise be confusing.
+
+## Coordinator
+
+The Coordinator is the system on which Beaker itself is run. In many environments this will be a local host, typically a developer's primary machine. Used instead of [Master](#master) to avoid confusion.
+
+## Hypervisor
+
+The Hypervisor component manages the hypervisor adapters that connect to hypervisor systems (e.g. ESXi, Cisco, VMPooler) that provide SUTs.
+
+## Master
+
+A SUT running as a Puppet Master.
+
+## SUT
+
+(See [System Under Test](#system-under-test).)
+
+## System Under Test
+
+A System Under Test (SUT) is one of the systems which is the subject of testing with Beaker. Contrast the [Beaker Coordinator](#coordinator).

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -6,17 +6,9 @@ Most terms used in Beaker documentation should be common. The following document
 
 The Coordinator is the system on which Beaker itself is run. In many environments this will be a local host, typically a developer's primary machine. Used instead of [Master](#master) to avoid confusion.
 
-## Hypervisor
-
-The Hypervisor component manages the hypervisor adapters that connect to hypervisor systems (e.g. ESXi, Cisco, VMPooler) that provide SUTs.
-
 ## Master
 
-A SUT running as a Puppet Master.
-
-## SUT
-
-(See [System Under Test](#system-under-test).)
+A System Under Test running as a Puppet Master.
 
 ## System Under Test
 


### PR DESCRIPTION
Adds a glossary in `docs/concepts/glossary.md` for project-specific jargon which may be confusing.

Split from #1513

[skip ci]