### PR TITLE
(BKR-1669) Fixed method mkdir_p for powershell localhost

### DIFF
--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -104,9 +104,9 @@ module PSWindows::Exec
   # @param [String] dir The directory structure to create on the host
   # @return [Boolean] True, if directory construction succeeded, otherwise False
   def mkdir_p dir
-    windows_dirstring = dir.gsub('/','\\')
-    cmd = "if not exist #{windows_dirstring} (md #{windows_dirstring})"
-    result = exec(Beaker::Command.new(cmd), :acceptable_exit_codes => [0, 1])
+    normalized_path = dir.gsub('/','\\')
+    result = exec(powershell("New-Item -Path '#{normalized_path}' -ItemType 'directory'"),
+                  :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end
 

--- a/spec/beaker/host/pswindows/exec_spec.rb
+++ b/spec/beaker/host/pswindows/exec_spec.rb
@@ -128,5 +128,30 @@ module Beaker
         end
       end
     end
+
+    describe '#mkdir_p' do
+        let(:dir_path) { "C:\\tmpdir\\my_dir" }
+        let(:beaker_command) { instance_spy(Beaker::Command) }
+        let(:command) {"-Command New-Item -Path '#{dir_path}' -ItemType 'directory'"}
+        let(:result) { instance_spy(Beaker::Result) }
+
+        before do
+          allow(Beaker::Command).to receive(:new).
+              with('powershell.exe', array_including(command)).and_return(beaker_command)
+          allow(instance).to receive(:exec).with(beaker_command, :acceptable_exit_codes => [0, 1]).and_return(result)
+        end
+
+        it 'returns true and creates folder structure' do
+          allow(result).to receive(:exit_code).and_return(0)
+
+          expect(instance.mkdir_p(dir_path)).to be(true)
+        end
+
+        it 'returns false if failed to create directory structure' do
+          allow(result).to receive(:exit_code).and_return(1)
+
+          expect(instance.mkdir_p(dir_path)).to be(false)
+        end
+      end
   end
 end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -349,7 +349,13 @@ module Beaker
         allow( result ).to receive( :exit_code ).and_return( 0 )
         allow( host ).to receive( :exec ).and_return( result )
 
-        expect( Beaker::Command ).to receive(:new).with("if not exist test\\test\\test (md test\\test\\test)")
+        expect( Beaker::Command ).to receive(:new).
+          with("powershell.exe", ["-ExecutionPolicy Bypass",
+                                  "-InputFormat None",
+                                  "-NoLogo",
+                                  "-NoProfile",
+                                  "-NonInteractive",
+                                  "-Command New-Item -Path 'test\\test\\test' -ItemType 'directory'"])
         expect( host.mkdir_p('test/test/test') ).to be == true
 
       end


### PR DESCRIPTION
Fixed a bug when creating a directory structure using poweshell on windows localhost