### PR TITLE
(maint) Improve reboot code

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -50,7 +50,11 @@ module Unix::Exec
       sleep wait_time
 
       current_boot_time_str = exec(Beaker::Command.new('who -b'), {:max_connection_tries => max_connection_tries, :silent => true}).stdout
-      current_boot_time = Time.parse(current_boot_time_str.lines.grep(/boot/).first)
+      current_boot_time_line = current_boot_time_str.lines.grep(/boot/).first
+
+      raise Beaker::Host::RebootFailure, "Could not find system boot time using 'who -b': '#{current_boot_time_str}'" unless current_boot_time_line
+
+      current_boot_time = Time.parse(current_boot_time_line)
 
       @logger.debug("Original Boot Time: #{original_boot_time}")
       @logger.debug("Current Boot Time: #{current_boot_time}")


### PR DESCRIPTION
Before this change, the 'who -b' command was resilient when run before the reboot
Now making it retry too if it cannot find the /boot/ line after a reboot too.
We have seen one instance of a sles-12 machine rebooting, and the first request
for 'who -b' after the reboot failed the connection, which made the search for the line
be nil, and returning a stack trace when trying to convert that into Time with a
TypeError: no implicit conversion of nil into String. Now protects against that
and will retry as expected.