### PR TITLE
(MAINT) handle commandfailures in rsync tests

### DIFF
--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -113,10 +113,17 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
       contents = fixture_contents("simple_text_file")
 
       repeat_fibonacci_style_for(10) do
-        result = create_remote_file(
-          default, remote_filename, contents, { :protocol => "rsync" }
-        ) # return of block is whether or not we're done repeating
-        result.success?
+        begin
+          result = create_remote_file(
+            default, remote_filename, contents, { :protocol => "rsync" }
+          ) # return of block is whether or not we're done repeating
+          result.success?
+        rescue Beaker::Host::CommandFailure => err
+          logger.info("Rsync threw command failure, details: ")
+          logger.info("  #{err}")
+          logger.info("continuing back-off execution")
+          false
+        end
       end
 
       fails_intermittently("https://tickets.puppetlabs.com/browse/BKR-612",


### PR DESCRIPTION
In my previous work on this:
  https://github.com/puppetlabs/beaker/pull/1546
I took care of the cases where the method returned successfully
but the issue we are seeing in CI is where exceptions are
being thrown by the Host#do_rsync_to method. These changes take
the exceptions into account, allowing them to be other cases that
end similarly to the first, where we just continue backoff
execution