### PR TITLE
(BKR-1604) Add FIPS detection method to Host

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -209,6 +209,20 @@ module Beaker
       graceful
     end
 
+    # Returns true if the host is running in FIPS mode.
+    #
+    # We currently only test FIPS mode on Redhat 7. Other detection
+    # modes should be added here if we expand FIPS support to other
+    # platforms.
+    def fips_mode?
+      case self['platform']
+      when /el-7/
+        execute("cat /proc/sys/crypto/fips_enabled") == "1"
+      else
+        false
+      end
+    end
+
     # Modifies the host settings to indicate that it will be using passenger service scripts,
     # (apache2) by default.  Does nothing if this is a PE host, since it is already using
     # passenger.

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -849,5 +849,24 @@ module Beaker
         expect(host.down?).to be true
       end
     end
+
+    describe "#fips_mode?" do
+      it 'returns false on non-el7 hosts' do
+        @platform = 'windows'
+        expect(host.fips_mode?).to be false
+      end
+
+      it 'returns true when the `fips_enabled` file is present and contains "1"' do
+        @platform = 'el-7'
+        expect(host).to receive(:execute).with("cat /proc/sys/crypto/fips_enabled").and_return("1")
+        expect(host.fips_mode?).to be true
+      end
+
+      it 'returns false when the `fips_enabled` file is present and contains "0"' do
+        @platform = 'el-7'
+        expect(host).to receive(:execute).with("cat /proc/sys/crypto/fips_enabled").and_return("0")
+        expect(host.fips_mode?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit adds a method that reports if FIPS mode is enabled for a
host. Currently, we only test on Redhat 7 with FIPS mode, which
indicates its state via a file. If we eventually expand support to
testing with FIPS on more operating systems, those cases and their
detection methods should be added. For now, all other platforms simply
return false.