### PR TITLE
(BKR-1499) Adds Beaker::Host#chown, #chgrp, and #ls_ld

### DIFF
--- a/acceptance/tests/base/host/file_test.rb
+++ b/acceptance/tests/base/host/file_test.rb
@@ -1,0 +1,85 @@
+test_name 'File Test' do
+  # some shared setup stuff
+  hosts.each do |host|
+    host.user_present('testuser')
+    host.group_present('testgroup')
+  end
+
+  step "#chown changes file user ownership" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpfile = host.tmpfile('beaker')
+      # ensure we have a user to chown to
+      host.chown('testuser', tmpfile)
+      on host, "ls -l #{tmpfile}" do
+        assert_match /testuser/, stdout, "Should have found testuser in `ls -l` output"
+      end
+    end
+  end
+
+  step "#chown changes directory user ownership" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpdir = host.tmpdir('beaker')
+      # ensure we have a user to chown to
+      host.chgrp('testgroup', tmpdir)
+      on host, "ls -ld #{tmpdir}" do
+        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output: #{stdout}"
+      end
+    end
+  end
+
+  step "#chown changes directory user ownership recursively" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpdir = host.tmpdir('beaker')
+      on host, host.touch("#{tmpdir}/somefile.txt", false)
+      host.chown('testuser', tmpdir, true)
+      on host, "ls -l #{tmpdir}/somefile.txt" do
+        assert_match /testuser/, stdout, "Should have found testuser in `ls -l` output for sub-file"
+      end
+    end
+  end
+
+  step "#chgrp changes file group ownership" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpfile = host.tmpfile('beaker')
+      # ensure we have a group to chgrp to
+      host.chgrp('testgroup', tmpfile)
+      on host, "ls -l #{tmpfile}" do
+        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output"
+      end
+    end
+  end
+
+  step "#chgrp changes directory group ownership" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpdir = host.tmpdir('beaker')
+      # ensure we have a group to chgrp to
+      host.chgrp('testgroup', tmpdir)
+      on host, "ls -ld #{tmpdir}" do
+        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output"
+      end
+    end
+  end
+
+  step "#chgrp changes directory group ownership recursively" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpdir = host.tmpdir('beaker')
+      on host, host.touch("#{tmpdir}/somefile.txt", false)
+      host.chgrp('testgroup', tmpdir, true)
+      on host, "ls -l #{tmpdir}/somefile.txt" do
+        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output for sub-file"
+      end
+    end
+  end
+
+  # shared teardown
+  hosts.each do |host|
+    host.user_absent('testuser')
+    host.group_absent('testgroup')
+  end
+end

--- a/acceptance/tests/base/host/file_test.rb
+++ b/acceptance/tests/base/host/file_test.rb
@@ -11,9 +11,7 @@ test_name 'File Test' do
       tmpfile = host.tmpfile('beaker')
       # ensure we have a user to chown to
       host.chown('testuser', tmpfile)
-      on host, "ls -l #{tmpfile}" do
-        assert_match /testuser/, stdout, "Should have found testuser in `ls -l` output"
-      end
+      assert_match /testuser/, host.ls_ld(tmpfile), "Should have found testuser in `ls -ld` output"
     end
   end
 
@@ -23,9 +21,7 @@ test_name 'File Test' do
       tmpdir = host.tmpdir('beaker')
       # ensure we have a user to chown to
       host.chgrp('testgroup', tmpdir)
-      on host, "ls -ld #{tmpdir}" do
-        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output: #{stdout}"
-      end
+      assert_match /testgroup/, host.ls_ld(tmpdir), "Should have found testgroup in `ls -ld` output: #{stdout}"
     end
   end
 
@@ -35,9 +31,7 @@ test_name 'File Test' do
       tmpdir = host.tmpdir('beaker')
       on host, host.touch("#{tmpdir}/somefile.txt", false)
       host.chown('testuser', tmpdir, true)
-      on host, "ls -l #{tmpdir}/somefile.txt" do
-        assert_match /testuser/, stdout, "Should have found testuser in `ls -l` output for sub-file"
-      end
+      assert_match /testuser/, host.ls_ld("#{tmpdir}/somefile.txt"), "Should have found testuser in `ls -ld` output for sub-file"
     end
   end
 
@@ -47,9 +41,7 @@ test_name 'File Test' do
       tmpfile = host.tmpfile('beaker')
       # ensure we have a group to chgrp to
       host.chgrp('testgroup', tmpfile)
-      on host, "ls -l #{tmpfile}" do
-        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output"
-      end
+      assert_match /testgroup/, host.ls_ld(tmpfile), "Should have found testgroup in `ls -ld` output"
     end
   end
 
@@ -59,9 +51,7 @@ test_name 'File Test' do
       tmpdir = host.tmpdir('beaker')
       # ensure we have a group to chgrp to
       host.chgrp('testgroup', tmpdir)
