### PR TITLE
(BKR-1610) append at the end of existing path

### DIFF
--- a/acceptance/tests/base/host/host_test.rb
+++ b/acceptance/tests/base/host/host_test.rb
@@ -147,7 +147,7 @@ hosts.each do |host|
   host.add_env_var("TEST", "3")
   logger.debug("ensure that TEST env var has correct setting")
   val = host.get_env_var("TEST")
-  assert_match(/TEST=3(;|:)2(;|:)1$/, val, "add_env_var can correctly add env vars")
+  assert_match(/TEST=1(;|:)2(;|:)3$/, val, "add_env_var can correctly add env vars")
 end
 
 step "#add_env_var : can preserve an environment between ssh connections"
@@ -166,7 +166,7 @@ hosts.each do |host|
   host.close
   logger.debug("ensure that TEST env var has correct setting")
   val = host.get_env_var("TEST")
-  assert_match(/TEST=3(;|:)2(;|:)1$/, val, "can preserve an environment between ssh connections")
+  assert_match(/TEST=1(;|:)2(;|:)3$/, val, "can preserve an environment between ssh connections")
 end
 
 step "#delete_env_var : can delete an environment"
@@ -174,7 +174,7 @@ hosts.each do |host|
   logger.debug("remove TEST=3")
   host.delete_env_var("TEST", "3")
   val = host.get_env_var("TEST")
-  assert_match(/TEST=2(;|:)1$/, val, "delete_env_var can correctly delete part of a chained env var")
+  assert_match(/TEST=1(;|:)2$/, val, "delete_env_var can correctly delete part of a chained env var")
   logger.debug("remove TEST=1")
   host.delete_env_var("TEST", "1")
   val = host.get_env_var("TEST")

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -114,7 +114,7 @@ module Unix::Exec
       return #nothing to do here, key value pair already exists
     #see if the key already exists
     elsif exec(Beaker::Command.new("grep ^#{key}= #{env_file}"), :accept_all_exit_codes => true ).exit_code == 0
-      exec(Beaker::SedCommand.new(self['platform'], "s/^#{key}=/#{key}=#{escaped_val}:/", env_file))
+      exec(Beaker::SedCommand.new(self['platform'], "/^#{key}=/ s/$/:#{escaped_val}/", env_file))
     else
       exec(Beaker::Command.new("echo \"#{key}=#{val}\" >> #{env_file}"))
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -181,7 +181,7 @@ module Beaker
         result.exit_code = 0
         expect( Beaker::Command ).to receive(:new).with(/grep \^key= ~\/\.ssh\/environment/)
         expect( host ).to receive(:exec).and_return(result)
-        expect( Beaker::SedCommand ).to receive(:new).with('unix', 's/^key=/key=\\/my\\/first\\/value:/', '~/.ssh/environment')
+        expect( Beaker::SedCommand ).to receive(:new).with('unix', '/^key=/ s/$/:\\/my\\/first\\/value/', '~/.ssh/environment')
         host.add_env_var('key', '/my/first/value')
       end
 


### PR DESCRIPTION
Updated the `add_env_var` method the append the value
at the end of the existing path instead of inserting
it at the beginning.