### PR TITLE
(PUP-9136) Preserve host hash from beaker exec run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/4.0.0...master)
 
+### Added
+- `--preserve-state` flag will preserve a given host options hash across subcommand runs(BKR-1541)
+
 ### Changed
 
 - Added additional tests for EL-like systems and added 'redhat' support where necessary

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -61,6 +61,14 @@ module Beaker
             @cmd_options[:pre_cleanup] = value
           end
 
+          opts.on '--preserve-state',
+                  'Preserve the state of the host vm hash for a beaker exec run',
+                  'This adds any additional host settings that are defined',
+                  'during a beaker subcommand run to .beaker/subcommand_options.yaml,',
+                  'allowing us to preserve state across beaker subcommand runs.' do |bool|
+            @cmd_options[:preserve_state] = bool
+          end
+
           opts.on '--[no-]provision',
                   'Do not provision vm images before testing',
                   '(default: true)' do |bool|

--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -30,6 +30,7 @@ module Beaker
     class_option :'pre-cleanup', :type => :string, :group => 'Beaker run'
     class_option :'provision', :type => :boolean, :group => 'Beaker run'
     class_option :'preserve-hosts', :type => :string, :group => 'Beaker run'
+    class_option :'preserve-state', :type => :boolean, :group => 'Beaker run'
     class_option :'root-keys', :type => :boolean, :group => 'Beaker run'
     class_option :keyfile, :type => :string, :group => 'Beaker run'
     class_option :timeout, :type => :string, :group => 'Beaker run'
@@ -202,6 +203,15 @@ module Beaker
       end
 
       @cli.execute!
+
+      if options['preserve-state']
+        @cli.logger.notify 'updating HOSTS key in subcommand_options'
+        hosts = SubcommandUtil.sanitize_options_for_save(@cli.combined_instance_and_options_hosts)
+        options_storage = YAML::Store.new(SubcommandUtil::SUBCOMMAND_OPTIONS)
+        options_storage.transaction do
+          options_storage['HOSTS'] = hosts
+        end
+      end
     end
 
     desc "destroy", "Destroys the provisioned VMs"


### PR DESCRIPTION
Prior to this change, we were losing state that had been set up when
running our pre-suite. Unfortunately, this oversight wasn't felt because
beaker was loading these defaults automatically for every beaker
invocation. In beaker 4, that functionality was removed, and we found
that state between beaker subcommand invocations was unfortunately not
preserved. This commit adds in an optional flag `--preserve-state` that
users can pass into a `beaker exec` invocation. This will update the
beaker options file to amend the host has to include any new or updated
information. This is particularly relevant for paths like
`privatebindir` that are referenced in tests.