### PR TITLE
Provide for OpenSSL 1.1.x+ support

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
-  s.add_runtime_dependency 'net-ssh', '~> 4.0'
+  s.add_runtime_dependency 'net-ssh', '~> 5.0'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 


### PR DESCRIPTION
Beaker is failing to run on newer systems due to https://github.com/net-ssh/net-ssh/issues/503

Updating to the latest `net-ssh` release family does not appear to demonstrate issues.