### PR TITLE
(maint) Remove codeowners content

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-* @puppetlabs/beaker
-* @puppetlabs/dio


### PR DESCRIPTION
This removes Puppet teams as codeowners on the Beaker repo, since these
team references won't work once the repository is moved to the Vox
Pupuli organization. We tried to add a new clause to the CO file to
notify certain Puppet teams when `lib/beaker/version.rb` is updated but
teams cannot be referenced, and it's a security risk to add Puppet
emails to a public file. We determined that any individuals at Puppet
who want to be notified when Beaker is released can ask to be added
individually, either to a Vox organization team or individually to the
CO file, but that they should opt-in to getting notifications.