-      on host, "ls -ld #{tmpdir}" do
-        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output"
-      end
+      assert_match /testgroup/, host.ls_ld(tmpdir), "Should have found testgroup in `ls -ld` output"
     end
   end
 
@@ -71,9 +61,15 @@ test_name 'File Test' do
       tmpdir = host.tmpdir('beaker')
       on host, host.touch("#{tmpdir}/somefile.txt", false)
       host.chgrp('testgroup', tmpdir, true)
-      on host, "ls -l #{tmpdir}/somefile.txt" do
-        assert_match /testgroup/, stdout, "Should have found testgroup in `ls -l` output for sub-file"
-      end
+      assert_match /testgroup/, host.ls_ld("#{tmpdir}/somefile.txt"), "Should have found testgroup in `ls -ld` output for sub-file"
+    end
+  end
+
+  step "#ls_ld produces output" do
+    hosts.each do |host|
+      # create a tmp file to mangle
+      tmpdir = host.tmpdir('beaker')
+      assert_match /beaker/, host.ls_ld(tmpdir), "Should have found beaker in `ls -ld` output"
     end
   end
 

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -13,6 +13,36 @@ module Unix::File
     '/tmp'
   end
 
+  # Change user ownership of a path
+  #
+  # @see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/chown.html
+  #
+  # @note To maintain argument order consistency with the underlying
+  #   syscall, avoid having to specify nil arguments, and not do
+  #   anything hacky with the arguments list, this method does not
+  #   allow you to modify group ownership. Use Host::chgrp instead.
+  # @param [String] user User to chown to
+  # @param [String] path Path to chown
+  # @param [Boolean] recursive Whether to pass the recursive flag
+  #
+  # @return [Beaker::Result] result of command execution
+  def chown(user, path, recursive=false)
+    execute("chown #{recursive ? '-R ' : ''}#{user} #{path}")
+  end
+
+  # Change group ownership of a path
+  #
+  # @see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/chgrp.html
+  #
+  # @param [String] group Group to chgrp to
+  # @param [String] path Path to chgrp
+  # @param [Boolean] recursive Whether to pass the recursive flag
+  #
+  # @return [Beaker::Result] result of command execution
+  def chgrp(group, path, recursive=false)
+    execute("chgrp #{recursive ? '-R ' : ''}#{group} #{path}")
+  end
+
   # Handles any changes needed in a path for SCP
   #
   # @param [String] path File path to SCP to

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -43,6 +43,17 @@ module Unix::File
     execute("chgrp #{recursive ? '-R ' : ''}#{group} #{path}")
   end
 
+  # List long output of a path
+  #
+  # @see http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html
+  #
+  # @param [String] path Path to list properties of
+  #
+  # @return [Beaker::Result] result of command execution
+  def ls_ld(path)
+    execute("ls -ld #{path}")
+  end
+
   # Handles any changes needed in a path for SCP
   #
   # @param [String] path File path to SCP to

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -15,6 +15,26 @@ module Windows::File
     tmp_path.gsub(/\n/, '') + '\\TEMP'
   end
 
+  # (see {Beaker::Host::Unix::File#chown})
+  # @note Cygwin's `chown` implementation does not support
+  #   windows-, DOS-, or mixed-style paths, only UNIX/POSIX-style.
+  #   This method simply wraps the normal Host#chown call with
+  #   a call to cygpath to sanitize input.
+  def chown(user, path, recursive=false)
+    cygpath = execute("cygpath -u #{path}")
+    super(user, cygpath, recursive)
+  end
+
+  # (see {Beaker::Host::Unix::File#chgrp})
+  # @note Cygwin's `chgrp` implementation does not support
+  #   windows-, DOS-, or mixed-style paths, only UNIX/POSIX-style.
+  #   This method simply wraps the normal Host#chgrp call with
+  #   a call to cygpath to sanitize input.
+  def chgrp(group, path, recursive=false)
+    cygpath = execute("cygpath -u #{path}")
+    super(group, cygpath, recursive)
+  end
+
   # Updates a file path for use with SCP, depending on the SSH Server
   #
   # @note This will fail with an SSH server that is not OpenSSL or BitVise.

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -35,6 +35,16 @@ module Windows::File
     super(group, cygpath, recursive)
   end
 
+  # (see {Beaker::Host::Unix::File#ls_ld})
+  # @note Cygwin's `ls_ld` implementation does not support
+  #   windows-, DOS-, or mixed-style paths, only UNIX/POSIX-style.
+  #   This method simply wraps the normal Host#ls_ld call with
+  #   a call to cygpath to sanitize input.
+  def ls_ld(path)
+    cygpath = execute("cygpath -u #{path}")
+    super(cygpath)
+  end
+
   # Updates a file path for use with SCP, depending on the SSH Server
   #
   # @note This will fail with an SSH server that is not OpenSSL or BitVise.

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -165,5 +165,35 @@ module Beaker
         expect( text ).to match( /basedir\=default/ )
       end
     end
