### PR TITLE
(maint) Add net-ssh 6.x compatability

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
-  s.add_runtime_dependency 'net-ssh', '~> 5.0'
+  s.add_runtime_dependency 'net-ssh', '>= 5.0'
   s.add_runtime_dependency 'net-scp', '~> 1.2'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 


### PR DESCRIPTION
This commit relaxes the net-ssh dependency to support both the 5.x and 6.x series. This allows compatability with bolt features that rely on net-ssh 6.x. The 5 series is still supported in case other projects that use beaker are still restricted to the 5 series.