### PR TITLE
Run host generation tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - gem update --system 2.2.1
+  - gem update
   - gem --version
 language: ruby
 script: "bundle exec rake travis"
@@ -7,6 +7,4 @@ notifications:
   email: false
 rvm:
   - 2.6
-  - 2.0.0
-  - 1.9.3
-  - 1.8.7-p374
+  - 2.4

--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,7 @@ task :history do
   Rake::Task['history:gen'].invoke
 end
 
-task :travis do
-  Rake::Task['yard'].invoke if !Beaker::Shared::Semvar.version_is_less(RUBY_VERSION, '2.0.0')
-  Rake::Task['spec'].invoke
-end
+task travis: [:yard, :test]
 
 module HarnessOptions
   defaults = {

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.1.8')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.4')
 
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'minitar', '~> 0.6'
-  s.add_runtime_dependency 'pry-byebug', '~> 3.6'
+  s.add_runtime_dependency 'pry-byebug', '~> 3.9'
   # pry-byebug can have issues with native readline libs so add rb-readline
   s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
 


### PR DESCRIPTION
This modifies the `:travis` rake task to run all available tests in the
Rakefile, including host generation tests and Beaker subcommand tests.
This ensures that any changes that may break Beaker host generation or
subcommands will be caught before the change is merged.

This additional bumps the required Ruby version to 2.4, since Beaker
uses the safe navigation operator `&.` which was introduced in Ruby 2.3,
and in order to use Ruby 2.3 the required pry and pry-byebug versions
that are compatible require Ruby 2.4.

It also updates the Travis ruby matrix to include the lowest supported
version - Ruby 2.4.