### PR TITLE
(MAINT) remove reboot test from acceptance suite

### DIFF
--- a/acceptance/tests/base/host/reboot_test.rb
+++ b/acceptance/tests/base/host/reboot_test.rb
@@ -1,8 +1,0 @@
-test_name 'Reboot Test' do
-  step "#reboot: can reboot the host" do
-    hosts.each do |host|
-      host.reboot
-      on host, "echo #{host} rebooted!"
-    end
-  end
-end


### PR DESCRIPTION
This test has not been diagnostic of beaker-side
failures since early after the reboot functionality
was added to beaker.

Since this is the case, and testing results are
plagued by failures at the infrastructure-level,
this should be pulled from beaker itself and
debugged/verified at those levels.