### PR TITLE
(BKR-1651) Remove el-5 support

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -244,7 +244,7 @@ module Beaker
       report_and_raise(logger, e, "proxy_config")
     end
 
-    #Install EPEL on host or hosts with platform = /el-(5|6|7)/.  Do nothing on host or hosts of other platforms.
+    #Install EPEL on host or hosts with platform = /el-(6|7)/.  Do nothing on host or hosts of other platforms.
     # @param [Host, Array<Host>] host One or more hosts to act upon.  Will use individual host epel_url, epel_arch
     #                                 and epel_pkg before using defaults provided in opts.
     # @param [Hash{Symbol=>String}] opts Options to alter execution.
@@ -258,11 +258,10 @@ module Beaker
       debug_opt = opts[:debug] ? 'vh' : ''
       block_on host do |host|
         case
-        when el_based?(host) && ['5','6','7'].include?(host['platform'].version)
+        when el_based?(host) && ['6','7'].include?(host['platform'].version)
           result = host.exec(Command.new('rpm -qa | grep epel-release'), :acceptable_exit_codes => [0,1])
           if result.exit_code == 1
             url_base = opts[:epel_url]
-            url_base = opts[:epel_url_archive] if host['platform'].version == '5'
             host.install_package_with_rpm("#{url_base}/epel-release-latest-#{host['platform'].version}.noarch.rpm", '--replacepkgs', { :package_proxy => opts[:package_proxy] })
             #update /etc/yum.repos.d/epel.repo for new baseurl
             host.exec(Command.new("sed -i -e 's;#baseurl.*$;baseurl=#{Regexp.escape("#{url_base}/#{host['platform'].version}")}/\$basearch;' /etc/yum.repos.d/epel.repo"))

--- a/lib/beaker/options/presets.rb
+++ b/lib/beaker/options/presets.rb
@@ -174,7 +174,6 @@ module Beaker
           :package_proxy          => false,
           :add_el_extras          => false,
           :epel_url               => "http://dl.fedoraproject.org/pub/epel",
-          :epel_url_archive       => 'http://archive.fedoraproject.org/pub/archive/epel',
           :consoleport            => 443,
           :pe_dir                 => '/opt/enterprise/dists',
           :pe_version_file        => 'LATEST',

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -329,33 +329,6 @@ describe Beaker do
   context "add_el_extras" do
     subject { dummy_class.new }
 
-    it 'adds archived extras for el-5 hosts' do
-
-      hosts = make_hosts( { :platform => Beaker::Platform.new('el-5-arch'), :exit_code => 1 }, 2 )
-      hosts[1][:platform] = Beaker::Platform.new('oracle-5-arch')
-
-      expect( Beaker::Command ).to receive( :new ).with(
-        "rpm -qa | grep epel-release"
-      ).exactly( 2 ).times
-      hosts.each do |host|
-        expect(host).to receive( :install_package_with_rpm ).with(
-          "http://archive.fedoraproject.org/pub/archive/epel/epel-release-latest-5.noarch.rpm", "--replacepkgs", {:package_proxy => false}
-        ).once
-      end
-      expect( Beaker::Command ).to receive( :new ).with(
-        "sed -i -e 's;#baseurl.*$;baseurl=http://archive\\.fedoraproject\\.org/pub/archive/epel/5/$basearch;' /etc/yum.repos.d/epel.repo"
-      ).exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with(
-        "sed -i -e '/mirrorlist/d' /etc/yum.repos.d/epel.repo"
-      ).exactly( 2 ).times
-      expect( Beaker::Command ).to receive( :new ).with(
-        "yum clean all && yum makecache"
-      ).exactly( 2 ).times
-
-      subject.add_el_extras( hosts, options )
-
-    end
-
     it 'adds extras for el-6 hosts' do
 
       hosts = make_hosts( { :platform => Beaker::Platform.new('el-6-arch'), :exit_code => 1 }, 4 )


### PR DESCRIPTION
This commit removes support for adding the EPEL repos via Beaker.
This is being done because the EPEL mirrors provided by RedHat have
changed their structure significantly and we do not have time to update
Beaker's code to match.

Previously #1639 cleaned this up for the external resource test. This removes the remaining references.