### PR TITLE
 (BKR-1105) nil is not a safe role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.35.0...master)
 
+### Fixed
+
+- raise `ArgumentError` when passing `role = nil` to `only_host_with_role()` or `find_at_most_one_host_with_role()`
+
 # [3.35.0](https://github.com/puppetlabs/beaker/compare/3.34.0...3.35.0) - 2018-05-16
 
 ### Fixed

--- a/lib/beaker/shared/host_manager.rb
+++ b/lib/beaker/shared/host_manager.rb
@@ -33,9 +33,10 @@ module Beaker
       #@param [Array<Host>] hosts The hosts to examine
       #@param [String] role The host returned will have this role in its role list
       #@return [Host] The single host with the desired role in its roles list
-      #@raise [ArgumentError] Raised if more than one host has the given role defined, or if no host has the
-      #                       role defined.
+      #@raise [ArgumentError] Raised if more than one host has the given role defined, if no host has the
+      #                       role defined, or if role = nil since hosts_with_role(nil) returns all hosts.
       def only_host_with_role(hosts, role)
+        raise ArgumentError, "role cannot be nil." if role.nil?
         a_host = hosts_with_role(hosts, role)
         case
           when a_host.length == 0
@@ -53,8 +54,10 @@ module Beaker
       # @param [String] role The host returned will have this role in its role list
       # @return [Host] The single host with the desired role in its roles list
       #                     or nil if no host is found
-      # @raise [ArgumentError] Raised if more than one host has the given role defined
+      # @raise [ArgumentError] Raised if more than one host has the given role defined,
+      #   or if role = nil since hosts_with_role(nil) returns all hosts.
       def find_at_most_one_host_with_role(hosts, role)
+        raise ArgumentError, "role cannot be nil." if role.nil?
         role_hosts = hosts_with_role(hosts, role)
         host_with_role = nil
         case role_hosts.length

--- a/spec/beaker/shared/host_manager_spec.rb
+++ b/spec/beaker/shared/host_manager_spec.rb
@@ -98,6 +98,10 @@ module Beaker
           expect{ host_handler.only_host_with_role( hosts, 'surprise' ) }.to raise_error(ArgumentError)
 
         end
+
+        it "throws an error when role = nil" do
+          expect{ host_handler.find_at_most_one_host_with_role( hosts, nil ) }.to raise_error(ArgumentError)
+        end
       end
 
       context "#find_at_most_one_host_with_role" do
@@ -117,6 +121,10 @@ module Beaker
 
           expect( host_handler.find_at_most_one_host_with_role( hosts, 'surprise' ) ).to be_nil
 
+        end
+
+        it "throws an error when role = nil" do
+          expect{ host_handler.find_at_most_one_host_with_role( hosts, nil ) }.to raise_error(ArgumentError)
         end
       end
 


### PR DESCRIPTION
Passing `role = nil` to only_host_with_role or find_at_most_one_host_with_role is automatically invalid, since calling hosts_with_role(role = nil) returns all available hosts. So validate role before calling hosts_with_role, since that could return a single role in testing scenarios.