### PR TITLE
(QENG-7466) Get stack trace for prebuild steps when aborted

### DIFF
--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -82,27 +82,34 @@ module Beaker
     #Default configuration steps to be run for a given hypervisor.  Any additional configuration to be done
     #to the provided SUT for test execution to be successful.
     def configure(opts = {})
-      return unless @options[:configure]
-      run_in_parallel = run_in_parallel? opts, @options, 'configure'
-      block_on @hosts, { :run_in_parallel => run_in_parallel} do |host|
-        if host[:timesync]
-          timesync(host, @options)
+      begin
+        return unless @options[:configure]
+        run_in_parallel = run_in_parallel? opts, @options, 'configure'
+        block_on @hosts, { :run_in_parallel => run_in_parallel} do |host|
+          if host[:timesync]
+            timesync(host, @options)
+          end
         end
-      end
-      if @options[:root_keys]
-        sync_root_keys(@hosts, @options)
-      end
-      if @options[:add_el_extras]
-        add_el_extras(@hosts, @options)
-      end
-      if @options[:disable_iptables]
-        disable_iptables @hosts, @options
-      end
-      if @options[:set_env]
-        set_env(@hosts, @options)
-      end
-      if @options[:disable_updates]
-        disable_updates(@hosts, @options)
+        if @options[:root_keys]
+          sync_root_keys(@hosts, @options)
+        end
+        if @options[:add_el_extras]
+          add_el_extras(@hosts, @options)
+        end
+        if @options[:disable_iptables]
+          disable_iptables @hosts, @options
+        end
+        if @options[:set_env]
+          set_env(@hosts, @options)
+        end
+        if @options[:disable_updates]
+          disable_updates(@hosts, @options)
+        end
+      rescue SignalException => ex
+        if ex.signo == 15 #SIGTERM
+          report_and_raise(@logger, ex, "validate")
+        end
+        raise
       end
     end
 

--- a/lib/beaker/hypervisor.rb
+++ b/lib/beaker/hypervisor.rb
@@ -107,7 +107,7 @@ module Beaker
         end
       rescue SignalException => ex
         if ex.signo == 15 #SIGTERM
-          report_and_raise(@logger, ex, "validate")
+          report_and_raise(@logger, ex, "configure")
         end
         raise
       end

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -42,7 +42,6 @@ module Beaker
     context "#configure" do
       let( :options ) { make_opts.merge({ 'logger' => double().as_null_object }) }
       let( :hypervisor ) { Beaker::Hypervisor.new( hosts, options ) }
-      let( :logger ) { double() }
 
       context 'if :timesync option set true on host' do
         it 'does call timesync for host' do
@@ -53,6 +52,7 @@ module Beaker
         end
 
         it 'catches signal exceptions and returns stack trace' do
+          logger = double()
           hosts[0].options[:timesync] = true
           allow( logger ).to receive( :error )
           allow( logger ).to receive( :pretty_backtrace ).and_return("multiline\nstring")

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -58,7 +58,7 @@ module Beaker
           allow( logger ).to receive( :pretty_backtrace ).and_return("multiline\nstring")
           hypervisor.instance_variable_set(:@logger, logger)
           allow(Beaker::Command).to receive(:new).and_raise(SignalException.new('SIGTERM'))
-          expect( hypervisor.configure ).to raise_error(SignalException)
+          expect{ hypervisor.configure }.to raise_error(SignalException)
         end
       end
 


### PR DESCRIPTION
Before this change we would sometimes hang in the prebuilt host steps
that beaker runs, and the CI system would then send a SIGTERM to stop
beaker. With this change, we want to get a stacktrace when this happens
to try and pinpoint where the issue is