### PR TITLE
(MAINT) Adding some generic host helper utility methods

### DIFF
--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -606,6 +606,31 @@ module Beaker
             end
           end
         end
+
+        def ruby_command(host)
+          "env PATH=\"#{host['privatebindir']}:${PATH}\" ruby"
+        end
+
+        # Returns an array containing the owner, group and mode of
+        # the file specified by path. The returned mode is an integer
+        # value containing only the file mode, excluding the type, e.g
+        # S_IFDIR 0040000
+        def stat(host, path)
+          ruby = ruby_command(host)
+          owner = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getpwuid(File.stat(\"#{path}\").uid).name)'").stdout.chomp
+          group = on(host, "#{ruby} -e 'require \"etc\"; puts (Etc.getgrgid(File.stat(\"#{path}\").gid).name)'").stdout.chomp
+          mode  = on(host, "#{ruby} -e 'puts (File.stat(\"#{path}\").mode & 0777).to_s(8)'").stdout.chomp.to_i
+
+          [owner, group, mode]
+        end
+
+        def assert_ownership_permissions(host, location, expected_user, expected_group, expected_permissions)
+          permissions = stat(host, location)
+          assert_equal(expected_user, permissions[0], "Owner #{permissions[0]} does not match expected #{expected_user}")
+          assert_equal(expected_group, permissions[1], "Group #{permissions[1]} does not match expected #{expected_group}")
+          assert_equal(expected_permissions, permissions[2], "Permissions  #{permissions[2]} does not match expected #{expected_permissions}")
+        end
+
       end
     end
   end


### PR DESCRIPTION
PE-16486 required checking of file permissions of certain files and as part of
that work some generic utility type methods were identified. And reviewers suggested
they be made part of beaker for more broader use.
Pl refer to PR https://github.com/puppetlabs/pe_acceptance_tests/pull/1883 for additional background.