### PR TITLE
(IMAGES-844) enable Solaris10Sparc pkgutil SSL CA2

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -23,7 +23,7 @@ module Beaker
     SLES_PACKAGES = ['curl', 'ntp']
     DEBIAN_PACKAGES = ['curl', 'ntpdate', 'lsb-release']
     CUMULUS_PACKAGES = ['curl', 'ntpdate']
-    SOLARIS10_PACKAGES = ['CSWcurl', 'CSWntp']
+    SOLARIS10_PACKAGES = ['CSWcurl', 'CSWntp', 'wget']
     SOLARIS11_PACKAGES = ['curl', 'ntp']
     ETC_HOSTS_PATH = "/etc/hosts"
     ETC_HOSTS_PATH_SOLARIS = "/etc/inet/hosts"


### PR DESCRIPTION
pkgutil from Solaris 10 uses wget to retrieve the repo information. The wget version from our sparc instance is old: 1.12 from 2009. This version of wget does not support SSL CA 2.
This PR updates the wget version to the latest available, that contains support for SSL CA2.