### PR TITLE
(hotfix) Remove single quotes from Unix host file ops

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -127,7 +127,7 @@ module Unix::Exec
   # @param [String] dir The directory structure to create on the host
   # @return [Boolean] True, if directory construction succeeded, otherwise False
   def mkdir_p dir
-    cmd = "mkdir -p '#{dir}'"
+    cmd = "mkdir -p #{dir}"
     result = exec(Beaker::Command.new(cmd), :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end
@@ -135,7 +135,7 @@ module Unix::Exec
   # Recursively remove the path provided
   # @param [String] path The path to remove
   def rm_rf path
-    execute("rm -rf '#{path}'")
+    execute("rm -rf #{path}")
   end
 
   # Move the origin to destination. The destination is removed prior to moving.
@@ -144,7 +144,7 @@ module Unix::Exec
   # @param [Boolean] rm Remove the destination prior to move
   def mv orig, dest, rm=true
     rm_rf dest unless !rm
-    execute("mv '#{orig}' '#{dest}'")
+    execute("mv #{orig} #{dest}")
   end
 
   # Attempt to ping the provided target hostname

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -29,7 +29,7 @@ module Beaker
 
       it "deletes" do
         path = '/path/to/delete'
-        expect( instance ).to receive(:execute).with("rm -rf '#{path}'").and_return(0)
+        expect( instance ).to receive(:execute).with("rm -rf #{path}").and_return(0)
         expect( instance.rm_rf(path) ).to be === 0
       end
     end
@@ -39,14 +39,14 @@ module Beaker
       let(:destination) { '/destination/path/of/content' }
 
       it 'rm first' do
-        expect( instance ).to receive(:execute).with("rm -rf '#{destination}'").and_return(0)
-        expect( instance ).to receive(:execute).with("mv '#{origin}' '#{destination}'").and_return(0)
+        expect( instance ).to receive(:execute).with("rm -rf #{destination}").and_return(0)
+        expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
         expect( instance.mv(origin, destination) ).to be === 0
 
       end
 
       it 'does not rm' do
-         expect( instance ).to receive(:execute).with("mv '#{origin}' '#{destination}'").and_return(0)
+         expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
          expect( instance.mv(origin, destination, false) ).to be === 0
       end
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -325,7 +325,7 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("mkdir -p 'test/test/test'")
+        expect( Beaker::Command ).to receive(:new).with("mkdir -p test/test/test")
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end
@@ -337,7 +337,7 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("mkdir -p 'test/test/test'")
+        expect( Beaker::Command ).to receive(:new).with("mkdir -p test/test/test")
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end


### PR DESCRIPTION
Prior to this commit single quotes were added around the `mkdir_p`
`rm_rf` and `mv` commands in `Beaker::Unix::Exec`. Refer to https://github.com/puppetlabs/beaker/commit/a60451cfa546126972f6588024552ca95c4ec9b5
These added single quotes caused interpolation of variables such as `~` for
the user HOME to stop working.

This commit removes the single quotes added to those command string in
the mentioned commit. We can consider adding double quote in the future,
although folks may be reliant on shell globbing and other features of
not having quotes so we may need to add a parameter to control the
behavior.