### PR TITLE
(maint) Encode powershell commands in file helpers

### DIFF
--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -550,7 +550,6 @@ module Beaker
           file_contents = nil
 
           split_path = win_ads_path(file_path)
-
           if file_exists_on(host, split_path[:path])
             if host['platform'] =~ /windows/
               file_path.gsub!('/', '\\')

--- a/lib/beaker/dsl/wrappers.rb
+++ b/lib/beaker/dsl/wrappers.rb
@@ -75,18 +75,14 @@ module Beaker
         Command.new("powershell.exe", ps_args)
       end
 
-      # Convert the provided command string to Base64
+      # Convert the provided command string to Base64 encoded UTF-16LE command
       # @param [String] cmd The command to convert to Base64
       # @return [String] The converted string
       # @api private
       def encode_command(cmd)
-        cmd = cmd.chars.to_a.join("\x00").chomp
-        cmd << "\x00" unless cmd[-1].eql? "\x00"
         # use strict_encode because linefeeds are not correctly handled in our model
-        cmd = Base64.strict_encode64(cmd).chomp
-        cmd
+        Base64.strict_encode64(cmd.encode(Encoding::UTF_16LE)).chomp
       end
-
     end
   end
 end


### PR DESCRIPTION
As far as I can tell there is some problematic path mangling with cygwin configuration on vmpooler. For example a path like `C:\Windows\TEMP\install-puppet-2020-02-21_08.37.02.log` is magically turned in to `'C:\cygwin64\home\Administrator\WindowsTEMPinstall-puppet-2020-02-21_08.37.02.log'`. Base64 encoding the command appears to circumvent the conversion.