### PR TITLE
(BKR-1549) Recursively remove unpersisted subcommand options

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -83,14 +83,7 @@ module Beaker
 
       @cli.parse_options
 
-      # delete unnecessary keys for saving the options
-      options_to_write = @cli.configured_options
-      # Remove keys we don't want to save
-      [:timestamp, :logger, :command_line, :beaker_version, :hosts_file].each do |key|
-        options_to_write.delete(key)
-      end
-
-      options_to_write = SubcommandUtil.sanitize_options_for_save(options_to_write)
+      options_to_write = SubcommandUtil.sanitize_options_for_save(@cli.configured_options)
 
       @cli.logger.notify 'Writing configured options to disk'
       File.open(SubcommandUtil::SUBCOMMAND_OPTIONS, 'w') do |f|


### PR DESCRIPTION
Certain option keys (like :logger, for a logger object), should never be
persisted in a subcommand options yaml file. SubcommandUtil was already
removing these keys from the top level of any options hash before
persisting it, but it wasn't recursing into child values.

If a child value (like the HOSTS hash, written during provisioning)
contained a :logger entry, that entry was persisted to the options file
as a string. This string representation of the logger would subsequently
be used while trying to ssh to a host, raising an exception.

This change updates sanitize_options_for_save so that it recursively
removes unwanted keys from any configs that are about to be persisted.