### PR TITLE
(RE-12690) Raise scp error on failure

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -267,6 +267,7 @@ module Beaker
         logger.warn "#{e.class} error in scp'ing. Forcing the connection to close, which should " <<
           "raise an error."
         close
+        raise "#{e}\n#{e.backtrace}"
       end
 
 
@@ -299,6 +300,7 @@ module Beaker
         logger.warn "#{e.class} error in scp'ing. Forcing the connection to close, which should " <<
           "raise an error."
         close
+        raise "#{e}\n#{e.backtrace}"
       end
 
       # Setting these values allows reporting via result.log(test_name)

--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -255,6 +255,7 @@ module Beaker
         local_opts[:recursive] = File.directory?(source)
       end
       local_opts[:chunk_size] ||= 16384
+      local_opts[:verbose] ||= true
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"
@@ -288,6 +289,7 @@ module Beaker
         local_opts[:recursive] = true
       end
       local_opts[:chunk_size] ||= 16384
+      local_opts[:verbose] ||= true
 
       result = Result.new(@hostname, [source, target])
       result.stdout = "\n"

--- a/spec/beaker/ssh_connection_spec.rb
+++ b/spec/beaker/ssh_connection_spec.rb
@@ -231,9 +231,9 @@ module Beaker
       end
 
       it 'ensures the connection closes when scp.upload! errors' do
-        expect( @mock_scp ).to receive( :upload! ).once.and_raise(RuntimeError)
+        expect( @mock_scp ).to receive( :upload! ).once.and_raise(Net::SCP::Error)
         expect(connection).to receive(:close).once
-        connection.scp_to '', ''
+        expect{ connection.scp_to '', ''}.to raise_error(/Net::SCP::Error/)
       end
 
       it 'returns a result object' do
@@ -258,9 +258,9 @@ module Beaker
       end
 
       it 'ensures the connection closes when scp.download! errors' do
-        expect( @mock_scp ).to receive( :download! ).once.and_raise(RuntimeError)
+        expect( @mock_scp ).to receive( :download! ).once.and_raise(Net::SCP::Error)
         expect(connection).to receive(:close).once
-        connection.scp_from '', ''
+        expect{ connection.scp_from '', ''}.to raise_error(/Net::SCP::Error/)
       end
 
       it 'returns a result object' do


### PR DESCRIPTION
Filesync tests are experiencing a recurring transient issue where scp fails and
we end up with a corrupted .list file on ubuntu hosts. This should give us more
info as to *why* the scp is failing by including the actual error output.
This should also prevent processes from continuing after the error, which
previously was resulting in further-downstream errors.