### PR TITLE
(MAINT) add rsync backoff for testing

### DIFF
--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -112,7 +112,12 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       remote_filename = File.join(remote_tmpdir, "testfile.txt")
       contents = fixture_contents("simple_text_file")
 
-      result = create_remote_file default, remote_filename, contents, { :protocol => "rsync" }
+      repeat_fibonacci_style_for(10) do
+        result = create_remote_file(
+          default, remote_filename, contents, { :protocol => "rsync" }
+        ) # return of block is whether or not we're done repeating
+        result.success?
+      end
 
       fails_intermittently("https://tickets.puppetlabs.com/browse/BKR-612",
         "default" => default,


### PR DESCRIPTION
Before, we would have a number of tests fail where
it was caused by some connection error that if we
had run it again, it probably would not be a problem.
This change allows these calls to be made with backoffs
so that the tests will be a little slower occasionally,
but much more resilient to network issues