### PR TITLE
(RE-13304) add apt-transport-https to debian

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -21,7 +21,7 @@ module Beaker
     PSWINDOWS_PACKAGES = []
     SLES10_PACKAGES = ['curl']
     SLES_PACKAGES = ['curl', 'ntp']
-    DEBIAN_PACKAGES = ['curl', 'ntpdate', 'lsb-release']
+    DEBIAN_PACKAGES = ['curl', 'ntpdate', 'lsb-release', 'apt-transport-https']
     CUMULUS_PACKAGES = ['curl', 'ntpdate']
     SOLARIS10_PACKAGES = ['CSWcurl', 'CSWntp', 'wget']
     SOLARIS11_PACKAGES = ['curl', 'ntp']


### PR DESCRIPTION
the puppet-release package is now setting the url for apt puppet-agent repo to https transport. On the default Debian installation < 10 apt-transport-https is not provided causing the installation of puppet-agent to fail.
This PR adds apt-transport-https to the provisioning phase of beaker.