### PR TITLE
(QENG-7422) Improvement to host.reboot (MOB Programming)

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '~> 5.0'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
-  s.add_runtime_dependency 'net-ping', '~> 2.0'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 
   s.add_runtime_dependency 'rsync', '~> 1.0.9'

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -2,7 +2,6 @@ require 'socket'
 require 'timeout'
 require 'benchmark'
 require 'rsync'
-require 'net/ping'
 
 require 'beaker/dsl/helpers'
 require 'beaker/dsl/patterns'
@@ -593,27 +592,6 @@ module Beaker
 
       return result if result.success?
       raise Beaker::Host::CommandFailure, result.error
-    end
-
-    def ping?
-      check = Net::Ping::External.new(self)
-      check.ping?
-    end
-
-    def down?
-      @logger.debug("host.down?: checking if host has gone down using ping...")
-      host_up = true
-      # give it max 3 minutes to go down, check every 10 seconds
-      repeat_for_and_wait 180, 10 do
-        host_up = self.ping?
-        @logger.debug("- ping result: #{host_up}. Done checking? #{!host_up}")
-        !host_up # host down? -> continue looping. up? -> finished
-      end
-      if host_up
-        raise Beaker::Host::RebootFailure, 'Host failed to go down'
-      end
-      @logger.debug("host.down? host stopped responding, returning true")
-      true
     end
   end
 

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -16,6 +16,9 @@ module Unix::Exec
         exec(Beaker::Command.new("/sbin/shutdown -r now"), :expect_connection_failure => true)
       end
 
+      # give the host a little time to shutdown
+      sleep 5 
+
       #use uptime to check if the host has rebooted
       current_uptime_exec = exec(Beaker::Command.new("uptime"), {:max_connection_tries => 9, :silent => true})
       current_uptime = current_uptime_exec.stdout

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -44,37 +44,38 @@ module Beaker
       connection
     end
 
-    def connect_block host, user, ssh_opts
+    def connect_block host, user, ssh_opts, options
       try = 1
       last_wait = 2
       wait = 3
+      max_connection_tries = options[:max_connection_tries] || 11
       begin
          @logger.debug "Attempting ssh connection to #{host}, user: #{user}, opts: #{ssh_opts}"
          Net::SSH.start(host, user, ssh_opts)
        rescue *RETRYABLE_EXCEPTIONS => e
-         if try <= 11
-           @logger.warn "Try #{try} -- Host #{host} unreachable: #{e.class.name} - #{e.message}"
-           @logger.warn "Trying again in #{wait} seconds"
+         if try <= max_connection_tries
+           @logger.warn "Try #{try} -- Host #{host} unreachable: #{e.class.name} - #{e.message}" unless options[:silent]
+           @logger.warn "Trying again in #{wait} seconds" unless options[:silent]
            sleep wait
           (last_wait, wait) = wait, last_wait + wait
            try += 1
            retry
          else
-           @logger.warn "Failed to connect to #{host}, after #{try} attempts"
+           @logger.warn "Failed to connect to #{host}, after #{try} attempts" unless options[:silent]
            nil
          end
        end
     end
 
     # connect to the host
-    def connect
+    def connect options = {}
       # Try three ways to connect to host (vmhostname, ip, hostname)
       # Try each method in turn until we succeed
       methods = @ssh_connection_preference.dup
       while (not @ssh) && (not methods.empty?) do
         unless instance_variable_get("@#{methods[0]}").nil?
           if SUPPORTED_CONNECTION_METHODS.include?(methods[0])
-            @ssh = connect_block(instance_variable_get("@#{methods[0].to_s}"), @user, @ssh_opts)
+            @ssh = connect_block(instance_variable_get("@#{methods[0].to_s}"), @user, @ssh_opts, options)
           else
             @logger.warn "Beaker does not support #{methods[0]} to SSH to host, trying next available method."
             @ssh_connection_preference.delete(methods[0])
@@ -199,7 +200,7 @@ module Beaker
     def execute command, options = {}, stdout_callback = nil,
                 stderr_callback = stdout_callback
       # ensure that we have a current connection object
-      connect
+      connect(options)
       try_to_execute(command, options, stdout_callback, stderr_callback)
     end
 

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -234,7 +234,9 @@ module Beaker
       it 'parses time segment variation 4 into a minute value' do
         expect(instance.uptime_int("54 days")).to be == 77760
       end
-      it 'raises if we pass garbage to it'
+      it 'raises if we pass garbage to it' do
+        expect { instance.uptime_int("solaris roxx my soxx") }.to raise_error
+      end
     end
   end
 end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -825,30 +825,6 @@ module Beaker
       end
     end
 
-    describe "#down?" do
-
-      it "repeats & fails with 'failed to go down' after X seconds" do
-        allow(host).to receive(:repeat_for_and_wait).with(180,10).and_return(false)
-        expect {
-          host.down?
-        }.to raise_error(Beaker::Host::RebootFailure, "Host failed to go down")
-      end
-
-      it "returns that the host is down (true) if ping? is false" do
-        expect(host).to receive(:ping?).exactly(1).times.and_return(false)
-
-        expect(host.down?).to be true
-      end
-
-      it "cuts off execution correctly if host becomes unreachable" do
-        expect(host).to receive(:sleep).exactly(3).times
-        expect(host).to receive(:ping?).exactly(3).times.and_return(true).ordered
-        expect(host).to receive(:ping?).exactly(1).times.and_return(false).ordered
-
-        expect(host.down?).to be true
-      end
-    end
-
     describe "#fips_mode?" do
       it 'returns false on non-el7 hosts' do
         @platform = 'windows'


### PR DESCRIPTION
* When rebooting via `Host.reboot`, we now verify that uptime is less
  than original uptime.
* When the uptime after rebooting is not less than the original uptime,
  or some other issue happens during the reboot, a RebootFailure exception
  will be raised
* Adds a uptime_parser method to the unix host and corresponding specs
  * Parses from uptime time segment str to int mins
  * Note that there is a special Solaris workaround due to the
  non-standard uptime string that platform returns
* Add yarddoc to the reboot method
* Also removes `net-ping`, a gem used to ping natively from Ruby,
as well as the `Host.down?` and `Host.ping?` methods because they will
no longer be used by the `Host.reboot` method. (Do users call `down?` or `ping?` If so, does this necessitate a major or minor version bump?)

Co-authored-by: Matt Kirby
Co-authored-by: Kevin Imber
Co-authored-by: John O'Connor
Co-authored-by: Samuel Beaulieu
Co-authored-by: Brandon High