### PR TITLE
(BKR-1637) fix for Ubuntu 20.04 ssh cmd environment

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -252,6 +252,7 @@ module Unix::Exec
       directory = tmpdir()
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
+      exec(Beaker::Command.new("echo '' >/etc/environment")) if self['platform'] =~ /ubuntu-20.04/
     when /el-7|centos-7|redhat-7|oracle-7|scientific-7|eos-7|el-8|centos-8|redhat-8|oracle-8/
       directory = tmpdir()
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))


### PR DESCRIPTION
In Ubuntu 20.04 openssh server was updated to `OpenSSH_8.1p1 Ubuntu-5`
and the way the environment is handled was changed: if a variable
is defined in `/etc/environment` it cannot be overwritten from
`~/.ssh/envirnment`.

With this change we empty `/etc/environment` on Ubuntu 20.04 to keep
the previous behaviour.