### PR TITLE
(FACT-2392) Bump Thor dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rsync', '~> 1.0.9'
   s.add_runtime_dependency 'open_uri_redirections', '~> 0.2.1'
   s.add_runtime_dependency 'in-parallel', '~> 0.1'
-  s.add_runtime_dependency 'thor', '~> 0.19'
+  s.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2.0']
 
   # Run time dependencies that are Beaker libraries
   s.add_runtime_dependency 'stringify-hash', '~> 0.0'


### PR DESCRIPTION
Facter 4 depends on Thor > 1.0 and some module's tests depend on Beaker which require Thor < 1.
Also Thor was released to a stable version and this is not breaking Beaker, as it was tested in: 
https://jenkins-master-prod-1.delivery.puppetlabs.net/view/Adhoc/job/platform_puppet-agent-extra_puppet-agent-integration-suite_adhoc-ad_hoc/756/
![image](https://user-images.githubusercontent.com/49147761/75245182-e0d61b00-57d5-11ea-89c3-4391435ed72a.png)