### PR TITLE
(QENG-7466) Add capability to configure syslog

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -327,13 +327,13 @@ module Unix::Exec
     exec(Beaker::Command.new("sudo selinuxenabled"), :accept_all_exit_codes => true).exit_code == 0
   end
 
-  def enable_remote_rsyslog()
+  def enable_remote_rsyslog(server = 'rsyslog.ops.puppetlabs.net', port = 514)
     if self['platform'] !~ /ubuntu/
       @logger.warn "Enabling rsyslog is only implemented for ubuntu hosts"
       return
     end
     commands = [
-      'echo "*.* @rsyslog.ops.puppetlabs.net:514" >> /etc/rsyslog.d/51-sendrsyslogs.conf',
+      "echo '*.* @#{server}:#{port}' >> /etc/rsyslog.d/51-sendrsyslogs.conf",
       'systemctl restart rsyslog'
     ]
     commands.each do |command|

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -332,11 +332,14 @@ module Unix::Exec
       @logger.warn "Enabling rsyslog is only implemented for ubuntu hosts"
       return
     end
-    command = 'echo "*.* @rsyslog.ops.puppetlabs.net:514" >> /etc/rsyslog.d/51-sendrsyslogs'
-    result = exec(Beaker::Command.new(command), :accept_all_exit_codes => true)
-    command = 'systemctl restart rsyslog'
-    result = exec(Beaker::Command.new(command), :accept_all_exit_codes => true)
-    result.exit_code == 0
+    commands = [
+      'echo "*.* @rsyslog.ops.puppetlabs.net:514" >> /etc/rsyslog.d/51-sendrsyslogs.conf',
+      'systemctl restart rsyslog'
+    ]
+    commands.each do |command|
+      exec(Beaker::Command.new(command))
+    end
+    true
   end
 
 end

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -327,4 +327,16 @@ module Unix::Exec
     exec(Beaker::Command.new("sudo selinuxenabled"), :accept_all_exit_codes => true).exit_code == 0
   end
 
+  def enable_remote_rsyslog()
+    if self['platform'] !~ /ubuntu/
+      @logger.warn "Enabling rsyslog is only implemented for ubuntu hosts"
+      return
+    end
+    command = 'echo "*.* @rsyslog.ops.puppetlabs.net:514" >> /etc/rsyslog.d/51-sendrsyslogs'
+    result = exec(Beaker::Command.new(command), :accept_all_exit_codes => true)
+    command = 'systemctl restart rsyslog'
+    result = exec(Beaker::Command.new(command), :accept_all_exit_codes => true)
+    result.exit_code == 0
+  end
+
 end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -173,5 +173,16 @@ module Beaker
         expect{ instance.reboot }.to raise_error(Beaker::Host::RebootFailure, /Unexpected exception in reboot: .*/)
       end
     end
+
+    describe '#enable_remote_rsyslog' do
+      it 'always calls restart' do
+        opts['platform'] = 'ubuntu-18-x86_64'
+        allow(Beaker::Command).to receive(:new).with(anything)
+        allow(instance).to receive(:exec)
+        expect(Beaker::Command).to receive(:new).with("systemctl restart rsyslog")
+        instance.enable_remote_rsyslog
+      end
+
+    end
   end
 end


### PR DESCRIPTION
This change adds the capability to configure syslog on ubuntu. Without this change we have no way via beaker to configure syslog.