### PR TITLE
(FACT-2580) Added rm_rf, mkdir_p and mv for windows

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -127,7 +127,7 @@ module Unix::Exec
   # @param [String] dir The directory structure to create on the host
   # @return [Boolean] True, if directory construction succeeded, otherwise False
   def mkdir_p dir
-    cmd = "mkdir -p #{dir}"
+    cmd = "mkdir -p \"#{dir}\""
     result = exec(Beaker::Command.new(cmd), :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end
@@ -144,7 +144,7 @@ module Unix::Exec
   # @param [Boolean] rm Remove the destination prior to move
   def mv orig, dest, rm=true
     rm_rf dest unless !rm
-    execute("mv #{orig} #{dest}")
+    execute("mv \"#{orig}\" \"#{dest}\"")
   end
 
   # Attempt to ping the provided target hostname

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -40,13 +40,13 @@ module Beaker
 
       it 'rm first' do
         expect( instance ).to receive(:execute).with("rm -rf #{destination}").and_return(0)
-        expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
+        expect( instance ).to receive(:execute).with("mv \"#{origin}\" \"#{destination}\"").and_return(0)
         expect( instance.mv(origin, destination) ).to be === 0
 
       end
 
       it 'does not rm' do
-         expect( instance ).to receive(:execute).with("mv #{origin} #{destination}").and_return(0)
+         expect( instance ).to receive(:execute).with("mv \"#{origin}\" \"#{destination}\"").and_return(0)
          expect( instance.mv(origin, destination, false) ).to be === 0
       end
     end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -325,7 +325,7 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("mkdir -p test/test/test")
+        expect( Beaker::Command ).to receive(:new).with("mkdir -p \"test/test/test\"")
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end
@@ -337,7 +337,7 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("mkdir -p test/test/test")
+        expect( Beaker::Command ).to receive(:new).with("mkdir -p \"test/test/test\"")
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end


### PR DESCRIPTION
These are required on Windows with cygwin, directories do not get created/removed without single quotes.
Initially they were added on unix, but that failed when using `~\path` because it was not expanded correctly.