### PR TITLE
(MAINT) Add debian jessie fixture for acceptance testing

### DIFF
--- a/acceptance/fixtures/package/deb/pl-puppetserver-latest-jessie.list
+++ b/acceptance/fixtures/package/deb/pl-puppetserver-latest-jessie.list
@@ -1,0 +1,1 @@
+deb http://nightlies.puppetlabs.com/puppetserver-latest/repos/apt/jessie jessie PC1


### PR DESCRIPTION
Wheezy was dropped from our internal apt repo, so we moved to debian 8
for our full suite pipelines. That requires a small fixture to be in place
for certain tests.