### PR TITLE
(RE-13193) remove unused rake task and old RE references

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -192,14 +192,6 @@ Run the hypervisor beaker acceptance tests
     beaker_test(:hypervisor)
   end
 
-  desc <<-EOS
-Run the puppet beaker acceptance tests on a pe install.
-#{USAGE}
-  EOS
-  task :puppetpe  => 'gen_hosts' do
-    beaker_test(:puppetpe)
-  end
-
 
   desc 'Generate Beaker Host Config File'
   task :gen_hosts do

--- a/acceptance/config/puppetpe/acceptance-options.rb
+++ b/acceptance/config/puppetpe/acceptance-options.rb
@@ -1,5 +1,0 @@
-{
-    :pre_suite            => 'acceptance/pre_suite/pe/install.rb',
-    :tests                => 'acceptance/tests/puppet',
-    :pe_dir               => 'http://neptune.puppetlabs.lan/archives/releases/3.7.2'
-}.merge(eval File.read('acceptance/config/acceptance-options.rb'))

--- a/acceptance/fixtures/files/sles-11-x86_64.repo
+++ b/acceptance/fixtures/files/sles-11-x86_64.repo
@@ -1,5 +1,0 @@
-[PE-2016.4-sles-11-x86_64]
-name=PE-2016.4-sles-11-x86_64
-baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-11-x86_64
-enabled=1
-gpgcheck=0

--- a/acceptance/fixtures/files/sles-12-x86_64.repo
+++ b/acceptance/fixtures/files/sles-12-x86_64.repo
@@ -1,5 +1,0 @@
-[PE-2016.4-sles-12-x86_64]
-name=PE-2016.4-sles-12-x86_64
-baseurl=http://enterprise.delivery.puppetlabs.net/2016.4/repos/sles-12-x86_64
-enabled=1
-gpgcheck=0


### PR DESCRIPTION
In reviewing #1614, I'm starting to suspect that the files @mwaggett is changing aren't being used in our system today. One of the files hadn't been updated in four years, for example.

I'm proposing this change to verify that in our CI, and suggest we get rid of our old configurations rather than worrying about keeping them up-to-date, so that Molly won't have to come through again in the future & update these files if artifactory details change.