### PR TITLE
(RE-13193) Migrate to Artifactory

### DIFF
--- a/acceptance/config/puppetpe/acceptance-options.rb
+++ b/acceptance/config/puppetpe/acceptance-options.rb
@@ -1,5 +1,5 @@
 {
     :pre_suite            => 'acceptance/pre_suite/pe/install.rb',
     :tests                => 'acceptance/tests/puppet',
-    :pe_dir               => 'http://neptune.puppetlabs.lan/archives/releases/3.7.2'
+    :pe_dir               => 'https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2018.1.11'
 }.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/fixtures/files/sles-11-x86_64.repo
+++ b/acceptance/fixtures/files/sles-11-x86_64.repo
@@ -1,5 +1,5 @@
 [PE-2016.4-sles-11-x86_64]
 name=PE-2016.4-sles-11-x86_64
-baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-11-x86_64
+baseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2016.4/repos/sles-11-x86_64
 enabled=1
 gpgcheck=0

--- a/acceptance/fixtures/files/sles-12-x86_64.repo
+++ b/acceptance/fixtures/files/sles-12-x86_64.repo
@@ -1,5 +1,5 @@
 [PE-2016.4-sles-12-x86_64]
 name=PE-2016.4-sles-12-x86_64
-baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-12-x86_64
+baseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm_enterprise__local/2016.4/repos/sles-12-x86_64
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
This commit replaces all references to enterprise.delivery.puppetlabs.net (aka
saturn aka neptune) with Artifactory, as part of a larger migration.