### PR TITLE
(BKR-1656) Fixes for cat and file_exist? on PSWindows

### DIFF
--- a/lib/beaker/host/pswindows/file.rb
+++ b/lib/beaker/host/pswindows/file.rb
@@ -21,11 +21,11 @@ module PSWindows::File
   end
 
   def cat(path)
-    exec(powershell("type #{path}"))
+    exec(powershell("type #{path}")).stdout
   end
 
   def file_exist?(path)
-    result = exec(Beaker::Command.new("if exist #{path} echo true"), :acceptable_exit_codes => [0, 1])
-    result.stdout =~ /true/
+    result = exec(Beaker::Command.new("if exist #{path} echo true"), accept_all_exit_codes: true)
+    result.stdout.strip == 'true'
   end
 end

--- a/spec/beaker/host/pswindows/file_spec.rb
+++ b/spec/beaker/host/pswindows/file_spec.rb
@@ -25,11 +25,31 @@ module Beaker
     let (:instance) { PSWindowsFileTest.new(opts, logger) }
 
     describe '#cat' do
+      let(:path) { '/path/to/cat' }
+      let(:content) { 'file content' }
       it 'reads output for file' do
-        path = '/path/to/delete'
-        expect(instance).to receive(:exec)
+        expect(instance).to receive(:exec).and_return(double(stdout: content))
         expect(Beaker::Command).to receive(:new).with('powershell.exe', array_including("-Command type #{path}"))
-        instance.cat(path)
+        expect(instance.cat(path)).to eq(content)
+      end
+    end
+
+    describe '#file_exist?' do
+      let(:path) { '/path/to/test/file.txt' }
+      context 'file exists' do
+        it 'returns true' do
+          expect(instance).to receive(:exec).and_return(double(stdout: "true\n"))
+          expect(Beaker::Command).to receive(:new).with("if exist #{path} echo true")
+          expect(instance.file_exist?(path)).to eq(true)
+        end
+      end
+
+      context 'file does not exist' do
+        it 'returns false' do
+          expect(instance).to receive(:exec).and_return(double(stdout: ""))
+          expect(Beaker::Command).to receive(:new).with("if exist #{path} echo true")
+          expect(instance.file_exist?(path)).to eq(false)
+        end
       end
     end
 
@@ -39,7 +59,6 @@ module Beaker
 
       before do
         allow(instance).to receive(:execute).with(anything)
-
       end
 
       context 'with dirname sent' do


### PR DESCRIPTION
These changes are needed in order to have the same output when these methods are used on different platforms. The implementation for unix is slightly different and had a different return values. 
Having the same return values for both unix and windows implementation will reduce the need to check which os you're running on when writing beaker tests.

**file_exist?** had a different output compared to the unix implementation (which returns bool). It actually returned the position of where it found the the match.
```
2.5.3 :001 > "true" =~ /true/
 => 0
2.5.3 :002 > "true" =~ /rue/
 => 1
```
**cat** had different output due to the fact that `execute` does not wrap the output in an `Response` object, but `exec` does.