### PR TITLE
(BK-1562) return root considerations for appending on nexus devices

### DIFF
--- a/lib/beaker/host/cisco.rb
+++ b/lib/beaker/host/cisco.rb
@@ -94,8 +94,8 @@ module Cisco
     # @return [String] Command string as needed for this host
     def append_commands(command = '', user_ac = '', opts = {})
       command.gsub('"') {'\\"'}
-      # vsh commands and ntpdate commands do not require an appended `"`
-      return '"' unless command =~ /ntpdate|\/isan\/bin\/vsh/
+      # vsh commands, ntpdate or when user is root commands do not require an appended `"`
+      return '"' unless command =~ /ntpdate|\/isan\/bin\/vsh/ || self[:user] == 'root'
     end
 
     # Construct the environment string for this command

--- a/spec/beaker/host/cisco_spec.rb
+++ b/spec/beaker/host/cisco_spec.rb
@@ -107,10 +107,18 @@ module Cisco
 
         before :each do
           @platform = 'cisco_nexus-7-x86_64'
+          @options = { :user => 'non_root' }
         end
 
         it 'appends `"` for commands' do
           answer_correct = '"'
+          answer_test = host.append_commands( 'fake_command' )
+          expect( answer_test ).to be === answer_correct
+        end
+
+        it 'returns nil for root user commands' do
+          @options = { :user => 'root' }
+          answer_correct = nil
           answer_test = host.append_commands( 'fake_command' )
           expect( answer_test ).to be === answer_correct
         end
@@ -138,10 +146,18 @@ module Cisco
 
         before :each do
           @platform = 'cisco_ios_xr-6-x86_64'
+          @options = { :user => 'non_root' }
         end
 
         it 'appends `"` for commands' do
           answer_correct = '"'
+          answer_test = host.append_commands( 'fake_command' )
+          expect( answer_test ).to be === answer_correct
+        end
+
+        it 'returns nil for root user commands' do
+          @options = { :user => 'root' }
+          answer_correct = nil
           answer_test = host.append_commands( 'fake_command' )
           expect( answer_test ).to be === answer_correct
         end


### PR DESCRIPTION
BK-1556 changes refactored the appending of strings and it was missed when the user is a root user, which caused an EOF error on some use cases, i.e. when running guestshell as a root user.

This commit adds in the root user check to only append `"` for non-root users.