### PR TITLE
Drop is_x86_64? and determine_if_x86_64

### DIFF
--- a/acceptance/tests/base/host/host_test.rb
+++ b/acceptance/tests/base/host/host_test.rb
@@ -21,15 +21,6 @@ hosts.each do |host|
   assert_match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/, ip, "#{ip} on #{host} isn't correct format")
 end
 
-step "#is_x86_64? : can determine arch on hosts"
-hosts.each do |host|
-  if /x86_64|_64|amd64|-64/.match?(host['platform'])
-    assert_equal(true, host.is_x86_64?, "is_x86_64? should be true on #{host}: #{host['platform']}")
-  else
-    assert_equal(false, host.is_x86_64?, "is_x86_64? should be false on #{host}: #{host['platform']}")
-  end
-end
-
 step "#get_env_var : can get a specific environment variable"
 hosts.each do |host|
   env_prefix = 'BEAKER' + SecureRandom.hex(4).upcase

--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -241,11 +241,6 @@ module Beaker
       self['ip'] = get_public_ip || get_ip
     end
 
-    # @return [Boolean] true if x86_64, false otherwise
-    def is_x86_64?
-      @x86_64 ||= determine_if_x86_64
-    end
-
     def connection
       # create new connection object if necessary
       if self['hypervisor'] == 'none' && @name == 'localhost'

--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -66,11 +66,4 @@ module Mac::Pkg
   def upgrade_package(name, _cmdline_args = '')
     raise "Package #{name} cannot be upgraded on #{self}"
   end
-
-  # Examine the host system to determine the architecture
-  # @return [Boolean] true if x86_64, false otherwise
-  def determine_if_x86_64
-    result = exec(Beaker::Command.new("uname -a | grep x86_64"), :expect_all_exit_codes => true)
-    result.exit_code == 0
-  end
 end

--- a/lib/beaker/host/pswindows/pkg.rb
+++ b/lib/beaker/host/pswindows/pkg.rb
@@ -24,12 +24,6 @@ module PSWindows::Pkg
     0
   end
 
-  # Examine the host system to determine the architecture, overrides default host determine_if_x86_64 so that wmic is used
-  # @return [Boolean] true if x86_64, false otherwise
-  def determine_if_x86_64
-    identify_windows_architecture.include?('64')
-  end
-
   private
 
   # @api private

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -219,18 +219,6 @@ module Unix::Pkg
     end
   end
 
-  # Examine the host system to determine the architecture
-  # @return [Boolean] true if x86_64, false otherwise
-  def determine_if_x86_64
-    if self[:platform].include?('solaris')
-      result = exec(Beaker::Command.new("uname -a | grep x86_64"), :accept_all_exit_codes => true)
-      result.exit_code == 0
-    else
-      result = exec(Beaker::Command.new("arch | grep x86_64"), :accept_all_exit_codes => true)
-      result.exit_code == 0
-    end
-  end
-
   # Extract RPM command's proxy options from URL
   #
   # @param [String] url  A URL of form http://host:port

--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -29,12 +29,6 @@ module Windows::Pkg
     raise "Package #{name} cannot be uninstalled on #{self}"
   end
 
-  # Examine the host system to determine the architecture, overrides default host determine_if_x86_64 so that wmic is used
-  # @return [Boolean] true if x86_64, false otherwise
-  def determine_if_x86_64
-    identify_windows_architecture.include?('64')
-  end
-
   private
 
   # @api private


### PR DESCRIPTION
These helpers are only used by beaker-puppet and not generally useful. They completely ignore ARM and other architectures. The distinction between i386 and x86_64 is also largely irrelevant now that i386 is effectively dead.