### PR TITLE
(maint) allow logging of frozen strings

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -203,7 +203,7 @@ module Beaker
         end
       else
         # Remove invalid and undefined UTF-8 character encodings
-        string.to_s.force_encoding('UTF-8')
+        string = string.to_s.dup.force_encoding('UTF-8')
         return string.to_s.chars.select{|i| i.valid_encoding?}.join
       end
     end

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -24,6 +24,10 @@ module Beaker
           pending "not supported in ruby 1.8 (using #{RUBY_VERSION})"
         end
       end
+      it 'supports frozen strings' do
+        valid_utf8.freeze
+        expect( logger.convert(valid_utf8) ).to be === valid_utf8
+      end
     end
 
     context '#generate_dated_log_folder' do


### PR DESCRIPTION
If a frozen string was passed into the logging routines, it would
fail with an exception about strings being frozen.  This change
allows frozen strings to be logged.  For example:

```
irb(main):001:0> foo = "hello there"
=> "hello there"
irb(main):002:0> foo.freeze
=> "hello there"
irb(main):003:0> foo.to_s.force_encoding('UTF-8')
RuntimeError: can't modify frozen String
	from (irb):3:in `force_encoding'
	from (irb):3
	from /Users/jnewman/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
irb(main):004:0> foo.to_s.dup.force_encoding('UTF-8')
=> "hello there"
```