### PR TITLE
Ensure verify_host_key is symbolized before use

### DIFF
--- a/lib/beaker/ssh_connection.rb
+++ b/lib/beaker/ssh_connection.rb
@@ -76,6 +76,12 @@ module Beaker
           end
         end
 
+        # Beaker stringifies options when storing them in a config file.
+        # net-ssh raises a fatal error if it does not get a symbol.
+        if ssh_opts[:verify_host_key].is_a?(String)
+          ssh_opts[:verify_host_key] = ssh_opts[:verify_host_key].to_sym
+        end
+
         Net::SSH.start(host, user, ssh_opts)
       rescue *RETRYABLE_EXCEPTIONS => e
         if try <= max_connection_tries


### PR DESCRIPTION
Beaker stringifies option values when writing out config files. The net-ssh library requires the value of `verify_host_key` to be a symbol and raises a fatal error if `"never"` is passed instead of `:never`. This means that `beaker provision` would fail as the config written out by `beaker init` contains the stringified form.

This commit adds a check to ensure the config value is symbolized before it gets passed down to `net-ssh`.