### PR TITLE
(maint) remove "repos-pe" prefix

### DIFF
--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -119,7 +119,6 @@ module Unix::File
       fedora_prefix = ((variant == 'fedora') ? 'f' : '')
 
       pattern = "%s-%s%s-%s.repo"
-      pattern = "repos-pe-#{pattern}" if self.is_pe?
 
       repo_filename << pattern % [
         variant,

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -114,7 +114,7 @@ module Beaker
         @platform = 'el-21-x86_64'
         allow( instance ).to receive( :is_pe? ) { true }
         filename = instance.repo_filename( 'pkg_name', 'pkg_version9' )
-        correct = 'pl-pkg_name-pkg_version9-repos-pe-el-21-x86_64.repo'
+        correct = 'pl-pkg_name-pkg_version9-el-21-x86_64.repo'
         expect( filename ).to be === correct
       end
 


### PR DESCRIPTION
In JIRA ticket RE-1990, a bug was introduced that added the unnecessary
string "repos-pe" to repo filenames. Now that that bug has been
resolved, beaker itself no longer needs to prefix this string when
generating a repo filename.