+
+    describe '#chown' do
+      let (:user) { 'someuser' }
+      let (:path) { '/path/to/chown' }
+
+      it 'calls the system method' do
+        expect( instance ).to receive( :execute ).with( "chown #{user} #{path}" ).and_return( 0 )
+        expect( instance.chown( user, path ) ).to be === 0
+      end
+
+      it 'passes -R if recursive' do
+        expect( instance ).to receive( :execute ).with( "chown \-R #{user} #{path}" )
+        instance.chown( user, path, true )
+      end
+    end
+
+    describe '#chgrp' do
+      let (:group) { 'somegroup' }
+      let (:path) { '/path/to/chgrp' }
+
+      it 'calls the system method' do
+        expect( instance ).to receive( :execute ).with( "chgrp #{group} #{path}" ).and_return( 0 )
+        expect( instance.chgrp( group, path ) ).to be === 0
+      end
+
+      it 'passes -R if recursive' do
+        expect( instance ).to receive( :execute ).with( "chgrp \-R #{group} #{path}" )
+        instance.chgrp( group, path, true )
+      end
+    end
   end
 end

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -168,7 +168,7 @@ module Beaker
 
     describe '#chown' do
       let (:user) { 'someuser' }
-      let (:path) { '/path/to/chown' }
+      let (:path) { '/path/to/chown/on' }
 
       it 'calls the system method' do
         expect( instance ).to receive( :execute ).with( "chown #{user} #{path}" ).and_return( 0 )
@@ -183,7 +183,7 @@ module Beaker
 
     describe '#chgrp' do
       let (:group) { 'somegroup' }
-      let (:path) { '/path/to/chgrp' }
+      let (:path) { '/path/to/chgrp/on' }
 
       it 'calls the system method' do
         expect( instance ).to receive( :execute ).with( "chgrp #{group} #{path}" ).and_return( 0 )
@@ -193,6 +193,15 @@ module Beaker
       it 'passes -R if recursive' do
         expect( instance ).to receive( :execute ).with( "chgrp \-R #{group} #{path}" )
         instance.chgrp( group, path, true )
+      end
+    end
+
+    describe '#ls_ld' do
+      let (:path) { '/path/to/ls_ld' }
+
+      it 'calls the system method' do
+        expect( instance ).to receive( :execute ).with( "ls -ld #{path}" ).and_return( 0 )
+        expect( instance.ls_ld( path ) ).to be === 0
       end
     end
   end

--- a/spec/beaker/host/windows/file_spec.rb
+++ b/spec/beaker/host/windows/file_spec.rb
@@ -40,5 +40,16 @@ module Beaker
         host.chgrp( group, path, true )
       end
     end
+
+    describe '#ls_ld' do
+      let(:result) { Beaker::Result.new(host, 'ls') }
+
+      it 'calls cygpath first' do
+        expect( host ).to receive( :execute ).with( "cygpath -u #{path}" ).and_return( path )
+        expect( host ).to receive( :execute ).with( "ls -ld #{path}" )
+
+        host.ls_ld( path )
+      end
+    end
   end
 end

--- a/spec/beaker/host/windows/file_spec.rb
+++ b/spec/beaker/host/windows/file_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module Beaker
+  describe Windows::File do
+    let (:user) { 'someuser' }
+    let (:group) { 'somegroup' }
+    let (:path) { 'C:\Foo\Bar' }
+    let (:newpath) { '/Foo/Bar' }
+    let(:host)    { make_host( 'name', { :platform => 'windows' } ) }
+
+
+    describe '#chown' do
+      it 'calls cygpath first' do
+        expect( host ).to receive( :execute ).with( "cygpath -u #{path}" )
+        expect( host ).to receive( :execute ).with( /chown/ )
+
+        host.chown( user, path )
+      end
+
+      it 'passes cleaned path to super' do
+        allow_any_instance_of( Windows::Host ).to receive( :execute ).with( /cygpath/ ).and_return( newpath )
+        expect_any_instance_of( Unix::Host ).to receive( :chown ).with( user, newpath , true)
+
+        host.chown( user, path, true )
+      end
+    end
+
+    describe '#chgrp' do
+      it 'calls cygpath first' do
+        expect( host ).to receive( :execute ).with( "cygpath -u #{path}" ).and_return( path )
+        expect( host ).to receive( :execute ).with( "chgrp #{group} #{path}" )
+
+        host.chgrp( group, path )
+      end
+
+      it 'passes cleaned path to super' do
+        allow_any_instance_of( Windows::Host ).to receive( :execute ).with( /cygpath/ ).and_return( newpath )
+        expect_any_instance_of( Unix::Host ).to receive( :chgrp ).with( group, newpath , true)
+
+        host.chgrp( group, path, true )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds chown and chgrp methods so that hosts can handle per-host peculiarities, e.g. Cygwin hosts must call `cygpath -u` to get UNIX/POSIX style paths to pass to chown, because Cygwin chown does not support Windows-style paths.

This helps with overall efforts to make host abstractions more platform-independent.

Needs PSWindows coverage.