### PR TITLE
(BKR-1168) Exit early on --version, --help, and --parse-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/3.36.0...master)
 
+### Fixed
+
+- Exit early on --help/--version/--parse-only arguments instead of partial dry-run
+
 # [3.36.0](https://github.com/puppetlabs/beaker/compare/3.35.0...3.36.0) - 2018-06-18
 
 ### Fixed

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -32,6 +32,27 @@ module Beaker
         end
       end
 
+      describe '#parse_options special behavior' do
+        # NOTE: this `describe` block must be separate, with the following `before` block.
+        #       Use the above `describe` block for #parse_options when access to the logger object is not needed
+        before do
+          # Within parse_options() the reassignment of cli.logger makes it impossible to capture subsequent logger calls.
+          # So, hijack the reassignment call so that we can keep a reference to it.
+          allow(Beaker::Logger).to receive(:new).with(no_args).once.and_call_original
+          allow(Beaker::Logger).to receive(:new).once.and_return(cli.instance_variable_get(:@logger))
+        end
+
+        it 'prints the version and exits cleanly' do
+          expect(cli.logger).to receive(:notify).once
+          expect{ cli.parse_options(['--version']) }.to raise_exception(SystemExit) { |e| expect(e.success?).to eq(true) }
+        end
+
+        it 'prints the help and exits cleanly' do
+          expect(cli.logger).to receive(:notify).once
+          expect{ cli.parse_options(['--help']) }.to raise_exception(SystemExit) { |e| expect(e.success?).to eq(true) }
+        end
+      end
+
       describe '#print_version_and_options' do
         before do
           options  = Beaker::Options::OptionsHash.new

--- a/spec/beaker/subcommand_spec.rb
+++ b/spec/beaker/subcommand_spec.rb
@@ -176,6 +176,7 @@ module Beaker
       before :each do
         allow(subcommand.cli).to receive(:parse_options)
         allow(subcommand.cli).to receive(:initialize_network_manager)
+        allow(subcommand.cli).to receive(:execute!)
       end
 
       it 'calls execute! when no resource is given' do


### PR DESCRIPTION
Previously, some code paths could allow continued execution of Beaker after encountering these flags. This resulted in a not-so-dry run scenario which, at best, caused confusing error output when `beaker --version` was called and, at worst, may have led to the unintentional execution of a configured provisioning task.