### PR TITLE
(BEAKER-1599) Execute repeats retry logic

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -198,28 +198,9 @@ module Beaker
 
     def execute command, options = {}, stdout_callback = nil,
                 stderr_callback = stdout_callback
-      try = 1
-      wait = 1
-      last_wait = 0
-      begin
-        # ensure that we have a current connection object
-        connect
-        result = try_to_execute(command, options, stdout_callback, stderr_callback)
-      rescue *RETRYABLE_EXCEPTIONS => e
-        if try < 11
-           sleep wait
-          (last_wait, wait) = wait, last_wait + wait
-           try += 1
-          @logger.error "Command execution '#{@hostname}$ #{command}' failed (#{e.class.name} - #{e.message})"
-          close
-          @logger.debug "Preparing to retry: closed ssh object"
-          retry
-        else
-          raise
-        end
-      end
-
-      result
+      # ensure that we have a current connection object
+      connect
+      try_to_execute(command, options, stdout_callback, stderr_callback)
     end
 
     def request_terminal_for channel, command

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -86,24 +86,11 @@ module Beaker
     end
 
     describe '#execute' do
-      it 'retries if failed with a retryable exception' do
+      it 'raises an error if it fails' do
         mock_ssh = Object.new
         expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
         connection.connect
 
-        allow( subject ).to receive( :close )
-        expect( subject ).to receive( :try_to_execute ).ordered.once { raise Timeout::Error }
-        expect( subject ).to receive( :try_to_execute ).ordered.once { Beaker::Result.new('name', 'ls') }
-        expect( subject ).to_not receive( :try_to_execute )
-        connection.execute('ls')
-      end
-
-      it 'raises an error if it fails both times' do
-        mock_ssh = Object.new
-        expect( Net::SSH ).to receive( :start ).with( ip, user, ssh_opts) { mock_ssh }
-        connection.connect
-
-        allow( subject ).to receive( :close )
         allow( subject ).to receive( :try_to_execute ) { raise Timeout::Error }
 
         expect{ connection.execute('ls') }.to raise_error Timeout::Error


### PR DESCRIPTION
This commit removes the nested retry logic from the execute method. Without this change the retry logic in connect_block is duplicated in execute, creating nested retry logic, which causes beaker to take longer than expected to fail.