### PR TITLE
Set packaging_platform default

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -70,6 +70,7 @@ module Beaker
     def initialize name, host_hash, options
       @logger = host_hash[:logger] || options[:logger]
       @name, @host_hash, @options = name.to_s, host_hash.dup, options.dup
+      @host_hash['packaging_platform'] ||= @host_hash['platform']
 
       @host_hash = self.platform_defaults.merge(@host_hash)
       pkg_initialize


### PR DESCRIPTION
Prior to this commit there was no default set for `packaging_platform`,
which would cause any host file that omitted that variable to fail.

This commit sets `packaging_platform` to the value of `platform` if it
is unset.