### PR TITLE
(maint) Cleanup dead code

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -63,42 +63,6 @@ module Unix::Exec
     end
   end
 
-  def uptime_int(uptime_str)
-    time_array = uptime_str.split(", ")
-    accumulated_mins = 0
-    time_array.each do |time_segment|
-      value, unit = time_segment.split
-      if unit.nil?
-        # 20:47 case: hours & mins
-        hours, mins = value.split(":")
-        accumulated_mins += (hours.to_i * 60 + mins.to_i)
-      elsif unit =~ /day(s)?/
-        accumulated_mins += (value.to_i * 1440) # 60 * 24 = 1440
-      elsif unit =~ /min(s)?/
-        accumulated_mins += value.to_i
-      else
-        raise ArgumentError, "can't parse uptime segment: #{time_segment}"
-      end
-    end
-
-    accumulated_mins
-  end
-
-  def parse_uptime(uptime)
-    # get String from up to users
-    # eg 19:52  up 14 mins, 2 users, load averages: 2.95 4.19 4.31
-    # 8:03 up 52 days, 20:47, 3 users, load averages: 1.36 1.42 1.40
-    # 22:19 up 54 days, 1 min, 4 users, load averages: 2.08 2.06 2.27
-    regexp = /.*up (.*)[[:space:]]+[[:digit:]]+ user.*/
-    result = uptime.match regexp
-    if self['platform'] =~ /solaris-/ && result[1].empty?
-      return "0 min"
-    end
-    raise "Couldn't parse uptime: #{uptime}" if result.nil?
-
-    result[1].strip.chomp(",")
-  end
-
   def echo(msg, abs=true)
     (abs ? '/bin/echo' : 'echo') + " #{msg}"
   end

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -312,42 +312,5 @@ module Beaker
       end
 
     end
-
-    describe '#parse_uptime' do
-      it 'parses variation of uptime string' do
-        expect(instance.parse_uptime("19:52  up 14 mins, 2 users, load averages: 2.95 4.19 4.31")).to be == "14 mins"
-      end
-      it 'parses variation 2 of uptime string' do
-        expect(instance.parse_uptime("8:03 up 52 days, 20:47, 3 users, load averages: 1.36 1.42 1.40")).to be == "52 days, 20:47"
-      end
-      it 'parses variation 3 of uptime string' do
-        expect(instance.parse_uptime("22:19 up 54 days, 1 min, 4 users, load averages: 2.08 2.06 2.27")).to be == "54 days, 1 min"
-      end
-      it 'parses variation 4 of uptime string' do
-        expect(instance.parse_uptime("18:44:45 up 5 min,  0 users,  load average: 0.14, 0.11, 0.05")).to be == "5 min"
-      end
-      it 'parses solaris\'s "just up" without time message' do
-        opts['platform'] = 'solaris-11-x86_64'
-        expect(instance.parse_uptime("10:05am  up  0 users,  load average: 0.66, 0.14, 0.05")).to be == "0 min"
-      end
-     end
-
-    describe '#uptime_int' do
-      it 'parses time segment variation into a minute value' do
-        expect(instance.uptime_int("14 mins")).to be == 14
-      end
-      it 'parses time segment variation 2 into a minute value' do
-        expect(instance.uptime_int("52 days, 20:47")).to be == 76127
-      end
-      it 'parses time segment variation 3 into a minute value' do
-        expect(instance.uptime_int("54 days, 1 min")).to be == 77761
-        end
-      it 'parses time segment variation 4 into a minute value' do
-        expect(instance.uptime_int("54 days")).to be == 77760
-      end
-      it 'raises if we pass garbage to it' do
-        expect { instance.uptime_int("solaris roxx my soxx") }.to raise_error
-      end
-    end
   end
 end


### PR DESCRIPTION
This commit removes the now unused `uptime_int` and `parse_uptime`
methods and their respective spec tests. The only calls to these methods
were removed in #1643 c1f5e7546d2f45bf71b70600a35b380e1f31509a