### PR TITLE
(BKR-1616) Use correct platform variant for FIPS repo configs download

### DIFF
--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -108,6 +108,8 @@ module Unix::File
     when /fedora|el|redhat|centos|cisco_nexus|cisco_ios_xr|sles/
       variant = 'el' if ['centos', 'redhat'].include?(variant)
 
+      variant = 'redhatfips' if self['packaging_platform'] =~ /redhatfips/
+
       if variant == 'cisco_nexus'
         variant = 'cisco-wrlinux'
         version = '5'

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -110,6 +110,15 @@ module Beaker
         expect( filename ).to be === correct
       end
 
+      it 'builds the filename correctly for redhatfips platforms' do
+        @platform = 'el-7-x86_64'
+        allow(instance).to receive(:[]).with('platform') { platform['platform'] }
+        expect(instance).to receive(:[]).with('packaging_platform') { 'redhatfips-7-x86_64' }
+        filename = instance.repo_filename('pkg_name', 'pkg_version')
+        correct = 'pl-pkg_name-pkg_version-redhatfips-7-x86_64.repo'
+        expect( filename ).to be === correct
+      end
+
       it 'adds in the PE portion of the filename correctly for el-based PE hosts' do
         @platform = 'el-21-x86_64'
         allow( instance ).to receive( :is_pe? ) { true }


### PR DESCRIPTION
This commit ensures that redhatfips dev repos are installed on
redhatfips platforms. Previously, el7 repos and packages were getting
installed.