### PR TITLE
(BKR-1559) Do not mirror profile.d on Debian

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -71,10 +71,10 @@ module Unix::Exec
   end
 
   # Converts the provided environment file to a new shell script in /etc/profile.d, then sources that file.
-  # This is for sles and debian based hosts.
+  # This is for sles based hosts.
   # @param [String] env_file The ssh environment file to read from
   def mirror_env_to_profile_d env_file
-    if self[:platform] =~ /sles-|debian/
+    if self[:platform] =~ /sles-/
       @logger.debug("mirroring environment to /etc/profile.d on sles platform host")
       cur_env = exec(Beaker::Command.new("cat #{env_file}")).stdout
       shell_env = ''
@@ -89,7 +89,7 @@ module Unix::Exec
       exec(Beaker::Command.new("source #{self[:profile_d_env_file]}"))
     else
       #noop
-      @logger.debug("will not mirror environment to /etc/profile.d on non-sles/debian platform host")
+      @logger.debug("will not mirror environment to /etc/profile.d on non-sles platform host")
     end
   end
 


### PR DESCRIPTION
This mirroring is not needed since directly executed SSH commands ignore profile.d. This means it's sufficient to set ~/.ssh/environment.

The format is another issue with this function. In ~/.ssh/environment it'll be PATH=PATH:/opt/puppetlabs/bin but this breaks the PATH in an actual shell.

This only removes it on Debian because I've verified that works and I don't have any SLES-based machines nor knowledge.