### PR TITLE
Introduce BEAKER_HYPERVISOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/beaker/compare/4.1.0...master)
 
+### Added
+
+- `BEAKER_HYPERVISOR` environment variable to choose the beaker-hostgenerator hypervisor
+
 # [4.1.0](https://github.com/puppetlabs/beaker/compare/4.0.0...4.1.0) - 2018.10.25
 
 ### Added

--- a/docs/tutorials/lets_write_a_test.md
+++ b/docs/tutorials/lets_write_a_test.md
@@ -89,7 +89,27 @@ end
 You can now run this with
 
 ```console
-    $ beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
+$ beaker --host redhat7-64ma.yaml --pre-suite install.rb --tests mytest.rb
+```
+
+## Creating the host configuration on at runtime
+
+When you don't want to store a static file, you can also let [beaker-hostgenerator](https://github.com/puppetlabs/beaker-hostgenerator) generate it on the fly. The filename is used as a host specification. A simple example is:
+
+```console
+$ beaker --host centos7-64 --pre-suite install.rb --tests mytest.rb
+```
+
+It's also possible to set the hypervisor and hostname:
+
+```console
+$ beaker --host 'centos7-64{hypervisor=docker,hostname=centos7-64.example.com}' --pre-suite install.rb --tests mytest.rb
+```
+
+An alternative way to set the hypervisor is `BEAKER_HYPERVISOR`:
+
+```console
+$ BEAKER_HYPERVISOR=docker beaker --host centos7-64 --pre-suite install.rb --tests mytest.rb
 ```
 
 Next up you may want to look at the [Beaker test for a module](../how_to/write_a_beaker_test_for_a_module.md) page.

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -291,8 +291,11 @@ module Beaker
         $stdout.puts dne_message
         require 'beaker-hostgenerator'
 
+        host_generator_options = [ @options[:hosts_file] ]
+        host_generator_options += [ '--hypervisor', ENV['BEAKER_HYPERVISOR'] ] if ENV['BEAKER_HYPERVISOR']
+
         hosts_file_content = begin
-          bhg_cli = BeakerHostGenerator::CLI.new( [ @options[:hosts_file] ] )
+          bhg_cli = BeakerHostGenerator::CLI.new(host_generator_options)
           bhg_cli.execute
         rescue BeakerHostGenerator::Exceptions::Error,
           BeakerHostGenerator::Exceptions::InvalidNodeSpecError => error


### PR DESCRIPTION
Beaker already knows how to generate hosts on the fly using beaker-hostgenrator. The problem is that there's no way to choose the default hypervisor. This means you always specify the long form. Using an environment variable we can simplify configs.