### PR TITLE
(maint) disabling hostkey checks for cisco hosts

### DIFF
--- a/lib/beaker/host/cisco.rb
+++ b/lib/beaker/host/cisco.rb
@@ -5,6 +5,19 @@ end
 module Cisco
   class Host < Unix::Host
 
+    # as the cisco hosts tend to have custom
+    # ssh configuration, the presets
+    # do not apply where verification of the
+    # host keys is disabled
+    def platform_defaults
+      h = Beaker::Options::OptionsHash.new
+      h.merge({
+        'ssh' => {
+          :verify_host_key => false,
+        },
+      })
+    end
+
     # Tells you whether a host platform supports beaker's
     #   {Beaker::HostPrebuiltSteps#set_env} method
     #

--- a/spec/beaker/host/cisco_spec.rb
+++ b/spec/beaker/host/cisco_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 module Cisco
   describe Host do
-    let(:options)  { @options ? @options : {} }
+    let(:options)  { @options ? @options : {
+      :user => 'root',
+    } }
     let(:platform) {
       if @platform
         { :platform => Beaker::Platform.new( @platform) }
@@ -58,6 +60,7 @@ module Cisco
         it 'retains user-specified prepend commands when adding vrf' do
           @options = {
             :vrf  => 'fakevrf',
+            :user => 'root',
           }
           answer_prepend_commands = 'prepend'
           answer_correct = 'source /etc/profile;ip netns exec fakevrf prepend'
@@ -92,7 +95,10 @@ module Cisco
         end
 
         it 'retains user-specified prepend commands when adding vrf' do
-          @options = { :vrf  => 'fakevrf', }
+          @options = { 
+            :vrf  => 'fakevrf', 
+            :user => 'root',
+          }
           answer_prepend_commands = 'prepend'
           answer_correct = 'source /etc/profile;ip netns exec fakevrf prepend'
           answer_test = host.prepend_commands( 'fake_command', answer_prepend_commands )


### PR DESCRIPTION
Other hosts have hostkey checks disabled as per the presets, but as cisco hosts tend to have custom ssh details the presets for ssh were overriden causing issues when reusing an IP from VMPooler.

Alternatively we could update the hostgenerator (https://github.com/puppetlabs/beaker-hostgenerator/blob/4f67207dab68246296f9d555d6eba01107a10aa9/lib/beaker-hostgenerator/data.rb#L235) if this is deemed only relevant to Puppet testing