### PR TITLE
GCG: Switch to upstream release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,5 @@ end
 
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
-  # fix from smortex to properly process commits that exist in multiple branches
-  gem 'github_changelog_generator', github: 'smortex/github-changelog-generator', branch: 'avoid-processing-a-single-commit-multiple-time', require: false
-  # gem 'github_changelog_generator', '~> 1.16.4', require: false
+  gem 'github_changelog_generator', '~> 1.18', require: false
 end


### PR DESCRIPTION
The required changes from smortex are merged now:

* https://github.com/github-changelog-generator/github-changelog-generator/pull/1058
* https://github.com/github-changelog-generator/github-changelog-generator/pull/1062