### PR TITLE
(BKR-1595) Do not use fibonacci back off

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -585,7 +585,8 @@ module Beaker
     def down?
       @logger.debug("host.down?: checking if host has gone down using ping...")
       host_up = true
-      repeat_fibonacci_style_for 11 do
+      # give it max 3 minutes to go down, check every 10 seconds
+      repeat_for_and_wait 180, 10 do
         host_up = self.ping?
         @logger.debug("- ping result: #{host_up}. Done checking? #{!host_up}")
         !host_up # host down? -> continue looping. up? -> finished

--- a/lib/beaker/shared/repetition.rb
+++ b/lib/beaker/shared/repetition.rb
@@ -3,10 +3,16 @@ module Beaker
     module Repetition
 
       def repeat_for seconds, &block
+        # do not peg CPU if &block takes less than 1 second
+        repeat_for_and_wait seconds, 1, &block
+      end
+
+      def repeat_for_and_wait seconds, wait, &block
         timeout = Time.now + seconds
         done = false
         until done or timeout < Time.now do
           done = block.call
+          sleep wait unless done
         end
         return done
       end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -827,12 +827,11 @@ module Beaker
 
     describe "#down?" do
 
-      it "repeats 11 times & fails if ping never returns false" do
-        allow(host).to receive(:sleep)
-        expect(host).to receive(:ping?).exactly(11).times.and_return(true)
+      it "repeats & fails with 'failed to go down' after X seconds" do
+        allow(host).to receive(:repeat_for_and_wait).with(180,10).and_return(false)
         expect {
           host.down?
-        }.to raise_error(Beaker::Host::RebootFailure, /failed to go down/)
+        }.to raise_error(Beaker::Host::RebootFailure, "Host failed to go down")
       end
 
       it "returns that the host is down (true) if ping? is false" do


### PR DESCRIPTION
Before this change there was a slim chance that the system could go
down and back up within one tick of the fibonacci back off, especially
once you are at the higher end of the loop where it can sleep for 300+
seconds.
Introduced a new method that sleeps for x seconds, and wait for y seconds
between each loop. Set the down? method to use it with 3 minutes timeout
and 10 second interval for the check. This ensure that a node going down
will not be missed.