### PR TITLE
(BKR-463) Rsync now fails with CommandFailed when destination path does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.35.0...master)
 
+### Fixed
+
+- `host.rsync_to` throws `Beaker::Host::CommandFailed` if rsync call fails (BKR-463)
+
 # [3.35.0](https://github.com/puppetlabs/beaker/compare/3.34.0...3.35.0) - 2018-05-16
 
 ### Fixed

--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -66,7 +66,9 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       remote_filename = File.join(remote_tmpdir, "testfile.txt")
       contents = fixture_contents("simple_text_file")
 
-      create_remote_file default, remote_filename, contents, { :protocol => "rsync" }
+      assert_raises Beaker::Host::CommandFailure do
+        create_remote_file default, remote_filename, contents, { :protocol => "rsync" }
+      end
 
       assert_raises Beaker::Host::CommandFailure do
         remote_contents = on(default, "cat #{remote_filename}").stdout
@@ -148,7 +150,9 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       remote_filename = File.join(remote_tmpdir, "testfile.txt")
       contents = fixture_contents("simple_text_file")
 
-      create_remote_file hosts, remote_filename, contents, { :protocol => 'rsync' }
+      assert_raises Beaker::Host::CommandFailure do
+        create_remote_file hosts, remote_filename, contents, { :protocol => 'rsync' }
+      end
 
       hosts.each do |host|
         assert_raises Beaker::Host::CommandFailure do
@@ -164,6 +168,7 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       remote_tmpdir = tmpdir_on default
 
       # NOTE: we do not do this step in the non-hosts-array version of the test, not sure why
+      # NOTE: this appears to be a workaround related to BKR-463
       on hosts, "mkdir -p #{remote_tmpdir}"
 
       remote_filename = File.join(remote_tmpdir, "testfile.txt")

--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -24,10 +24,10 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
     end
   end
 
-  step "#create_remote_file CURRENTLY does not fail and does not create a remote file when the remote path does not exist, using rsync" do
-    # NOTE: would expect this to fail with Beaker::Host::CommandFailure
-
-    create_remote_file default, "/non/existent/testfile.txt", "contents\n", { :protocol => 'rsync' }
+  step "#create_remote_file fails and does not create a remote file when the remote path does not exist, using rsync" do
+    assert_raises Beaker::Host::CommandFailure do
+      create_remote_file default, "/non/existent/testfile.txt", "contents\n", { :protocol => 'rsync' }
+    end
 
     assert_raises Beaker::Host::CommandFailure do
       on(default, "cat /non/existent/testfile.txt").exit_code

--- a/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
@@ -21,7 +21,9 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
         local_filename, contents = create_local_file_from_fixture("simple_text_file", local_dir, "testfile.txt")
         remote_tmpdir = tmpdir_on default
 
-        rsync_to default, local_filename, remote_tmpdir
+        assert_raises Beaker::Host::CommandFailure do
+          rsync_to default, local_filename, remote_tmpdir
+        end
 
         remote_filename = File.join(remote_tmpdir, "testfile.txt")
         assert_raises Beaker::Host::CommandFailure do

--- a/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
@@ -46,7 +46,9 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
       Dir.mktmpdir do |local_dir|
         local_filename, contents = create_local_file_from_fixture("simple_text_file", local_dir, "testfile.txt")
 
-        rsync_to default, local_filename, "/non/existent/testfile.txt"
+        assert_raises Beaker::Host::CommandFailure do
+          rsync_to default, local_filename, "/non/existent/testfile.txt"
+        end
         assert_raises Beaker::Host::CommandFailure do
           on(default, "cat /non/existent/testfile.txt").exit_code
         end

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -502,6 +502,8 @@ module Beaker
     # @param to_path [String] The destination path on the host
     # @param opts [Hash{Symbol=>String}] Options to alter execution
     # @option opts [Array<String>] :ignore An array of file/dir paths that will not be copied to the host
+    # @raise [Beaker::Host::CommandFailure] With Rsync error (if available)
+    # @return [Rsync::Result] Rsync result with status code
     def do_rsync_to from_path, to_path, opts = {}
       ssh_opts = self['ssh']
       rsync_args = []

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -571,7 +571,9 @@ module Beaker
       @logger.notify "rsync: localhost:#{from_path} to #{hostname_with_user}:#{to_path} {:ignore => #{opts[:ignore]}}"
       result = Rsync.run(from_path, to_path, rsync_args)
       @logger.debug("rsync returned #{result.inspect}")
-      result
+
+      return result if result.success?
+      raise Beaker::Host::CommandFailure, result.error
     end
 
   end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -617,7 +617,7 @@ module Beaker
 
         expect( host ).to receive(:reachable_name).and_return('default.ip.address')
 
-        expect( Rsync ).to receive(:run).with( *rsync_args ).and_return(Beaker::Result.new(host, 'output!'))
+        expect( Rsync ).to receive(:run).with( *rsync_args ).and_return(Rsync::Result.new('raw rsync output', 0))
 
         host.do_rsync_to *args
 
@@ -637,8 +637,8 @@ module Beaker
         FileUtils.mkdir_p('/var/folders/v0/')
         FileUtils.touch('/var/folders/v0/centos-64-x6420150625-48025-lu3u86')
         rsync_args = [ 'source', 'target', ['-az', "-e \"ssh -F /var/folders/v0/centos-64-x6420150625-48025-lu3u86 -o 'StrictHostKeyChecking no'\"", "--exclude '.bundle'"] ]
-        expect(Rsync).to receive(:run).with(*rsync_args).and_return(Beaker::Result.new(host, 'output!'))
-        expect(host.do_rsync_to(*args).cmd).to eq('output!')
+        expect(Rsync).to receive(:run).with(*rsync_args).and_return(Rsync::Result.new('raw rsync output', 0))
+        expect(host.do_rsync_to(*args).success?).to eq(true)
       end
 
       it 'does not use the ssh config file when config does not exist' do
@@ -647,8 +647,8 @@ module Beaker
         args = [ 'source', 'target',
                  {:ignore => ['.bundle']} ]
         rsync_args = [ 'source', 'target', ['-az', "-e \"ssh -o 'StrictHostKeyChecking no'\"", "--exclude '.bundle'"] ]
-        expect(Rsync).to receive(:run).with(*rsync_args).and_return(Beaker::Result.new(host, 'output!'))
-        expect(host.do_rsync_to(*args).cmd).to eq('output!')
+        expect(Rsync).to receive(:run).with(*rsync_args).and_return(Rsync::Result.new('raw rsync output', 0))
+        expect(host.do_rsync_to(*args).success?).to eq(true)
       end
 
       it "doesn't corrupt :ignore option" do
@@ -663,7 +663,7 @@ module Beaker
         end
 
         rsync_args = ['source', 'target', ['-az', "-e \"ssh -i #{key} -p 22 -o 'StrictHostKeyChecking no'\"", "--exclude '.bundle'"]]
-        expect(Rsync).to receive(:run).twice.with(*rsync_args).and_return(Beaker::Result.new(host, 'output!'))
+        expect(Rsync).to receive(:run).twice.with(*rsync_args).and_return(Rsync::Result.new('raw rsync output', 0))
 
         host.do_rsync_to *args
         host.do_rsync_to *args


### PR DESCRIPTION
Fixes BKR-463 as described, and includes improvement to spec mocking for rsync calls which should allow future rsync error handling improvements. Acceptance test coverage is modified to indicate fixed behavior.