### PR TITLE
(BKR-1547) Don't always start a new container with docker

### DIFF
--- a/lib/beaker/network_manager.rb
+++ b/lib/beaker/network_manager.rb
@@ -12,13 +12,12 @@ module Beaker
     # - only if we are running with ---provision
     # - only if we have a hypervisor
     # - only if either the specific hosts has no specification or has 'provision' in its config
-    # - always if it is a vagrant or docker box (vagrant boxes are always provisioned
-    #     as they always need ssh key hacking. docker boxes need to have docker_container_name
-    #     specified)
+    # - always if it is a vagrant box (vagrant boxes are always provisioned as
+    #   they always need ssh key hacking.)
     def provision? options, host
       command_line_says = options[:provision]
       host_says = host['hypervisor'] && (host.has_key?('provision') ? host['provision'] : true)
-      (command_line_says && host_says) or (host['hypervisor'] =~/(vagrant|docker)/)
+      (command_line_says && host_says) or (host['hypervisor'] =~/(vagrant)/)
     end
 
     attr_accessor :hosts, :hypervisors


### PR DESCRIPTION
This allows docker containers to be reused between invocations of the provision and exec beaker subcommands.

I know that docker was originally added alongside vagrant here to resolve buggy behavior (https://github.com/puppetlabs/beaker/pull/1077), but I'm not finding that it works (with beaker 4, anyway) unless I remove docker here. I've tested this with acceptance suites for puppet and the augeas_core module, and all seems well, but I'm not familiar with all use cases for this gem, so suggestions are very welcome!