### PR TITLE
Ensure .beaker dir exists before writing options

### DIFF
--- a/lib/beaker/subcommand.rb
+++ b/lib/beaker/subcommand.rb
@@ -84,6 +84,7 @@ module Beaker
       options_to_write = SubcommandUtil.sanitize_options_for_save(@cli.configured_options)
 
       @cli.logger.notify 'Writing configured options to disk'
+      FileUtils.mkdir_p(SubcommandUtil::CONFIG_DIR)
       SubcommandUtil::SUBCOMMAND_OPTIONS.write(options_to_write.to_yaml)
       @cli.logger.notify "Options written to #{SubcommandUtil::SUBCOMMAND_OPTIONS}"
 


### PR DESCRIPTION
Prior to this commit, the `beaker init` subcommand would fail if some external process had not created the `.beaker` directory. This commit fixes the issue by running a `mkdir_p` to ensure the directory exists before writing out options.