### PR TITLE
(maint) Remove EPEL5 from External Resource Test

### DIFF
--- a/acceptance/tests/base/external_resources_test.rb
+++ b/acceptance/tests/base/external_resources_test.rb
@@ -2,7 +2,6 @@ test_name 'External Resources Test' do
   step 'Verify EPEL resources are up and available' do
     def build_url(el_version)
       url_base = options[:epel_url]
-      url_base = options[:epel_url_archive] if el_version == 5
       "#{url_base}/epel-release-latest-#{el_version}.noarch.rpm"
     end
 
@@ -23,11 +22,10 @@ test_name 'External Resources Test' do
       assert_match(/200 OK/, curl_headers_result.stdout, "EPEL #{el_version} should be reachable at #{url}")
     end
 
-    step 'Verify el_version numbers 5,6,7 are found on the epel resource' do
-      [5,6,7].each do |el_version|
+    step 'Verify el_version numbers 6,7,8 are found on the epel resource' do
+      [6,7,8].each do |el_version|
         epel_url_test(el_version)
       end
     end
-
   end
 end


### PR DESCRIPTION
Updated tests not to test EPEL5 source and added EPEL.
Starting with the 21st of April 2020, EPEL 5 was removed from the archive.

Google webcache: https://webcache.googleusercontent.com/search?q=cache:IF8cMImOVCYJ:https://archive.fedoraproject.org/pub/archive/epel/+&cd=1&hl=en&ct=clnk&gl=ro

Current:
https://archive.fedoraproject.org/pub/archive/epel/