### PR TITLE
(maint) Change subcommand pre-suite to install ruby 2.3.1

### DIFF
--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -3,7 +3,7 @@ unless ruby_version
   ruby_version = "2.3.1"
   ruby_source = "default"
 end
-test_name 'Install and configure Ruby #{ruby_version} (from #{ruby_source}) on the SUT' do
+test_name "Install and configure Ruby #{ruby_version} (from #{ruby_source}) on the SUT" do
 
   step 'Ensure that the default system is an el-based system' do
     # The pre-suite currently only supports el systems, and we should
@@ -23,12 +23,12 @@ test_name 'Install and configure Ruby #{ruby_version} (from #{ruby_source}) on t
     on default, 'yum install wget -y'
   end
 
-  step 'download and install ruby #{ruby_version}' do
-    on default, 'wget http://cache.ruby-lang.org/pub/ruby/#{ruby_version[0..2]}/ruby-#{ruby_version}.tar.gz'
-    on default, 'tar xvfz ruby-#{ruby_version}.tar.gz'
-    on default, 'cd ruby-#{ruby_version};./configure'
-    on default, 'cd ruby-#{ruby_version};make'
-    on default, 'cd ruby-#{ruby_version};make install'
+  step "download and install ruby #{ruby_version}" do
+    on default, "wget http://cache.ruby-lang.org/pub/ruby/#{ruby_version[0..2]}/ruby-#{ruby_version}.tar.gz"
+    on default, "tar xvfz ruby-#{ruby_version}.tar.gz"
+    on default, "cd ruby-#{ruby_version};./configure"
+    on default, "cd ruby-#{ruby_version};make"
+    on default, "cd ruby-#{ruby_version};make install"
   end
 
   step 'update gem on the SUT and install bundler' do

--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -1,4 +1,9 @@
-test_name 'Install and configure Ruby 2.3.1 on the SUT' do
+uby_version, ruby_source = ENV['RUBY_VER'], "job parameter"
+unless ruby_version
+  ruby_version = "2.3.1"
+  ruby_source = "default"
+end
+test_name 'Install and configure Ruby #{ruby_version} (from #{ruby_source}) on the SUT' do
 
   step 'Ensure that the default system is an el-based system' do
     # The pre-suite currently only supports el systems, and we should
@@ -18,12 +23,12 @@ test_name 'Install and configure Ruby 2.3.1 on the SUT' do
     on default, 'yum install wget -y'
   end
 
-  step 'download and install ruby 2.3.1' do
-    on default, 'wget http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz'
-    on default, 'tar xvfz ruby-2.3.1.tar.gz'
-    on default, 'cd ruby-2.3.1;./configure'
-    on default, 'cd ruby-2.3.1;make'
-    on default, 'cd ruby-2.3.1;make install'
+  step 'download and install ruby #{ruby_version}' do
+    on default, 'wget http://cache.ruby-lang.org/pub/ruby/#{ruby_version[0..2]}/ruby-#{ruby_version}.tar.gz'
+    on default, 'tar xvfz ruby-#{ruby_version}.tar.gz'
+    on default, 'cd ruby-#{ruby_version};./configure'
+    on default, 'cd ruby-#{ruby_version};make'
+    on default, 'cd ruby-#{ruby_version};make install'
   end
 
   step 'update gem on the SUT and install bundler' do

--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -1,4 +1,4 @@
-uby_version, ruby_source = ENV['RUBY_VER'], "job parameter"
+ruby_version, ruby_source = ENV['RUBY_VER'], "job parameter"
 unless ruby_version
   ruby_version = "2.3.1"
   ruby_source = "default"

--- a/acceptance/pre_suite/subcommands/05_install_ruby.rb
+++ b/acceptance/pre_suite/subcommands/05_install_ruby.rb
@@ -1,4 +1,4 @@
-test_name 'Install and configure Ruby 2.2.5 on the SUT' do
+test_name 'Install and configure Ruby 2.3.1 on the SUT' do
 
   step 'Ensure that the default system is an el-based system' do
     # The pre-suite currently only supports el systems, and we should
@@ -18,12 +18,12 @@ test_name 'Install and configure Ruby 2.2.5 on the SUT' do
     on default, 'yum install wget -y'
   end
 
-  step 'download and install ruby 2.2.5' do
-    on default, 'wget http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.5.tar.gz'
-    on default, 'tar xvfz ruby-2.2.5.tar.gz'
-    on default, 'cd ruby-2.2.5;./configure'
-    on default, 'cd ruby-2.2.5;make'
-    on default, 'cd ruby-2.2.5;make install'
+  step 'download and install ruby 2.3.1' do
+    on default, 'wget http://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz'
+    on default, 'tar xvfz ruby-2.3.1.tar.gz'
+    on default, 'cd ruby-2.3.1;./configure'
+    on default, 'cd ruby-2.3.1;make'
+    on default, 'cd ruby-2.3.1;make install'
   end
 
   step 'update gem on the SUT and install bundler' do

--- a/acceptance/pre_suite/subcommands/08_install_beaker.rb
+++ b/acceptance/pre_suite/subcommands/08_install_beaker.rb
@@ -17,6 +17,6 @@ test_name 'Install beaker and checkout branch if necessary' do
   step 'Build the gem and install it on the local system' do
     build_output = on(default, 'cd /opt/beaker/;gem build beaker.gemspec').stdout
     version = build_output.match(/^  File: (.+)$/)[1]
-    on(default, "cd /opt/beaker/;gem install #{version} --no-rdoc --no-ri; gem install beaker-vmpooler")
+    on(default, "cd /opt/beaker/;gem install #{version} --no-document; gem install beaker-vmpooler")
   end
 end

--- a/acceptance/pre_suite/subcommands/08_install_beaker.rb
+++ b/acceptance/pre_suite/subcommands/08_install_beaker.rb
@@ -1,4 +1,9 @@
-test_name 'Install beaker and checkout branch if necessary' do
+ruby_version, ruby_source = ENV['RUBY_VER'], "job parameter"
+unless ruby_version
+  ruby_version = "2.3.1"
+  ruby_source = "default"
+end
+test_name 'Install and configure Ruby #{ruby_version} (from #{ruby_source}) on the SUT' do
 
   step 'Download the beaker git repo' do
    on default, 'git clone https://github.com/puppetlabs/beaker.git /opt/beaker/'

--- a/acceptance/pre_suite/subcommands/08_install_beaker.rb
+++ b/acceptance/pre_suite/subcommands/08_install_beaker.rb
@@ -1,9 +1,4 @@
-ruby_version, ruby_source = ENV['RUBY_VER'], "job parameter"
-unless ruby_version
-  ruby_version = "2.3.1"
-  ruby_source = "default"
-end
-test_name 'Install and configure Ruby #{ruby_version} (from #{ruby_source}) on the SUT' do
+test_name 'Install beaker and checkout branch if necessary' do
 
   step 'Download the beaker git repo' do
    on default, 'git clone https://github.com/puppetlabs/beaker.git /opt/beaker/'


### PR DESCRIPTION
This is required for the updated byebug gem dependency. All ruby
unit tests have already been moved to ruby 2.3+, this is keeping
consistentcy.